### PR TITLE
Add `Runtime` module

### DIFF
--- a/src/Debug.mo
+++ b/src/Debug.mo
@@ -1,6 +1,7 @@
 /// Debug functions
 
 import Prim "mo:⛔";
+import Runtime "Runtime";
 
 module {
 
@@ -8,16 +9,8 @@ module {
     Prim.debugPrint text
   };
 
-  public func trap(errorMessage : Text) : None {
-    Prim.trap errorMessage
-  };
-
   public func todo() : None {
-    trap("Debug.todo()")
-  };
-
-  public func unreachable() : None {
-    trap("Debug.unreachable()")
+    Runtime.trap("Debug.todo()")
   };
 
 }

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -1,6 +1,6 @@
-/// Typesafe nulls
+/// Type-safe nullable values
 
-import Debug "Debug";
+import Runtime "Runtime";
 
 module {
 
@@ -59,17 +59,17 @@ module {
   };
 
   public func assertSome(x : ?Any) = switch x {
-    case null { Debug.trap("Option.assertSome()") };
+    case null { Runtime.trap("Option.assertSome()") };
     case _ {}
   };
 
   public func assertNull(x : ?Any) = switch x {
     case null {};
-    case _ { Debug.trap("Option.assertNull()") }
+    case _ { Runtime.trap("Option.assertNull()") }
   };
 
   public func unwrap<T>(x : ?T) : T = switch x {
-    case null { Debug.trap("Option.unwrap()") };
+    case null { Runtime.trap("Option.unwrap()") };
     case (?x_) { x_ }
   };
 

--- a/src/Runtime.mo
+++ b/src/Runtime.mo
@@ -1,0 +1,15 @@
+// Runtime utilities
+
+import Prim "mo:⛔";
+
+module {
+
+  public func trap(errorMessage : Text) : None {
+    Prim.trap errorMessage
+  };
+
+  public func unreachable() : None {
+    trap("Runtime.unreachable()")
+  };
+
+}


### PR DESCRIPTION
Moves `Debug.trap()` and `Debug.unreachable()` to a new `Runtime` module per suggestion. The reason for this change is that these functions are often used outside of the context of debugging.