### PR TITLE
Add `allValues()` functions to modules with finite types

### DIFF
--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -1,6 +1,7 @@
 /// Boolean types and operations
 
 import Prim "mo:⛔";
+import Iter "IterType";
 import { todo } "Debug";
 
 module {
@@ -20,6 +21,10 @@ module {
   };
 
   public func compare(b1 : Bool, b2 : Bool) : { #less; #equal; #greater } {
+    todo()
+  };
+
+  public func allValues() : Iter.Iter<Bool> {
     todo()
   };
 

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -1,5 +1,9 @@
 /// Characters
+
+import Iter "IterType";
 import Prim "mo:⛔";
+import { todo } "Debug";
+
 module {
 
   public type Char = Prim.Types.Char;
@@ -40,6 +44,10 @@ module {
 
   public func compare(x : Char, y : Char) : { #less; #equal; #greater } {
     if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  };
+
+  public func allValues() : Iter.Iter<Char> {
+    todo()
   };
 
 }

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -1,7 +1,9 @@
 /// Utility functions on 16-bit signed integers
 
 import Int "Int";
+import Iter "IterType";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -119,6 +121,10 @@ module {
 
   public func mulWrap(x : Int16, y : Int16) : Int16 { x *% y };
 
-  public func powWrap(x : Int16, y : Int16) : Int16 { x **% y }
+  public func powWrap(x : Int16, y : Int16) : Int16 { x **% y };
+
+  public func allValues() : Iter.Iter<Int16> {
+    todo()
+  };
 
 }

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -1,7 +1,9 @@
 /// Utility functions on 32-bit signed integers
 
 import Int "Int";
+import Iter "IterType";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -120,5 +122,9 @@ module {
   public func mulWrap(x : Int32, y : Int32) : Int32 { x *% y };
 
   public func powWrap(x : Int32, y : Int32) : Int32 { x **% y };
+
+  public func allValues() : Iter.Iter<Int32> {
+    todo()
+  };
 
 }

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -1,7 +1,9 @@
 /// Utility functions on 64-bit signed integers
 
 import Int "Int";
+import Iter "IterType";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -115,5 +117,9 @@ module {
 
   public func mulWrap(x : Int64, y : Int64) : Int64 { x *% y };
 
-  public func powWrap(x : Int64, y : Int64) : Int64 { x **% y }
+  public func powWrap(x : Int64, y : Int64) : Int64 { x **% y };
+
+  public func allValues() : Iter.Iter<Bool> {
+    todo()
+  };
 }

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -1,7 +1,9 @@
 /// Utility functions on 8-bit signed integers
 
 import Int "Int";
+import Iter "IterType";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -116,5 +118,9 @@ module {
   public func mulWrap(x : Int8, y : Int8) : Int8 { x *% y };
 
   public func powWrap(x : Int8, y : Int8) : Int8 { x **% y };
+
+  public func allValues() : Iter.Iter<Int8> {
+    todo()
+  };
 
 }

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -1,10 +1,9 @@
 /// Natural numbers with infinite precision
 
 import Int "Int";
-import Order "Order";
-import Prim "mo:⛔";
-import Char "Char";
+import Iter "Iter";
 import { todo } "Debug";
+import Prim "mo:⛔";
 
 module {
 
@@ -59,5 +58,9 @@ module {
   public func bitshiftLeft(x : Nat, y : Nat32) : Nat { Prim.shiftLeft(x, y) };
 
   public func bitshiftRight(x : Nat, y : Nat32) : Nat { Prim.shiftRight(x, y) };
+
+  public func allValues() : Iter.Iter<Nat> {
+    todo()
+  };
 
 }

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -2,6 +2,7 @@
 
 import Nat "Nat";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -116,5 +117,9 @@ module {
   public func mulWrap(x : Nat16, y : Nat16) : Nat16 { x *% y };
 
   public func powWrap(x : Nat16, y : Nat16) : Nat16 { x **% y };
+
+  public func allValues() : Iter.Iter<Nat16> {
+    todo()
+  };
 
 }

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -1,6 +1,7 @@
 /// Utility functions on 16-bit unsigned integers
 
 import Nat "Nat";
+import Iter "IterType";
 import Prim "mo:⛔";
 import { todo } "Debug";
 

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -1,6 +1,7 @@
 /// Utility functions on 32-bit unsigned integers
 
 import Nat "Nat";
+import Iter "IterType";
 import Prim "mo:⛔";
 import { todo } "Debug";
 

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -2,6 +2,7 @@
 
 import Nat "Nat";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -116,5 +117,9 @@ module {
   public func mulWrap(x : Nat32, y : Nat32) : Nat32 { x *% y };
 
   public func powWrap(x : Nat32, y : Nat32) : Nat32 { x **% y };
+
+  public func allValues() : Iter.Iter<Nat32> {
+    todo()
+  };
 
 }

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -2,6 +2,7 @@
 
 import Nat "Nat";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -109,5 +110,9 @@ module {
   public func mulWrap(x : Nat64, y : Nat64) : Nat64 { x *% y };
 
   public func powWrap(x : Nat64, y : Nat64) : Nat64 { x **% y };
+
+  public func allValues() : Iter.Iter<Nat64> {
+    todo()
+  };
 
 }

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -1,6 +1,7 @@
 /// Utility functions on 64-bit unsigned integers
 
 import Nat "Nat";
+import Iter "IterType";
 import Prim "mo:⛔";
 import { todo } "Debug";
 

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -2,6 +2,7 @@
 
 import Nat "Nat";
 import Prim "mo:⛔";
+import { todo } "Debug";
 
 module {
 
@@ -104,5 +105,9 @@ module {
   public func mulWrap(x : Nat8, y : Nat8) : Nat8 { x *% y };
 
   public func powWrap(x : Nat8, y : Nat8) : Nat8 { x **% y };
+
+  public func allValues() : Iter.Iter<Nat8> {
+    todo()
+  };
 
 }

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -1,6 +1,7 @@
 /// Utility functions on 8-bit unsigned integers
 
 import Nat "Nat";
+import Iter "IterType";
 import Prim "mo:⛔";
 import { todo } "Debug";
 

--- a/src/Order.mo
+++ b/src/Order.mo
@@ -1,5 +1,8 @@
 /// Order
 
+import Iter "IterType";
+import { todo } "Debug";
+
 module {
 
   public type Order = {
@@ -23,5 +26,9 @@ module {
   public func equal(o1 : Order, o2 : Order) : Bool {
     o1 == o2
   };
+
+  public func allValues() : Iter.Iter<Order> {
+    todo()
+  }
 
 }


### PR DESCRIPTION
Provides a way to iterate through all possible values of finite types such as `Bool`, `Order`, `Nat8`, `Char`, etc.

Context: https://github.com/dfinity/new-motoko-base/pull/54#discussion_r1894380633.