### PR TITLE
Move `compare` function to second arg where relevant

### DIFF
--- a/src/List.mo
+++ b/src/List.mo
@@ -72,7 +72,7 @@ module {
     todo()
   };
 
-  public func binarySearch<T>(list : List<T>, element : T, compare : (T, T) -> Order.Order) : ?Nat {
+  public func binarySearch<T>(list : List<T>, compare : (T, T) -> Order.Order, element : T) : ?Nat {
     todo()
   };
 

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -37,27 +37,27 @@ module {
     todo()
   };
 
-  public func containsKey<K>(map : Map<K, Any>, key : K, compare : (K, K) -> Order.Order) : Bool {
+  public func containsKey<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool {
     todo()
   };
 
-  public func get<K, V>(map : Map<K, V>, key : K, compare : (K, K) -> Order.Order) : ?V {
+  public func get<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V {
     todo()
   };
 
-  public func add<K, V>(map : Map<K, V>, key : K, value : V, compare : (K, K) -> Order.Order) : () {
+  public func add<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : () {
     todo()
   };
 
-  public func put<K, V>(map : Map<K, V>, key : K, value : V, compare : (K, K) -> Order.Order) : ?V {
+  public func put<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V {
     todo()
   };
 
-  public func replaceIfExists<K, V>(map : Map<K, V>, key : K, value : V, compare : (K, K) -> Order.Order) : ?V {
+  public func replaceIfExists<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V {
     todo()
   };
 
-  public func delete<K, V>(map : Map<K, V>, key : K, compare : (K, K) -> Order.Order) : () {
+  public func delete<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : () {
     todo()
   };
 

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -29,7 +29,7 @@ module {
     todo()
   };
 
-  public func contains<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : Bool {
+  public func contains<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool {
     todo()
   };
 
@@ -37,11 +37,11 @@ module {
     todo()
   };
 
-  public func add<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : () {
+  public func add<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : () {
     todo()
   };
 
-  public func delete<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : Bool {
+  public func delete<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool {
     todo()
   };
 

--- a/src/immutable/Map.mo
+++ b/src/immutable/Map.mo
@@ -20,27 +20,27 @@ module {
     todo()
   };
 
-  public func containsKey<K>(map : Map<K, Any>, key : K, compare : (K, K) -> Order.Order) : Bool {
+  public func containsKey<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool {
     todo()
   };
 
-  public func get<K, V>(map : Map<K, V>, key : K, compare : (K, K) -> Order.Order) : ?V {
+  public func get<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V {
     todo()
   };
 
-  public func add<K, V>(map : Map<K, V>, key : K, value : V, compare : (K, K) -> Order.Order) : Map<K, V> {
+  public func add<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : Map<K, V> {
     todo()
   };
 
-  public func put<K, V>(map : Map<K, V>, key : K, value : V, compare : (K, K) -> Order.Order) : (Map<K, V>, ?V) {
+  public func put<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : (Map<K, V>, ?V) {
     todo()
   };
 
-  public func delete<K, V>(map : Map<K, V>, key : K, compare : (K, K) -> Order.Order) : Map<K, V> {
+  public func delete<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : Map<K, V> {
     todo()
   };
 
-  public func take<K, V>(map : Map<K, V>, key : K, compare : (K, K) -> Order.Order) : (Map<K, V>, ?V) {
+  public func take<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : (Map<K, V>, ?V) {
     todo()
   };
 

--- a/src/immutable/Set.mo
+++ b/src/immutable/Set.mo
@@ -24,15 +24,15 @@ module {
     todo()
   };
 
-  public func contains<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : Bool {
+  public func contains<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool {
     todo()
   };
 
-  public func add<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : Set<T> {
+  public func add<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T> {
     todo()
   };
 
-  public func delete<T>(set : Set<T>, item : T, compare : (T, T) -> Order.Order) : Set<T> {
+  public func delete<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T> {
     todo()
   };
 


### PR DESCRIPTION
Moves the `compare` arg for all data structure operations with the exception of those comparing two data structures as the first two args. 

Supersedes #106.
