### PR TITLE
Experiment: `Iter.convert()`

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -78,6 +78,10 @@ module {
 
   public func singleton<T>(element : T) : [T] = [element];
 
+  public func fromIter<T>(iter : Iter.Iter<T>) : [T] {
+    todo()
+  };
+
   public func toIter<T>(array : [T]) : Iter.Iter<T> = array.vals();
 
   public func vals<T>(array : [T]) : Iter.Iter<T> = array.vals();

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -72,7 +72,11 @@ module {
     todo()
   };
 
-  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
+  public func convert<A, B, T>(
+    A : module { toIter : A -> Iter<T> },
+    B : module { fromIter : Iter<T> -> B },
+    a : A
+  ) : B {
     A.toIter(a) |> B.fromIter(_)
   };
 

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -72,4 +72,8 @@ module {
     todo()
   };
 
+  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
+    A.toIter(a) |> B.fromIter(_)
+  };
+
 }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -1,11 +1,12 @@
 /// Iterators
 
+import Type "IterType";
 import Order "Order";
 import { nyi = todo } "Debug";
 
 module {
 
-  public type Iter<T> = { next : () -> ?T };
+  public type Iter<T> = Type.Iter<T>;
 
   public class range(fromInclusive : Int, toExclusive : Int) {
     todo()
@@ -69,6 +70,10 @@ module {
 
   public func sort<T>(iter : Iter<T>, compare : (T, T) -> Order.Order) : Iter<T> {
     todo()
+  };
+
+  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
+    A.toIter(a) |> B.fromIter(_)
   };
 
 }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -72,8 +72,4 @@ module {
     todo()
   };
 
-  public func convert<A, B, T>(A : module { toIter : A -> Iter<T> }, B : module { fromIter : Iter<T> -> B }, a : A) : B {
-    A.toIter(a) |> B.fromIter(_)
-  };
-
 }

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -152,6 +152,10 @@ module {
     todo()
   };
 
+  public func fromIter<T>(iter : Iter.Iter<T>) : Stack<T> {
+    todo()
+  };
+
   public func toIter<T>(stack : Stack<T>) : Iter.Iter<T> {
     todo()
   };

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -49,10 +49,6 @@ module {
 
   public func toIter<T>(queue : Queue<T>) : Iter.Iter<T> = vals(queue);
 
-  public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T> {
-    todo()
-  };
-
   public func vals<T>(queue : Queue<T>) : Iter.Iter<T> {
     todo()
   };

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -1,0 +1,11 @@
+import Iter "../src/Iter";
+import Array "../src/Array";
+import Text "../src/Text";
+import Stack "../src/Stack";
+
+// Example usages of `Iter.convert()`
+
+assert Iter.convert(Array, Text, ['a', 'b', 'c']) == "abc";
+assert Iter.convert(Text, Array, "abc") == ['a', 'b', 'c'];
+assert Iter.convert(Array, Stack, [1, 2, 3]) |> Iter.Convert(Stack, Array, _) == [1, 2, 3];
+assert Iter.convert(Array, Stack, [1, 2, 3]) == Stack.fromIter(Iter.generate(3, func(i) = i + 1));


### PR DESCRIPTION
Idea for a convenience function to convert between data structures. The examples don't compile with the current Motoko version (hopefully there's a way around this), so the goal is to show the motivation for the `toIter()` and `fromIter()` module functions. 
