### PR TITLE
Add `toIter()` and `fromIter()` to all collections

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -78,6 +78,10 @@ module {
 
   public func singleton<T>(element : T) : [T] = [element];
 
+  public func fromIter<T>(iter : Iter.Iter<T>) : [T] {
+    todo()
+  };
+
   public func toIter<T>(array : [T]) : Iter.Iter<T> = array.vals();
 
   public func vals<T>(array : [T]) : Iter.Iter<T> = array.vals();

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -1,11 +1,12 @@
 /// Iterators
 
+import Type "IterType";
 import Order "Order";
 import { nyi = todo } "Debug";
 
 module {
 
-  public type Iter<T> = { next : () -> ?T };
+  public type Iter<T> = Type.Iter<T>;
 
   public class range(fromInclusive : Int, toExclusive : Int) {
     todo()
@@ -69,6 +70,10 @@ module {
 
   public func sort<T>(iter : Iter<T>, compare : (T, T) -> Order.Order) : Iter<T> {
     todo()
+  };
+
+  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
+    A.toIter(a) |> B.fromIter(_)
   };
 
 }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -72,8 +72,4 @@ module {
     todo()
   };
 
-  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
-    A.toIter(a) |> B.fromIter(_)
-  };
-
 }

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -152,6 +152,10 @@ module {
     todo()
   };
 
+  public func fromIter<T>(iter : Iter.Iter<T>) : Stack<T> {
+    todo()
+  };
+
   public func toIter<T>(stack : Stack<T>) : Iter.Iter<T> {
     todo()
   };

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -49,10 +49,6 @@ module {
 
   public func toIter<T>(queue : Queue<T>) : Iter.Iter<T> = vals(queue);
 
-  public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T> {
-    todo()
-  };
-
   public func vals<T>(queue : Queue<T>) : Iter.Iter<T> {
     todo()
   };


### PR DESCRIPTION
Adds missing `toIter()` and `fromIter()` functions to provide a consistent interface for converting to/from iterators. This is intended for libraries which take a module implementing either of these functions. 

Note that `Map.fromIter()` and `Set.fromIter()` also take a `compare` function. 