### PR TITLE
Change variants to use PascalCase

### DIFF
--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -21,9 +21,9 @@ module {
 
   public func hash(blob : Blob) : Nat32 = Prim.hashBlob blob;
 
-  public func compare(b1 : Blob, b2 : Blob) : { #less; #equal; #greater } {
+  public func compare(b1 : Blob, b2 : Blob) : { #Less; #Equal; #Greater } {
     let c = Prim.blobCompare(b1, b2);
-    if (c < 0) #less else if (c == 0) #equal else #greater
+    if (c < 0) #Less else if (c == 0) #Equal else #Greater
   };
 
   public func equal(blob1 : Blob, blob2 : Blob) : Bool { blob1 == blob2 };

--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -20,7 +20,7 @@ module {
     a == b
   };
 
-  public func compare(a : Bool, b : Bool) : { #less; #equal; #greater } {
+  public func compare(a : Bool, b : Bool) : { #Less; #Equal; #Greater } {
     todo()
   };
 

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -42,8 +42,8 @@ module {
 
   public func greaterOrEqual(a : Char, b : Char) : Bool { a >= b };
 
-  public func compare(a : Char, b : Char) : { #less; #equal; #greater } {
-    if (a < b) { #less } else if (a == b) { #equal } else { #greater }
+  public func compare(a : Char, b : Char) : { #Less; #Equal; #Greater } {
+    if (a < b) { #Less } else if (a == b) { #Equal } else { #Greater }
   };
 
   public func allValues() : Iter.Iter<Char> {

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -52,11 +52,11 @@ module {
 
   public let log : (x : Float) -> Float = Prim.log;
 
-  public func format(fmt : { #fix : Nat8; #exp : Nat8; #gen : Nat8; #exact }, x : Float) : Text = switch fmt {
-    case (#fix(prec)) { Prim.floatToFormattedText(x, prec, 0) };
-    case (#exp(prec)) { Prim.floatToFormattedText(x, prec, 1) };
-    case (#gen(prec)) { Prim.floatToFormattedText(x, prec, 2) };
-    case (#exact) { Prim.floatToFormattedText(x, 17, 2) }
+  public func format(fmt : { #Fix : Nat8; #Exp : Nat8; #Gen : Nat8; #Exact }, x : Float) : Text = switch fmt {
+    case (#Fix(prec)) { Prim.floatToFormattedText(x, prec, 0) };
+    case (#Exp(prec)) { Prim.floatToFormattedText(x, prec, 1) };
+    case (#Gen(prec)) { Prim.floatToFormattedText(x, prec, 2) };
+    case (#Exact) { Prim.floatToFormattedText(x, 17, 2) }
   };
 
   public let toText : Float -> Text = Prim.floatToText;
@@ -93,7 +93,7 @@ module {
 
   public func greaterOrEqual(x : Float, y : Float) : Bool { x >= y };
 
-  public func compare(x : Float, y : Float) : { #less; #equal; #greater } {
+  public func compare(x : Float, y : Float) : { #Less; #Equal; #Greater } {
     todo()
   };
 

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -41,8 +41,8 @@ module {
 
   public func greaterOrEqual(x : Int, y : Int) : Bool { x >= y };
 
-  public func compare(x : Int, y : Int) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Int, y : Int) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func neg(x : Int) : Int { -x };

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -59,8 +59,8 @@ module {
 
   public func greaterOrEqual(x : Int16, y : Int16) : Bool { x >= y };
 
-  public func compare(x : Int16, y : Int16) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Int16, y : Int16) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func neg(x : Int16) : Int16 { -x };

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -59,8 +59,8 @@ module {
 
   public func greaterOrEqual(x : Int32, y : Int32) : Bool { x >= y };
 
-  public func compare(x : Int32, y : Int32) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Int32, y : Int32) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func neg(x : Int32) : Int32 { -x };

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -55,8 +55,8 @@ module {
 
   public func greaterOrEqual(x : Int64, y : Int64) : Bool { x >= y };
 
-  public func compare(x : Int64, y : Int64) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Int64, y : Int64) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func neg(x : Int64) : Int64 { -x };

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -55,8 +55,8 @@ module {
 
   public func greaterOrEqual(x : Int8, y : Int8) : Bool { x >= y };
 
-  public func compare(x : Int8, y : Int8) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Int8, y : Int8) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func neg(x : Int8) : Int8 { -x };

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -39,8 +39,8 @@ module {
 
   public func greaterOrEqual(x : Nat, y : Nat) : Bool { x >= y };
 
-  public func compare(x : Nat, y : Nat) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Nat, y : Nat) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func add(x : Nat, y : Nat) : Nat { x + y };

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -57,8 +57,8 @@ module {
 
   public func greaterOrEqual(x : Nat16, y : Nat16) : Bool { x >= y };
 
-  public func compare(x : Nat16, y : Nat16) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Nat16, y : Nat16) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func add(x : Nat16, y : Nat16) : Nat16 { x + y };

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -57,8 +57,8 @@ module {
 
   public func greaterOrEqual(x : Nat32, y : Nat32) : Bool { x >= y };
 
-  public func compare(x : Nat32, y : Nat32) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Nat32, y : Nat32) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func add(x : Nat32, y : Nat32) : Nat32 { x + y };

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -49,8 +49,8 @@ module {
 
   public func greaterOrEqual(x : Nat64, y : Nat64) : Bool { x >= y };
 
-  public func compare(x : Nat64, y : Nat64) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Nat64, y : Nat64) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func add(x : Nat64, y : Nat64) : Nat64 { x + y };

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -45,8 +45,8 @@ module {
 
   public func greaterOrEqual(x : Nat8, y : Nat8) : Bool { x >= y };
 
-  public func compare(x : Nat8, y : Nat8) : { #less; #equal; #greater } {
-    if (x < y) { #less } else if (x == y) { #equal } else { #greater }
+  public func compare(x : Nat8, y : Nat8) : { #Less; #Equal; #Greater } {
+    if (x < y) { #Less } else if (x == y) { #Equal } else { #Greater }
   };
 
   public func add(x : Nat8, y : Nat8) : Nat8 { x + y };

--- a/src/Order.mo
+++ b/src/Order.mo
@@ -6,9 +6,9 @@ import Iter "IterType";
 module {
 
   public type Order = {
-    #less;
-    #equal;
-    #greater
+    #Less;
+    #Equal;
+    #Greater
   };
 
   public func equal(o1 : Order, o2 : Order) : Bool {

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -6,8 +6,8 @@ import { todo } "Debug";
 module {
 
   public type Result<R, E> = {
-    #ok : R;
-    #err : E
+    #Ok : R;
+    #Err : E
   };
 
   public func equal<R, E>(
@@ -72,18 +72,6 @@ module {
   };
 
   public func assertErr(result : Result<Any, Any>) {
-    todo()
-  };
-
-  public func fromUpper<R, E>(
-    result : { #Ok : R; #Err : E }
-  ) : Result<R, E> {
-    todo()
-  };
-
-  public func toUpper<R, E>(
-    result : Result<R, E>
-  ) : { #Ok : R; #Err : E } {
     todo()
   };
 

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -70,9 +70,9 @@ module {
   };
 
   public type Pattern = {
-    #char : Char;
-    #text : Text;
-    #predicate : (Char -> Bool)
+    #Char : Char;
+    #Text : Text;
+    #Predicate : (Char -> Bool)
   };
 
   public func split(t : Text, p : Pattern) : Iter.Iter<Text> {

--- a/src/Time.mo
+++ b/src/Time.mo
@@ -8,12 +8,12 @@ module {
 
   public type Time = Int;
   public type Duration = {
-    #days : Nat;
-    #hours : Nat;
-    #minutes : Nat;
-    #seconds : Nat;
-    #milliseconds : Nat;
-    #nanoseconds : Nat;
+    #Days : Nat;
+    #Hours : Nat;
+    #Minutes : Nat;
+    #Seconds : Nat;
+    #Milliseconds : Nat;
+    #Nanoseconds : Nat;
   };
 
   public let now : () -> Time = func() : Int = Prim.nat64ToNat(Prim.time());
@@ -22,12 +22,12 @@ module {
 
   public func toNanoseconds(duration : Duration) : Nat {
     switch duration {
-      case (#days n) n * 86_400_000_000_000;
-      case (#hours n) n * 3_600_000_000_000;
-      case (#minutes n) n * 60_000_000_000;
-      case (#seconds n) n * 1_000_000_000;
-      case (#milliseconds n) n * 1_000_000;
-      case (#nanoseconds n) n
+      case (#Days n) n * 86_400_000_000_000;
+      case (#Hours n) n * 3_600_000_000_000;
+      case (#Minutes n) n * 60_000_000_000;
+      case (#Seconds n) n * 1_000_000_000;
+      case (#Milliseconds n) n * 1_000_000;
+      case (#Nanoseconds n) n
     };
   };
 


### PR DESCRIPTION
This PR uppercases the first letter of each variant in the base library. This convention is more interoperable with other languages in the ICP ecosystem and solves the long-standing issue of the differently-cased `Result` variants in Rust. 
