### PR TITLE
Add API validation in CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -65,4 +65,4 @@ jobs:
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview
-          message: "✨ Documentation preview for ${{ github.event.after }}:\n\n> **https://dfinity.github.io/${{ github.event.repository.name }}/${{ env.PR_PATH}}** ([source code](https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}/))"
+          message: "✨ Documentation preview for ${{ github.event.pull_request.head.sha }}:\n\n> **https://dfinity.github.io/${{ github.event.repository.name }}/${{ env.PR_PATH}}** ([source code](https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}/))"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -65,4 +65,4 @@ jobs:
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview
-          message: "✨ Documentation preview for ${{ github.event.pull_request.head.sha }}:\n\n> **https://dfinity.github.io/${{ github.event.repository.name }}/${{ env.PR_PATH}}** ([source code](https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}/))"
+          message: "✨ Documentation preview for ${{ github.event.after || github.event.pull_request.head.sha }}:\n\n> **https://dfinity.github.io/${{ github.event.repository.name }}/${{ env.PR_PATH}}** ([source code](https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}/))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,15 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm run validate
+      - name: Check for API changes
+        run: |
+          DIFF=$(git diff HEAD^ HEAD -- validation/api)
+          if [ -n "$DIFF" ]; then
+            echo "API changes:"
+            echo "$DIFF"
+            echo If this seems correct, please run the `npm run validate` command and then commit the output.
+            exit 1
+          fi
 
   format:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm run validate
       - name: Check for API changes
         run: |
-          DIFF=$(git diff HEAD^ HEAD -- validation/api)
+          DIFF=$(git diff origin/main -- validation/api)
           if [ -n "$DIFF" ]; then
             echo "API changes:"
             echo "$DIFF"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm run validate
       - name: Check for API changes
         run: |
-          DIFF=$(git diff origin/main -- validation/api)
+          DIFF=$(git diff -- validation/api)
           if [ -n "$DIFF" ]; then
             echo "API changes:"
             echo "$DIFF"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           if [ -n "$DIFF" ]; then
             echo "API changes:"
             echo "$DIFF"
-            echo If this seems correct, please run the `npm run validate` command and then commit the output.
+            echo 'If this looks correct, please run the command `npm run validate` and commit the output.'
             exit 1
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,9 @@ jobs:
           if [ -n "$DIFF" ]; then
             echo "API changes:"
             echo "$DIFF"
-            echo 'If this looks correct, please run the command `npm run validate` and commit the output.'
+            echo
+            echo '>>> If this looks correct, please run the command `npm run validate` and commit the output.'
+            echo
             exit 1
           fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "devDependencies": {
         "execa": "^4.1.0",
         "fast-glob": "^3.3.2",
-        "husky": "^9.1.7",
         "ic-mops": "^1.1.1",
         "mo-dev": "^0.13.0",
         "npm-run-all": "^4.1.5",
@@ -4443,22 +4442,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ic-mops": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "execa": "^4.1.0",
     "fast-glob": "^3.3.2",
-    "husky": "^9.1.7",
     "ic-mops": "^1.1.1",
     "mo-dev": "^0.13.0",
     "npm-run-all": "^4.1.5",

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -9,9 +9,9 @@ module {
 
   public type Int16 = Prim.Types.Int16;
 
-  public let minimumValue = -32_768 : Int16;
+  public let minValue : Int16 = -32_768;
 
-  public let maximumValue = 32_767 : Int16;
+  public let maxValue : Int16 = 32_767;
 
   public let toInt : Int16 -> Int = Prim.int16ToInt;
 

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -9,9 +9,9 @@ module {
 
   public type Int32 = Prim.Types.Int32;
 
-  public let minimumValue = -2_147_483_648 : Int32;
+  public let minValue : Int32 = -2_147_483_648;
 
-  public let maximumValue = 2_147_483_647 : Int32;
+  public let maxValue : Int32 = 2_147_483_647;
 
   public let toInt : Int32 -> Int = Prim.int32ToInt;
 

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -9,9 +9,9 @@ module {
 
   public type Int64 = Prim.Types.Int64;
 
-  public let minimumValue = -9_223_372_036_854_775_808 : Int64;
+  public let minValue : Int64 = -9_223_372_036_854_775_808;
 
-  public let maximumValue = 9_223_372_036_854_775_807 : Int64;
+  public let maxValue : Int64 = 9_223_372_036_854_775_807;
 
   public let toInt : Int64 -> Int = Prim.int64ToInt;
 

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -9,9 +9,9 @@ module {
 
   public type Int8 = Prim.Types.Int8;
 
-  public let minimumValue = -128 : Int8;
+  public let minValue : Int8 = -128;
 
-  public let maximumValue = 127 : Int8;
+  public let maxValue : Int8 = 127;
 
   public let toInt : Int8 -> Int = Prim.int8ToInt;
 

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -9,7 +9,7 @@ module {
 
   public type Nat16 = Prim.Types.Nat16;
 
-  public let maximumValue = 65535 : Nat16;
+  public let maxValue : Nat16 = 65535;
 
   public let toNat : Nat16 -> Nat = Prim.nat16ToNat;
 

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -9,7 +9,7 @@ module {
 
   public type Nat32 = Prim.Types.Nat32;
 
-  public let maximumValue = 4294967295 : Nat32;
+  public let maxValue : Nat32 = 4294967295;
 
   public let toNat : Nat32 -> Nat = Prim.nat32ToNat;
 

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -9,7 +9,7 @@ module {
 
   public type Nat64 = Prim.Types.Nat64;
 
-  public let maximumValue = 18446744073709551615 : Nat64;
+  public let maxValue : Nat64 = 18446744073709551615;
 
   public let toNat : Nat64 -> Nat = Prim.nat64ToNat;
 

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -9,7 +9,7 @@ module {
 
   public type Nat8 = Prim.Types.Nat8;
 
-  public let maximumValue = 255 : Nat8;
+  public let maxValue : Nat8 = 255;
 
   public let toNat : Nat8 -> Nat = Prim.nat8ToNat;
 

--- a/src/immutable/Map.mo
+++ b/src/immutable/Map.mo
@@ -8,7 +8,7 @@ module {
 
   public type Map<K, V> = (); // Placeholder
 
-  public func empty123<K, V>() : Map<K, V> {
+  public func empty<K, V>() : Map<K, V> {
     todo()
   };
 

--- a/src/immutable/Map.mo
+++ b/src/immutable/Map.mo
@@ -8,7 +8,7 @@ module {
 
   public type Map<K, V> = (); // Placeholder
 
-  public func empty<K, V>() : Map<K, V> {
+  public func empty123<K, V>() : Map<K, V> {
     todo()
   };
 

--- a/test/ts/validate/spec.ts
+++ b/test/ts/validate/spec.ts
@@ -1,9 +1,10 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const rootDir = join(__dirname, "../../..");
 const srcDir = join(rootDir, "src");
-const interfaceDir = join(rootDir, "validation");
+const validationDir = join(rootDir, "validation");
+const apiDir = join(validationDir, "api");
 
 interface Module {
   name: string;
@@ -32,21 +33,33 @@ function readModules(dir: string, subdir: string = "") {
       readModules(dir, subPath);
     } else if (entry.isFile() && entry.name.endsWith(".mo")) {
       const name = subPath.replace(/\.mo$/, "");
-      const functions = parseFunctions(readFileSync(fullPath, "utf8"));
+      const functions = parseFunctions(name, readFileSync(fullPath, "utf8"));
       moduleMap.set(name, { name, functions });
     }
   });
 }
 
 // Regex-based module function parser
-function parseFunctions(source: string) {
-  const regex = /public\s+(func|let|class)\s+(\w+)([^{=]+)\s*[{=]/g;
+function parseFunctions(moduleName: string, source: string) {
+  const regex =
+    /public\s+(func|let|class)\s+(\w+)([^{:=]+(?::\s*\{?[^{:=]*)*)\s*[{=]/g;
   const functions: Func[] = [];
   let match;
   while ((match = regex.exec(source)) !== null) {
     const [_, _declarationType, name, type] = match;
-    functions.push({ name, type: type.replace(/\s+/g, " ") });
+    const resolvedType = type.replace(/\s+/g, " ").trim();
+    if (
+      !resolvedType ||
+      resolvedType.endsWith(":") ||
+      resolvedType.endsWith("{")
+    ) {
+      throw new Error(
+        `Validation regex was unable to correctly parse the type of ${moduleName}.${name}: ${resolvedType}`
+      );
+    }
+    functions.push({ name, type: resolvedType });
   }
+  functions.sort((a, b) => a.name.localeCompare(b.name));
   return functions;
 }
 
@@ -56,18 +69,18 @@ if (!existsSync(srcDir)) {
 
 const errors: string[] = [];
 
-// Module files
+// Read module files
 readModules(srcDir);
 
-// Spec files
+// Read spec files
 const specs: Spec[] = [];
 const specMap = new Map<string, Spec>();
-readdirSync(interfaceDir)
+readdirSync(validationDir)
   .filter((file) => file.endsWith(".json"))
   .forEach((file) => {
     try {
       const content = JSON.parse(
-        readFileSync(join(interfaceDir, file), "utf-8")
+        readFileSync(join(validationDir, file), "utf-8")
       );
       const items = content.specs;
       if (!Array.isArray(items)) {
@@ -98,6 +111,18 @@ readdirSync(interfaceDir)
     }
   });
 
+// Update lockfile
+writeFileSync(
+  join(apiDir, "api.lock.json"),
+  JSON.stringify(
+    [...moduleMap.keys()].sort().map((key) => moduleMap.get(key)),
+    null,
+    2
+  ),
+  "utf8"
+);
+
+// Validate spec files
 const resolveSpec = (spec: Spec, functions: string[]) => {
   functions.push(
     ...spec.functions.filter((funcName) => !functions.includes(funcName))
@@ -105,7 +130,9 @@ const resolveSpec = (spec: Spec, functions: string[]) => {
   spec.extends.forEach((extendName) => {
     const extend = specMap.get(extendName);
     if (!extend) {
-      errors.push(`Unknown module: '${extendName}' (referenced in '${spec.name}')`);
+      errors.push(
+        `Unknown module: '${extendName}' (referenced in '${spec.name}')`
+      );
       return;
     }
     resolveSpec(extend, functions);

--- a/test/ts/validate/spec.ts
+++ b/test/ts/validate/spec.ts
@@ -42,7 +42,7 @@ function readModules(dir: string, subdir: string = "") {
 // Regex-based module function parser
 function parseFunctions(moduleName: string, source: string) {
   const regex =
-    /^ {2}(public\s+(?:func|let|class)\s+(\w+)?([^{:=]+(?::\s*\{?[^{:=]*)*))\s*[{=]/gm;
+    /\n {2}(public\s+(?:func|let|class)\s+(\w+)?([^{:=]+(?::\s*\{?[^{:=]*)*))\s*[{=]/g;
   const functions: Func[] = [];
   let match;
   while ((match = regex.exec(source)) !== null) {

--- a/test/ts/validate/spec.ts
+++ b/test/ts/validate/spec.ts
@@ -42,7 +42,7 @@ function readModules(dir: string, subdir: string = "") {
 // Regex-based module function parser
 function parseFunctions(moduleName: string, source: string) {
   const regex =
-    /(public\s+(?:func|let|class)\s+(\w+)?([^{:=]+(?::\s*\{?[^{:=]*)*))\s*[{=]/g;
+    /^ {2}(public\s+(?:func|let|class)\s+(\w+)?([^{:=]+(?::\s*\{?[^{:=]*)*))\s*[{=]/gm;
   const functions: Func[] = [];
   let match;
   while ((match = regex.exec(source)) !== null) {

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -878,16 +878,6 @@
     "exports": [
       "public class AsyncRandom(generator : () -> async* Blob)",
       "public let blob : shared () -> async Blob",
-      "public func bool() : Bool",
-      "public func bool() : async* Bool",
-      "public func byte() : Nat8",
-      "public func byte() : async* Nat8",
-      "public func float() : Float",
-      "public func float() : async* Float",
-      "public func intRange(min : Int, maxExclusive : Int) : Int",
-      "public func intRange(min : Int, maxExclusive : Int) : async* Int",
-      "public func natRange(min : Nat, maxExclusive : Nat) : Nat",
-      "public func natRange(min : Nat, maxExclusive : Nat) : async* Nat",
       "public func new(seed : Blob) : Random",
       "public func newAsync() : AsyncRandom",
       "public class Random(generator : () -> Blob)"

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1,4392 +1,1260 @@
 [
   {
     "name": "Array",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(array : [T], predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(array : [T], predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "append",
-        "type": "<T>(array1 : [T], array2 : [T]) : [T]"
-      },
-      {
-        "name": "chain",
-        "type": "<T, Y>(array : [T], k : T -> [Y]) : [Y]"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(array1 : [T], array2 : [T], compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : [T]"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(array1 : [T], array2 : [T], equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(array : [T], f : T -> Bool) : [T]"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, Y>(array : [T], f : T -> ?Y) : [Y]"
-      },
-      {
-        "name": "find",
-        "type": "<T>(array : [T], predicate : T -> Bool) : ?T"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(arrays : Iter.Iter<[T]>) : [T]"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>(array : [T], base : A, combine : (A, T) -> A) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>(array : [T], base : A, combine : (T, A) -> A) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(array : [T], f : T -> ())"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : [T]"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "<T>(varArray : [var T]) : [T]"
-      },
-      {
-        "name": "generate",
-        "type": "<T>(size : Nat, generator : Nat -> T) : [T]"
-      },
-      {
-        "name": "indexOf",
-        "type": "<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "init",
-        "type": "<T>(size : Nat, initValue : T) : [T]"
-      },
-      {
-        "name": "isEmpty",
-        "type": "<T>(array : [T]) : Bool"
-      },
-      {
-        "name": "keys",
-        "type": "<T>(array : [T]) : Iter.Iter<Nat>"
-      },
-      {
-        "name": "lastIndexOf",
-        "type": "<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "map",
-        "type": "<T, Y>(array : [T], f : T -> Y) : [Y]"
-      },
-      {
-        "name": "mapEntries",
-        "type": "<T, Y>(array : [T], f : (T, Nat) -> Y) : [Y]"
-      },
-      {
-        "name": "mapResult",
-        "type": "<T, Y, E>(array : [T], f : T -> Result.Result<Y, E>) : Result.Result<[Y], E>"
-      },
-      {
-        "name": "nextIndexOf",
-        "type": "<T>(element : T, array : [T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "prevIndexOf",
-        "type": "<T>(element : T, array : [T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "reverse",
-        "type": "<T>(array : [T]) : [T]"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(element : T) : [T]"
-      },
-      {
-        "name": "size",
-        "type": "<T>(array : [T]) : Nat"
-      },
-      {
-        "name": "slice",
-        "type": "<T>(array : [T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>"
-      },
-      {
-        "name": "sort",
-        "type": "<T>(array : [T], compare : (T, T) -> Order.Order) : [T]"
-      },
-      {
-        "name": "subArray",
-        "type": "<T>(array : [T], start : Nat, length : Nat) : [T]"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(array : [T], f : T -> Text) : Text"
-      },
-      {
-        "name": "toVarArray",
-        "type": "<T>(array : [T]) : [var T]"
-      },
-      {
-        "name": "values",
-        "type": "<T>(array : [T]) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func all<T>(array : [T], predicate : T -> Bool) : Bool",
+      "public func any<T>(array : [T], predicate : T -> Bool) : Bool",
+      "public func append<T>(array1 : [T], array2 : [T]) : [T]",
+      "public func chain<T, Y>(array : [T], k : T -> [Y]) : [Y]",
+      "public func compare<T>(array1 : [T], array2 : [T], compare : (T, T) -> Order.Order) : Order.Order",
+      "public func empty<T>() : [T]",
+      "public func equal<T>(array1 : [T], array2 : [T], equal : (T, T) -> Bool) : Bool",
+      "public func filter<T>(array : [T], f : T -> Bool) : [T]",
+      "public func filterMap<T, Y>(array : [T], f : T -> ?Y) : [Y]",
+      "public func find<T>(array : [T], predicate : T -> Bool) : ?T",
+      "public func flatten<T>(arrays : Iter.Iter<[T]>) : [T]",
+      "public func foldLeft<T, A>(array : [T], base : A, combine : (A, T) -> A) : A",
+      "public func foldRight<T, A>(array : [T], base : A, combine : (T, A) -> A) : A",
+      "public func forEach<T>(array : [T], f : T -> ())",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : [T]",
+      "public func fromVarArray<T>(varArray : [var T]) : [T]",
+      "public func generate<T>(size : Nat, generator : Nat -> T) : [T]",
+      "public func indexOf<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat",
+      "public func init<T>(size : Nat, initValue : T) : [T]",
+      "public func isEmpty<T>(array : [T]) : Bool",
+      "public func keys<T>(array : [T]) : Iter.Iter<Nat>",
+      "public func lastIndexOf<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat",
+      "public func map<T, Y>(array : [T], f : T -> Y) : [Y]",
+      "public func mapEntries<T, Y>(array : [T], f : (T, Nat) -> Y) : [Y]",
+      "public func mapResult<T, Y, E>(array : [T], f : T -> Result.Result<Y, E>) : Result.Result<[Y], E>",
+      "public func nextIndexOf<T>(element : T, array : [T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat",
+      "public func prevIndexOf<T>(element : T, array : [T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat",
+      "public func reverse<T>(array : [T]) : [T]",
+      "public func singleton<T>(element : T) : [T]",
+      "public func size<T>(array : [T]) : Nat",
+      "public func slice<T>(array : [T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>",
+      "public func sort<T>(array : [T], compare : (T, T) -> Order.Order) : [T]",
+      "public func subArray<T>(array : [T], start : Nat, length : Nat) : [T]",
+      "public func toText<T>(array : [T], f : T -> Text) : Text",
+      "public func toVarArray<T>(array : [T]) : [var T]",
+      "public func values<T>(array : [T]) : Iter.Iter<T>"
     ]
   },
   {
     "name": "Blob",
-    "functions": [
-      {
-        "name": "compare",
-        "type": "(b1 : Blob, b2 : Blob) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "empty",
-        "type": "() : Blob"
-      },
-      {
-        "name": "equal",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "fromArray",
-        "type": "(bytes : [Nat8]) : Blob"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "(bytes : [var Nat8]) : Blob"
-      },
-      {
-        "name": "greater",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "hash",
-        "type": "(blob : Blob) : Nat32"
-      },
-      {
-        "name": "less",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "notEqual",
-        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
-      },
-      {
-        "name": "size",
-        "type": "(blob : Blob) : Nat"
-      },
-      {
-        "name": "toArray",
-        "type": "(blob : Blob) : [Nat8]"
-      },
-      {
-        "name": "toVarArray",
-        "type": "(blob : Blob) : [var Nat8]"
-      }
+    "exports": [
+      "public func compare(b1 : Blob, b2 : Blob) : { #less; #equal; #greater }",
+      "public func empty() : Blob",
+      "public func equal(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func fromArray(bytes : [Nat8]) : Blob",
+      "public func fromVarArray(bytes : [var Nat8]) : Blob",
+      "public func greater(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func greaterOrEqual(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func hash(blob : Blob) : Nat32",
+      "public func less(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func lessOrEqual(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func notEqual(blob1 : Blob, blob2 : Blob) : Bool",
+      "public func size(blob : Blob) : Nat",
+      "public func toArray(blob : Blob) : [Nat8]",
+      "public func toVarArray(blob : Blob) : [var Nat8]"
     ]
   },
   {
     "name": "Bool",
-    "functions": [
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Bool>"
-      },
-      {
-        "name": "compare",
-        "type": "(a : Bool, b : Bool) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "equal",
-        "type": "(a : Bool, b : Bool) : Bool"
-      },
-      {
-        "name": "logicalAnd",
-        "type": "(a : Bool, b : Bool) : Bool"
-      },
-      {
-        "name": "logicalNot",
-        "type": "(bool : Bool) : Bool"
-      },
-      {
-        "name": "logicalOr",
-        "type": "(a : Bool, b : Bool) : Bool"
-      },
-      {
-        "name": "logicalXor",
-        "type": "(a : Bool, b : Bool) : Bool"
-      },
-      {
-        "name": "toText",
-        "type": "(bool : Bool) : Text"
-      }
+    "exports": [
+      "public func allValues() : Iter.Iter<Bool>",
+      "public func compare(a : Bool, b : Bool) : { #less; #equal; #greater }",
+      "public func equal(a : Bool, b : Bool) : Bool",
+      "public func logicalAnd(a : Bool, b : Bool) : Bool",
+      "public func logicalNot(bool : Bool) : Bool",
+      "public func logicalOr(a : Bool, b : Bool) : Bool",
+      "public func logicalXor(a : Bool, b : Bool) : Bool",
+      "public func toText(bool : Bool) : Text"
     ]
   },
   {
     "name": "CertifiedData",
-    "functions": [
-      {
-        "name": "getCertificate",
-        "type": ": () -> ?Blob"
-      },
-      {
-        "name": "set",
-        "type": ": (data : Blob) -> ()"
-      }
+    "exports": [
+      "public let getCertificate : () -> ?Blob",
+      "public let set : (data : Blob) -> ()"
     ]
   },
   {
     "name": "Char",
-    "functions": [
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Char>"
-      },
-      {
-        "name": "compare",
-        "type": "(a : Char, b : Char) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "equal",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "fromNat32",
-        "type": ": (nat32 : Nat32) -> Char"
-      },
-      {
-        "name": "greater",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "isAlphabetic",
-        "type": ": (char : Char) -> Bool"
-      },
-      {
-        "name": "isDigit",
-        "type": "(char : Char) : Bool"
-      },
-      {
-        "name": "isLower",
-        "type": ": (char : Char) -> Bool"
-      },
-      {
-        "name": "isUpper",
-        "type": ": (char : Char) -> Bool"
-      },
-      {
-        "name": "isWhitespace",
-        "type": ": (char : Char) -> Bool"
-      },
-      {
-        "name": "less",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "notEqual",
-        "type": "(a : Char, b : Char) : Bool"
-      },
-      {
-        "name": "toLower",
-        "type": ": (char : Char) -> Char"
-      },
-      {
-        "name": "toNat32",
-        "type": ": (char : Char) -> Nat32"
-      },
-      {
-        "name": "toText",
-        "type": ": (char : Char) -> Text"
-      },
-      {
-        "name": "toUpper",
-        "type": ": (char : Char) -> Char"
-      }
+    "exports": [
+      "public func allValues() : Iter.Iter<Char>",
+      "public func compare(a : Char, b : Char) : { #less; #equal; #greater }",
+      "public func equal(a : Char, b : Char) : Bool",
+      "public let fromNat32 : (nat32 : Nat32) -> Char",
+      "public func greater(a : Char, b : Char) : Bool",
+      "public func greaterOrEqual(a : Char, b : Char) : Bool",
+      "public let isAlphabetic : (char : Char) -> Bool",
+      "public func isDigit(char : Char) : Bool",
+      "public let isLower : (char : Char) -> Bool",
+      "public let isUpper : (char : Char) -> Bool",
+      "public let isWhitespace : (char : Char) -> Bool",
+      "public func less(a : Char, b : Char) : Bool",
+      "public func lessOrEqual(a : Char, b : Char) : Bool",
+      "public func notEqual(a : Char, b : Char) : Bool",
+      "public let toLower : (char : Char) -> Char",
+      "public let toNat32 : (char : Char) -> Nat32",
+      "public let toText : (char : Char) -> Text",
+      "public let toUpper : (char : Char) -> Char"
     ]
   },
   {
     "name": "Cycles",
-    "functions": [
-      {
-        "name": "accept",
-        "type": ": <system>(amount : Nat) -> (accepted : Nat)"
-      },
-      {
-        "name": "add",
-        "type": ": <system>(amount : Nat) -> ()"
-      },
-      {
-        "name": "available",
-        "type": ": () -> (amount : Nat)"
-      },
-      {
-        "name": "balance",
-        "type": ": () -> (amount : Nat)"
-      },
-      {
-        "name": "refunded",
-        "type": ": () -> (amount : Nat)"
-      }
+    "exports": [
+      "public let accept : <system>(amount : Nat) -> (accepted : Nat)",
+      "public let add : <system>(amount : Nat) -> ()",
+      "public let available : () -> (amount : Nat)",
+      "public let balance : () -> (amount : Nat)",
+      "public let refunded : () -> (amount : Nat)"
     ]
   },
   {
     "name": "Debug",
-    "functions": [
-      {
-        "name": "print",
-        "type": "(text : Text)"
-      },
-      {
-        "name": "todo",
-        "type": "() : None"
-      }
+    "exports": [
+      "public func print(text : Text)",
+      "public func todo() : None"
     ]
   },
   {
     "name": "Error",
-    "functions": [
-      {
-        "name": "code",
-        "type": ": (error : Error) -> ErrorCode"
-      },
-      {
-        "name": "message",
-        "type": ": (error : Error) -> Text"
-      },
-      {
-        "name": "reject",
-        "type": ": (message : Text) -> Error"
-      }
+    "exports": [
+      "public let code : (error : Error) -> ErrorCode",
+      "public let message : (error : Error) -> Text",
+      "public let reject : (message : Text) -> Error"
     ]
   },
   {
     "name": "Float",
-    "functions": [
-      {
-        "name": "abs",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "add",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "arccos",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "arcsin",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "arctan",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "arctan2",
-        "type": ": (y : Float, x : Float) -> Float"
-      },
-      {
-        "name": "ceil",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Float, y : Float) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "copySign",
-        "type": ": (x : Float, y : Float) -> Float"
-      },
-      {
-        "name": "cos",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "div",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "e",
-        "type": ": Float"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "equalWithin",
-        "type": "(x : Float, y : Float, epsilon : Float) : Bool"
-      },
-      {
-        "name": "exp",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "floor",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "format",
-        "type": "(fmt : { #fix : Nat8; #exp : Nat8; #gen : Nat8; #exact }, x : Float) : Text"
-      },
-      {
-        "name": "fromInt",
-        "type": ": Int -> Float"
-      },
-      {
-        "name": "fromInt64",
-        "type": ": Int64 -> Float"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "isNaN",
-        "type": "(number : Float) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "log",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "max",
-        "type": ": (x : Float, y : Float) -> Float"
-      },
-      {
-        "name": "min",
-        "type": ": (x : Float, y : Float) -> Float"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "nearest",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Float) : Float"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Float, y : Float) : Bool"
-      },
-      {
-        "name": "notEqualWithin",
-        "type": "(x : Float, y : Float, epsilon : Float) : Bool"
-      },
-      {
-        "name": "pi",
-        "type": ": Float"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "sin",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "sqrt",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Float, y : Float) : Float"
-      },
-      {
-        "name": "tan",
-        "type": ": (x : Float) -> Float"
-      },
-      {
-        "name": "toInt",
-        "type": ": Float -> Int"
-      },
-      {
-        "name": "toInt64",
-        "type": ": Float -> Int64"
-      },
-      {
-        "name": "toText",
-        "type": ": Float -> Text"
-      },
-      {
-        "name": "trunc",
-        "type": ": (x : Float) -> Float"
-      }
+    "exports": [
+      "public let abs : (x : Float) -> Float",
+      "public func add(x : Float, y : Float) : Float",
+      "public let arccos : (x : Float) -> Float",
+      "public let arcsin : (x : Float) -> Float",
+      "public let arctan : (x : Float) -> Float",
+      "public let arctan2 : (y : Float, x : Float) -> Float",
+      "public let ceil : (x : Float) -> Float",
+      "public func compare(x : Float, y : Float) : { #less; #equal; #greater }",
+      "public let copySign : (x : Float, y : Float) -> Float",
+      "public let cos : (x : Float) -> Float",
+      "public func div(x : Float, y : Float) : Float",
+      "public let e : Float",
+      "public func equal(x : Float, y : Float) : Bool",
+      "public func equalWithin(x : Float, y : Float, epsilon : Float) : Bool",
+      "public let exp : (x : Float) -> Float",
+      "public let floor : (x : Float) -> Float",
+      "public func format(fmt : { #fix : Nat8; #exp : Nat8; #gen : Nat8; #exact }, x : Float) : Text",
+      "public let fromInt : Int -> Float",
+      "public let fromInt64 : Int64 -> Float",
+      "public func greater(x : Float, y : Float) : Bool",
+      "public func greaterOrEqual(x : Float, y : Float) : Bool",
+      "public func isNaN(number : Float) : Bool",
+      "public func less(x : Float, y : Float) : Bool",
+      "public func lessOrEqual(x : Float, y : Float) : Bool",
+      "public let log : (x : Float) -> Float",
+      "public let max : (x : Float, y : Float) -> Float",
+      "public let min : (x : Float, y : Float) -> Float",
+      "public func mul(x : Float, y : Float) : Float",
+      "public let nearest : (x : Float) -> Float",
+      "public func neg(x : Float) : Float",
+      "public func notEqual(x : Float, y : Float) : Bool",
+      "public func notEqualWithin(x : Float, y : Float, epsilon : Float) : Bool",
+      "public let pi : Float",
+      "public func pow(x : Float, y : Float) : Float",
+      "public func rem(x : Float, y : Float) : Float",
+      "public let sin : (x : Float) -> Float",
+      "public let sqrt : (x : Float) -> Float",
+      "public func sub(x : Float, y : Float) : Float",
+      "public let tan : (x : Float) -> Float",
+      "public let toInt : Float -> Int",
+      "public let toInt64 : Float -> Int64",
+      "public let toText : Float -> Text",
+      "public let trunc : (x : Float) -> Float"
     ]
   },
   {
     "name": "Func",
-    "functions": [
-      {
-        "name": "compose",
-        "type": "<A, B, C>(f : B -> C, g : A -> B) : A -> C"
-      },
-      {
-        "name": "const",
-        "type": "<A, B>(x : A) : B -> A"
-      },
-      {
-        "name": "identity",
-        "type": "<A>(x : A) : A"
-      }
+    "exports": [
+      "public func compose<A, B, C>(f : B -> C, g : A -> B) : A -> C",
+      "public func const<A, B>(x : A) : B -> A",
+      "public func identity<A>(x : A) : A"
     ]
   },
   {
     "name": "Hash",
-    "functions": [
-      {
-        "name": "bit",
-        "type": "(hash : Hash, pos : Nat) : Bool"
-      },
-      {
-        "name": "debugPrintBits",
-        "type": "(bits : Hash)"
-      },
-      {
-        "name": "debugPrintBitsRev",
-        "type": "(bits : Hash)"
-      },
-      {
-        "name": "equal",
-        "type": "(hash1 : Hash, hash2 : Hash) : Bool"
-      },
-      {
-        "name": "hash",
-        "type": "(nat : Nat) : Hash"
-      },
-      {
-        "name": "length",
-        "type": ": Nat"
-      }
+    "exports": [
+      "public func bit(hash : Hash, pos : Nat) : Bool",
+      "public func debugPrintBits(bits : Hash)",
+      "public func debugPrintBitsRev(bits : Hash)",
+      "public func equal(hash1 : Hash, hash2 : Hash) : Bool",
+      "public func hash(nat : Nat) : Hash",
+      "public let length : Nat"
     ]
   },
   {
     "name": "Int",
-    "functions": [
-      {
-        "name": "abs",
-        "type": "(x : Int) : Nat"
-      },
-      {
-        "name": "add",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Int, y : Int) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "hash",
-        "type": "(i : Int) : Hash.Hash"
-      },
-      {
-        "name": "less",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "min",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Int) : Int"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Int, y : Int) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int, toExclusive : Int) : Iter.Iter<Int>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Int, to : Int) : Iter.Iter<Int>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Int, y : Int) : Int"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Int) : Text"
-      }
+    "exports": [
+      "public func abs(x : Int) : Nat",
+      "public func add(x : Int, y : Int) : Int",
+      "public func compare(x : Int, y : Int) : { #less; #equal; #greater }",
+      "public func div(x : Int, y : Int) : Int",
+      "public func equal(x : Int, y : Int) : Bool",
+      "public func greater(x : Int, y : Int) : Bool",
+      "public func greaterOrEqual(x : Int, y : Int) : Bool",
+      "public func hash(i : Int) : Hash.Hash",
+      "public func less(x : Int, y : Int) : Bool",
+      "public func lessOrEqual(x : Int, y : Int) : Bool",
+      "public func max(x : Int, y : Int) : Int",
+      "public func min(x : Int, y : Int) : Int",
+      "public func mul(x : Int, y : Int) : Int",
+      "public func neg(x : Int) : Int",
+      "public func notEqual(x : Int, y : Int) : Bool",
+      "public func pow(x : Int, y : Int) : Int",
+      "public func range(fromInclusive : Int, toExclusive : Int) : Iter.Iter<Int>",
+      "public func rangeInclusive(from : Int, to : Int) : Iter.Iter<Int>",
+      "public func rem(x : Int, y : Int) : Int",
+      "public func sub(x : Int, y : Int) : Int",
+      "public func toText(x : Int) : Text"
     ]
   },
   {
     "name": "Int16",
-    "functions": [
-      {
-        "name": "abs",
-        "type": "(x : Int16) : Int16"
-      },
-      {
-        "name": "add",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Int16>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Int16, p : Nat) : Int16"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Int16) -> Int16"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Int16) -> Int16"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Int16) -> Int16"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Int16, p : Nat) : Int16"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Int16) : Int16"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Int16, p : Nat) : Int16"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Int16, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Int16, y : Int16) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "fromInt",
-        "type": ": Int -> Int16"
-      },
-      {
-        "name": "fromInt32",
-        "type": ": Int32 -> Int16"
-      },
-      {
-        "name": "fromInt8",
-        "type": ": Int8 -> Int16"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Int16"
-      },
-      {
-        "name": "fromNat16",
-        "type": ": Nat16 -> Int16"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Int16"
-      },
-      {
-        "name": "min",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "minValue",
-        "type": ": Int16"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Int16) : Int16"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Int16, y : Int16) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int16, toExclusive : Int16) : Iter.Iter<Int16>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Int16, to : Int16) : Iter.Iter<Int16>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Int16, y : Int16) : Int16"
-      },
-      {
-        "name": "toInt",
-        "type": ": Int16 -> Int"
-      },
-      {
-        "name": "toInt32",
-        "type": ": Int16 -> Int32"
-      },
-      {
-        "name": "toInt8",
-        "type": ": Int16 -> Int8"
-      },
-      {
-        "name": "toNat16",
-        "type": ": Int16 -> Nat16"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Int16) : Text"
-      }
+    "exports": [
+      "public func abs(x : Int16) : Int16",
+      "public func add(x : Int16, y : Int16) : Int16",
+      "public func addWrap(x : Int16, y : Int16) : Int16",
+      "public func allValues() : Iter.Iter<Int16>",
+      "public func bitand(x : Int16, y : Int16) : Int16",
+      "public func bitclear(x : Int16, p : Nat) : Int16",
+      "public let bitcountLeadingZero : (x : Int16) -> Int16",
+      "public let bitcountNonZero : (x : Int16) -> Int16",
+      "public let bitcountTrailingZero : (x : Int16) -> Int16",
+      "public func bitflip(x : Int16, p : Nat) : Int16",
+      "public func bitnot(x : Int16) : Int16",
+      "public func bitor(x : Int16, y : Int16) : Int16",
+      "public func bitrotLeft(x : Int16, y : Int16) : Int16",
+      "public func bitrotRight(x : Int16, y : Int16) : Int16",
+      "public func bitset(x : Int16, p : Nat) : Int16",
+      "public func bitshiftLeft(x : Int16, y : Int16) : Int16",
+      "public func bitshiftRight(x : Int16, y : Int16) : Int16",
+      "public func bittest(x : Int16, p : Nat) : Bool",
+      "public func bitxor(x : Int16, y : Int16) : Int16",
+      "public func compare(x : Int16, y : Int16) : { #less; #equal; #greater }",
+      "public func div(x : Int16, y : Int16) : Int16",
+      "public func equal(x : Int16, y : Int16) : Bool",
+      "public let fromInt : Int -> Int16",
+      "public let fromInt32 : Int32 -> Int16",
+      "public let fromInt8 : Int8 -> Int16",
+      "public let fromIntWrap : Int -> Int16",
+      "public let fromNat16 : Nat16 -> Int16",
+      "public func greater(x : Int16, y : Int16) : Bool",
+      "public func greaterOrEqual(x : Int16, y : Int16) : Bool",
+      "public func less(x : Int16, y : Int16) : Bool",
+      "public func lessOrEqual(x : Int16, y : Int16) : Bool",
+      "public func max(x : Int16, y : Int16) : Int16",
+      "public let maxValue : Int16",
+      "public func min(x : Int16, y : Int16) : Int16",
+      "public let minValue : Int16",
+      "public func mul(x : Int16, y : Int16) : Int16",
+      "public func mulWrap(x : Int16, y : Int16) : Int16",
+      "public func neg(x : Int16) : Int16",
+      "public func notEqual(x : Int16, y : Int16) : Bool",
+      "public func pow(x : Int16, y : Int16) : Int16",
+      "public func powWrap(x : Int16, y : Int16) : Int16",
+      "public func range(fromInclusive : Int16, toExclusive : Int16) : Iter.Iter<Int16>",
+      "public func rangeInclusive(from : Int16, to : Int16) : Iter.Iter<Int16>",
+      "public func rem(x : Int16, y : Int16) : Int16",
+      "public func sub(x : Int16, y : Int16) : Int16",
+      "public func subWrap(x : Int16, y : Int16) : Int16",
+      "public let toInt : Int16 -> Int",
+      "public let toInt32 : Int16 -> Int32",
+      "public let toInt8 : Int16 -> Int8",
+      "public let toNat16 : Int16 -> Nat16",
+      "public func toText(x : Int16) : Text"
     ]
   },
   {
     "name": "Int32",
-    "functions": [
-      {
-        "name": "abs",
-        "type": "(x : Int32) : Int32"
-      },
-      {
-        "name": "add",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Int32>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Int32, p : Nat) : Int32"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Int32) -> Int32"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Int32) -> Int32"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Int32) -> Int32"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Int32, p : Nat) : Int32"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Int32) : Int32"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Int32, p : Nat) : Int32"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Int32, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Int32, y : Int32) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "fromInt",
-        "type": ": Int -> Int32"
-      },
-      {
-        "name": "fromInt16",
-        "type": ": Int16 -> Int32"
-      },
-      {
-        "name": "fromInt64",
-        "type": ": Int64 -> Int32"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Int32"
-      },
-      {
-        "name": "fromNat32",
-        "type": ": Nat32 -> Int32"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Int32"
-      },
-      {
-        "name": "min",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "minValue",
-        "type": ": Int32"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Int32) : Int32"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Int32, y : Int32) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int32, toExclusive : Int32) : Iter.Iter<Int32>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Int32, to : Int32) : Iter.Iter<Int32>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Int32, y : Int32) : Int32"
-      },
-      {
-        "name": "toInt",
-        "type": ": Int32 -> Int"
-      },
-      {
-        "name": "toInt16",
-        "type": ": Int32 -> Int16"
-      },
-      {
-        "name": "toInt64",
-        "type": ": Int32 -> Int64"
-      },
-      {
-        "name": "toNat32",
-        "type": ": Int32 -> Nat32"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Int32) : Text"
-      }
+    "exports": [
+      "public func abs(x : Int32) : Int32",
+      "public func add(x : Int32, y : Int32) : Int32",
+      "public func addWrap(x : Int32, y : Int32) : Int32",
+      "public func allValues() : Iter.Iter<Int32>",
+      "public func bitand(x : Int32, y : Int32) : Int32",
+      "public func bitclear(x : Int32, p : Nat) : Int32",
+      "public let bitcountLeadingZero : (x : Int32) -> Int32",
+      "public let bitcountNonZero : (x : Int32) -> Int32",
+      "public let bitcountTrailingZero : (x : Int32) -> Int32",
+      "public func bitflip(x : Int32, p : Nat) : Int32",
+      "public func bitnot(x : Int32) : Int32",
+      "public func bitor(x : Int32, y : Int32) : Int32",
+      "public func bitrotLeft(x : Int32, y : Int32) : Int32",
+      "public func bitrotRight(x : Int32, y : Int32) : Int32",
+      "public func bitset(x : Int32, p : Nat) : Int32",
+      "public func bitshiftLeft(x : Int32, y : Int32) : Int32",
+      "public func bitshiftRight(x : Int32, y : Int32) : Int32",
+      "public func bittest(x : Int32, p : Nat) : Bool",
+      "public func bitxor(x : Int32, y : Int32) : Int32",
+      "public func compare(x : Int32, y : Int32) : { #less; #equal; #greater }",
+      "public func div(x : Int32, y : Int32) : Int32",
+      "public func equal(x : Int32, y : Int32) : Bool",
+      "public let fromInt : Int -> Int32",
+      "public let fromInt16 : Int16 -> Int32",
+      "public let fromInt64 : Int64 -> Int32",
+      "public let fromIntWrap : Int -> Int32",
+      "public let fromNat32 : Nat32 -> Int32",
+      "public func greater(x : Int32, y : Int32) : Bool",
+      "public func greaterOrEqual(x : Int32, y : Int32) : Bool",
+      "public func less(x : Int32, y : Int32) : Bool",
+      "public func lessOrEqual(x : Int32, y : Int32) : Bool",
+      "public func max(x : Int32, y : Int32) : Int32",
+      "public let maxValue : Int32",
+      "public func min(x : Int32, y : Int32) : Int32",
+      "public let minValue : Int32",
+      "public func mul(x : Int32, y : Int32) : Int32",
+      "public func mulWrap(x : Int32, y : Int32) : Int32",
+      "public func neg(x : Int32) : Int32",
+      "public func notEqual(x : Int32, y : Int32) : Bool",
+      "public func pow(x : Int32, y : Int32) : Int32",
+      "public func powWrap(x : Int32, y : Int32) : Int32",
+      "public func range(fromInclusive : Int32, toExclusive : Int32) : Iter.Iter<Int32>",
+      "public func rangeInclusive(from : Int32, to : Int32) : Iter.Iter<Int32>",
+      "public func rem(x : Int32, y : Int32) : Int32",
+      "public func sub(x : Int32, y : Int32) : Int32",
+      "public func subWrap(x : Int32, y : Int32) : Int32",
+      "public let toInt : Int32 -> Int",
+      "public let toInt16 : Int32 -> Int16",
+      "public let toInt64 : Int32 -> Int64",
+      "public let toNat32 : Int32 -> Nat32",
+      "public func toText(x : Int32) : Text"
     ]
   },
   {
     "name": "Int64",
-    "functions": [
-      {
-        "name": "abs",
-        "type": "(x : Int64) : Int64"
-      },
-      {
-        "name": "add",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Int64>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Int64, p : Nat) : Int64"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Int64) -> Int64"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Int64) -> Int64"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Int64) -> Int64"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Int64, p : Nat) : Int64"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Int64) : Int64"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Int64, p : Nat) : Int64"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Int64, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Int64, y : Int64) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "fromInt",
-        "type": ": Int -> Int64"
-      },
-      {
-        "name": "fromInt32",
-        "type": ": Int32 -> Int64"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Int64"
-      },
-      {
-        "name": "fromNat64",
-        "type": ": Nat64 -> Int64"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Int64"
-      },
-      {
-        "name": "min",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "minValue",
-        "type": ": Int64"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Int64) : Int64"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Int64, y : Int64) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int64, toExclusive : Int64) : Iter.Iter<Int64>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Int64, to : Int64) : Iter.Iter<Int64>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Int64, y : Int64) : Int64"
-      },
-      {
-        "name": "toInt",
-        "type": ": Int64 -> Int"
-      },
-      {
-        "name": "toInt32",
-        "type": ": Int64 -> Int32"
-      },
-      {
-        "name": "toNat64",
-        "type": ": Int64 -> Nat64"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Int64) : Text"
-      }
+    "exports": [
+      "public func abs(x : Int64) : Int64",
+      "public func add(x : Int64, y : Int64) : Int64",
+      "public func addWrap(x : Int64, y : Int64) : Int64",
+      "public func allValues() : Iter.Iter<Int64>",
+      "public func bitand(x : Int64, y : Int64) : Int64",
+      "public func bitclear(x : Int64, p : Nat) : Int64",
+      "public let bitcountLeadingZero : (x : Int64) -> Int64",
+      "public let bitcountNonZero : (x : Int64) -> Int64",
+      "public let bitcountTrailingZero : (x : Int64) -> Int64",
+      "public func bitflip(x : Int64, p : Nat) : Int64",
+      "public func bitnot(x : Int64) : Int64",
+      "public func bitor(x : Int64, y : Int64) : Int64",
+      "public func bitrotLeft(x : Int64, y : Int64) : Int64",
+      "public func bitrotRight(x : Int64, y : Int64) : Int64",
+      "public func bitset(x : Int64, p : Nat) : Int64",
+      "public func bitshiftLeft(x : Int64, y : Int64) : Int64",
+      "public func bitshiftRight(x : Int64, y : Int64) : Int64",
+      "public func bittest(x : Int64, p : Nat) : Bool",
+      "public func bitxor(x : Int64, y : Int64) : Int64",
+      "public func compare(x : Int64, y : Int64) : { #less; #equal; #greater }",
+      "public func div(x : Int64, y : Int64) : Int64",
+      "public func equal(x : Int64, y : Int64) : Bool",
+      "public let fromInt : Int -> Int64",
+      "public let fromInt32 : Int32 -> Int64",
+      "public let fromIntWrap : Int -> Int64",
+      "public let fromNat64 : Nat64 -> Int64",
+      "public func greater(x : Int64, y : Int64) : Bool",
+      "public func greaterOrEqual(x : Int64, y : Int64) : Bool",
+      "public func less(x : Int64, y : Int64) : Bool",
+      "public func lessOrEqual(x : Int64, y : Int64) : Bool",
+      "public func max(x : Int64, y : Int64) : Int64",
+      "public let maxValue : Int64",
+      "public func min(x : Int64, y : Int64) : Int64",
+      "public let minValue : Int64",
+      "public func mul(x : Int64, y : Int64) : Int64",
+      "public func mulWrap(x : Int64, y : Int64) : Int64",
+      "public func neg(x : Int64) : Int64",
+      "public func notEqual(x : Int64, y : Int64) : Bool",
+      "public func pow(x : Int64, y : Int64) : Int64",
+      "public func powWrap(x : Int64, y : Int64) : Int64",
+      "public func range(fromInclusive : Int64, toExclusive : Int64) : Iter.Iter<Int64>",
+      "public func rangeInclusive(from : Int64, to : Int64) : Iter.Iter<Int64>",
+      "public func rem(x : Int64, y : Int64) : Int64",
+      "public func sub(x : Int64, y : Int64) : Int64",
+      "public func subWrap(x : Int64, y : Int64) : Int64",
+      "public let toInt : Int64 -> Int",
+      "public let toInt32 : Int64 -> Int32",
+      "public let toNat64 : Int64 -> Nat64",
+      "public func toText(x : Int64) : Text"
     ]
   },
   {
     "name": "Int8",
-    "functions": [
-      {
-        "name": "abs",
-        "type": "(x : Int8) : Int8"
-      },
-      {
-        "name": "add",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Int8>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Int8, p : Nat) : Int8"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Int8) -> Int8"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Int8) -> Int8"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Int8) -> Int8"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Int8, p : Nat) : Int8"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Int8) : Int8"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Int8, p : Nat) : Int8"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Int8, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Int8, y : Int8) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "fromInt",
-        "type": ": Int -> Int8"
-      },
-      {
-        "name": "fromInt16",
-        "type": ": Int16 -> Int8"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Int8"
-      },
-      {
-        "name": "fromNat8",
-        "type": ": Nat8 -> Int8"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Int8"
-      },
-      {
-        "name": "min",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "minValue",
-        "type": ": Int8"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "neg",
-        "type": "(x : Int8) : Int8"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Int8, y : Int8) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int8, toExclusive : Int8) : Iter.Iter<Int8>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Int8, to : Int8) : Iter.Iter<Int8>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Int8, y : Int8) : Int8"
-      },
-      {
-        "name": "toInt",
-        "type": ": Int8 -> Int"
-      },
-      {
-        "name": "toInt16",
-        "type": ": Int8 -> Int16"
-      },
-      {
-        "name": "toNat8",
-        "type": ": Int8 -> Nat8"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Int8) : Text"
-      }
+    "exports": [
+      "public func abs(x : Int8) : Int8",
+      "public func add(x : Int8, y : Int8) : Int8",
+      "public func addWrap(x : Int8, y : Int8) : Int8",
+      "public func allValues() : Iter.Iter<Int8>",
+      "public func bitand(x : Int8, y : Int8) : Int8",
+      "public func bitclear(x : Int8, p : Nat) : Int8",
+      "public let bitcountLeadingZero : (x : Int8) -> Int8",
+      "public let bitcountNonZero : (x : Int8) -> Int8",
+      "public let bitcountTrailingZero : (x : Int8) -> Int8",
+      "public func bitflip(x : Int8, p : Nat) : Int8",
+      "public func bitnot(x : Int8) : Int8",
+      "public func bitor(x : Int8, y : Int8) : Int8",
+      "public func bitrotLeft(x : Int8, y : Int8) : Int8",
+      "public func bitrotRight(x : Int8, y : Int8) : Int8",
+      "public func bitset(x : Int8, p : Nat) : Int8",
+      "public func bitshiftLeft(x : Int8, y : Int8) : Int8",
+      "public func bitshiftRight(x : Int8, y : Int8) : Int8",
+      "public func bittest(x : Int8, p : Nat) : Bool",
+      "public func bitxor(x : Int8, y : Int8) : Int8",
+      "public func compare(x : Int8, y : Int8) : { #less; #equal; #greater }",
+      "public func div(x : Int8, y : Int8) : Int8",
+      "public func equal(x : Int8, y : Int8) : Bool",
+      "public let fromInt : Int -> Int8",
+      "public let fromInt16 : Int16 -> Int8",
+      "public let fromIntWrap : Int -> Int8",
+      "public let fromNat8 : Nat8 -> Int8",
+      "public func greater(x : Int8, y : Int8) : Bool",
+      "public func greaterOrEqual(x : Int8, y : Int8) : Bool",
+      "public func less(x : Int8, y : Int8) : Bool",
+      "public func lessOrEqual(x : Int8, y : Int8) : Bool",
+      "public func max(x : Int8, y : Int8) : Int8",
+      "public let maxValue : Int8",
+      "public func min(x : Int8, y : Int8) : Int8",
+      "public let minValue : Int8",
+      "public func mul(x : Int8, y : Int8) : Int8",
+      "public func mulWrap(x : Int8, y : Int8) : Int8",
+      "public func neg(x : Int8) : Int8",
+      "public func notEqual(x : Int8, y : Int8) : Bool",
+      "public func pow(x : Int8, y : Int8) : Int8",
+      "public func powWrap(x : Int8, y : Int8) : Int8",
+      "public func range(fromInclusive : Int8, toExclusive : Int8) : Iter.Iter<Int8>",
+      "public func rangeInclusive(from : Int8, to : Int8) : Iter.Iter<Int8>",
+      "public func rem(x : Int8, y : Int8) : Int8",
+      "public func sub(x : Int8, y : Int8) : Int8",
+      "public func subWrap(x : Int8, y : Int8) : Int8",
+      "public let toInt : Int8 -> Int",
+      "public let toInt16 : Int8 -> Int16",
+      "public let toNat8 : Int8 -> Nat8",
+      "public func toText(x : Int8) : Text"
     ]
   },
   {
     "name": "InternetComputer",
-    "functions": [
-      {
-        "name": "call",
-        "type": ": (canister : Principal, name : Text, data : Blob) -> async (reply : Blob)"
-      },
-      {
-        "name": "countInstructions",
-        "type": "(comp : () -> ()) : Nat64"
-      },
-      {
-        "name": "performanceCounter",
-        "type": ": (counter : Nat32) -> (value: Nat64)"
-      },
-      {
-        "name": "replyDeadline",
-        "type": "() : Nat"
-      }
+    "exports": [
+      "public let call : (canister : Principal, name : Text, data : Blob) -> async (reply : Blob)",
+      "public func countInstructions(comp : () -> ()) : Nat64",
+      "public let performanceCounter : (counter : Nat32) -> (value: Nat64)",
+      "public func replyDeadline() : Nat"
     ]
   },
   {
     "name": "Iter",
-    "functions": [
-      {
-        "name": "concat",
-        "type": "<T>(a : Iter<T>, b : Iter<T>) : Iter<T>"
-      },
-      {
-        "name": "concatAll",
-        "type": "<T>(iters : [Iter<T>]) : Iter<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Iter<T>"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(iter : Iter<T>, f : T -> Bool) : Iter<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T1, T2>(iter : Iter<T1>, f : T1 -> ?T2) : Iter<T2>"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(iter : Iter<T>, f : (T, Nat) -> ())"
-      },
-      {
-        "name": "fromArray",
-        "type": "<T>(array : [T]) : Iter<T>"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "<T>(array : [var T]) : Iter<T>"
-      },
-      {
-        "name": "infinite",
-        "type": "<T>(x : T) : Iter<T>"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(iter : Iter<T1>, f : T1 -> T2) : Iter<T2>"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Int, toExclusive : Int)"
-      },
-      {
-        "name": "rangeRev",
-        "type": "(fromInclusive : Int, toExclusive : Int)"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(x : T) : Iter<T>"
-      },
-      {
-        "name": "size",
-        "type": "<T>(iter : Iter<T>) : Nat"
-      },
-      {
-        "name": "sort",
-        "type": "<T>(iter : Iter<T>, compare : (T, T) -> Order.Order) : Iter<T>"
-      },
-      {
-        "name": "toArray",
-        "type": "<T>(iter : Iter<T>) : [T]"
-      },
-      {
-        "name": "toVarArray",
-        "type": "<T>(iter : Iter<T>) : [var T]"
-      }
+    "exports": [
+      "public func concat<T>(a : Iter<T>, b : Iter<T>) : Iter<T>",
+      "public func concatAll<T>(iters : [Iter<T>]) : Iter<T>",
+      "public func empty<T>() : Iter<T>",
+      "public func filter<T>(iter : Iter<T>, f : T -> Bool) : Iter<T>",
+      "public func filterMap<T1, T2>(iter : Iter<T1>, f : T1 -> ?T2) : Iter<T2>",
+      "public func forEach<T>(iter : Iter<T>, f : (T, Nat) -> ())",
+      "public func fromArray<T>(array : [T]) : Iter<T>",
+      "public func fromVarArray<T>(array : [var T]) : Iter<T>",
+      "public func infinite<T>(x : T) : Iter<T>",
+      "public func map<T1, T2>(iter : Iter<T1>, f : T1 -> T2) : Iter<T2>",
+      "public class range(fromInclusive : Int, toExclusive : Int)",
+      "public class rangeRev(fromInclusive : Int, toExclusive : Int)",
+      "public func singleton<T>(x : T) : Iter<T>",
+      "public func size<T>(iter : Iter<T>) : Nat",
+      "public func sort<T>(iter : Iter<T>, compare : (T, T) -> Order.Order) : Iter<T>",
+      "public func toArray<T>(iter : Iter<T>) : [T]",
+      "public func toVarArray<T>(iter : Iter<T>) : [var T]"
     ]
   },
   {
     "name": "IterType",
-    "functions": []
+    "exports": []
   },
   {
     "name": "List",
-    "functions": [
-      {
-        "name": "add",
-        "type": "<T>(list : List<T>, item : T) : ()"
-      },
-      {
-        "name": "all",
-        "type": "<T>(list : List<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(list : List<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "binarySearch",
-        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order, element : T) : ?Nat"
-      },
-      {
-        "name": "chunk",
-        "type": "<T>(list : List<T>, size : Nat) : List<List<T>>"
-      },
-      {
-        "name": "clone",
-        "type": "<T>(list : List<T>) : List<T>"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "containsAll",
-        "type": "<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "distinct",
-        "type": "<T>(list : List<T>, equal : (T, T) -> Bool) : List<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : List<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(list1 : List<T>, list2 : List<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(list : List<T>, predicate : T -> Bool) : List<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T1, T2>(list : List<T1>, f : T1 -> ?T2) : List<T2>"
-      },
-      {
-        "name": "first",
-        "type": "<T>(list : List<T>) : T"
-      },
-      {
-        "name": "flatMap",
-        "type": "<T1, T2>(list : List<T1>, k : T1 -> Iter.Iter<T2>) : List<T2>"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(lists : Iter.Iter<List<T>>) : List<T>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<A, T>(list : List<T>, base : A, combine : (A, T) -> A) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>(list : List<T>, base : A, combine : (T, A) -> A) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(list : List<T>, f : T -> ())"
-      },
-      {
-        "name": "fromArray",
-        "type": "<T>(array : [T]) : List<T>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : { next : () -> ?T }) : List<T>"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "<T>(array : [var T]) : List<T>"
-      },
-      {
-        "name": "hash",
-        "type": "<T>(list : List<T>, hash : T -> Nat32) : Nat32"
-      },
-      {
-        "name": "indexOf",
-        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "indexOfList",
-        "type": "<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(list : List<Any>) : Bool"
-      },
-      {
-        "name": "isPrefixOf",
-        "type": "<T>(list : List<T>, prefix : List<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "isSuffixOf",
-        "type": "<T>(list : List<T>, suffix : List<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "last",
-        "type": "<T>(list : List<T>) : T"
-      },
-      {
-        "name": "lastIndexOf",
-        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2>"
-      },
-      {
-        "name": "mapEntries",
-        "type": "<T1, T2>(list : List<T1>, f : (Nat, T1) -> T2) : List<T2>"
-      },
-      {
-        "name": "mapResult",
-        "type": "<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E>"
-      },
-      {
-        "name": "max",
-        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "merge",
-        "type": "<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : List<T>"
-      },
-      {
-        "name": "min",
-        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "partition",
-        "type": "<T>(list : List<T>, predicate : T -> Bool) : (List<T>, List<T>)"
-      },
-      {
-        "name": "prefix",
-        "type": "<T>(list : List<T>, length : Nat) : List<T>"
-      },
-      {
-        "name": "put",
-        "type": "<T>(list : List<T>, index : Nat, item : T) : ()"
-      },
-      {
-        "name": "removeLast",
-        "type": "<T>(list : List<T>) : ?T"
-      },
-      {
-        "name": "reverse",
-        "type": "<T>(list : List<T>)"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(element : T) : List<T>"
-      },
-      {
-        "name": "size",
-        "type": "(list : List<Any>) : Bool"
-      },
-      {
-        "name": "split",
-        "type": "<T>(list : List<T>, index : Nat) : (List<T>, List<T>)"
-      },
-      {
-        "name": "subList",
-        "type": "<T>(list : List<T>, start : Nat, length : Nat) : List<T>"
-      },
-      {
-        "name": "suffix",
-        "type": "<T>(list : List<T>, length : Nat) : List<T>"
-      },
-      {
-        "name": "toArray",
-        "type": "<T>(list : List<T>) : [T]"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(list : List<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "toVarArray",
-        "type": "<T>(list : List<T>) : [var T]"
-      },
-      {
-        "name": "values",
-        "type": "<T>(list : List<T>) : Iter.Iter<T>"
-      },
-      {
-        "name": "zip",
-        "type": "<T1, T2>(list1 : List<T1>, list2 : List<T2>) : List<(T1, T2)>"
-      },
-      {
-        "name": "zipWith",
-        "type": "<T1, T2, Z>(list1 : List<T1>, list2 : List<T2>, zip : (T1, T2) -> Z) : List<Z>"
-      }
+    "exports": [
+      "public func add<T>(list : List<T>, item : T) : ()",
+      "public func all<T>(list : List<T>, predicate : T -> Bool) : Bool",
+      "public func any<T>(list : List<T>, predicate : T -> Bool) : Bool",
+      "public func binarySearch<T>(list : List<T>, compare : (T, T) -> Order.Order, element : T) : ?Nat",
+      "public func chunk<T>(list : List<T>, size : Nat) : List<List<T>>",
+      "public func clone<T>(list : List<T>) : List<T>",
+      "public func compare<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func contains<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : Bool",
+      "public func containsAll<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : Bool",
+      "public func distinct<T>(list : List<T>, equal : (T, T) -> Bool) : List<T>",
+      "public func empty<T>() : List<T>",
+      "public func equal<T>(list1 : List<T>, list2 : List<T>, equal : (T, T) -> Bool) : Bool",
+      "public func filter<T>(list : List<T>, predicate : T -> Bool) : List<T>",
+      "public func filterMap<T1, T2>(list : List<T1>, f : T1 -> ?T2) : List<T2>",
+      "public func first<T>(list : List<T>) : T",
+      "public func flatMap<T1, T2>(list : List<T1>, k : T1 -> Iter.Iter<T2>) : List<T2>",
+      "public func flatten<T>(lists : Iter.Iter<List<T>>) : List<T>",
+      "public func foldLeft<A, T>(list : List<T>, base : A, combine : (A, T) -> A) : A",
+      "public func foldRight<T, A>(list : List<T>, base : A, combine : (T, A) -> A) : A",
+      "public func forEach<T>(list : List<T>, f : T -> ())",
+      "public func fromArray<T>(array : [T]) : List<T>",
+      "public func fromIter<T>(iter : { next : () -> ?T }) : List<T>",
+      "public func fromVarArray<T>(array : [var T]) : List<T>",
+      "public func hash<T>(list : List<T>, hash : T -> Nat32) : Nat32",
+      "public func indexOf<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat",
+      "public func indexOfList<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : ?Nat",
+      "public func isEmpty(list : List<Any>) : Bool",
+      "public func isPrefixOf<T>(list : List<T>, prefix : List<T>, equal : (T, T) -> Bool) : Bool",
+      "public func isSuffixOf<T>(list : List<T>, suffix : List<T>, equal : (T, T) -> Bool) : Bool",
+      "public func last<T>(list : List<T>) : T",
+      "public func lastIndexOf<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat",
+      "public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2>",
+      "public func mapEntries<T1, T2>(list : List<T1>, f : (Nat, T1) -> T2) : List<T2>",
+      "public func mapResult<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E>",
+      "public func max<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func merge<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : List<T>",
+      "public func min<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func partition<T>(list : List<T>, predicate : T -> Bool) : (List<T>, List<T>)",
+      "public func prefix<T>(list : List<T>, length : Nat) : List<T>",
+      "public func put<T>(list : List<T>, index : Nat, item : T) : ()",
+      "public func removeLast<T>(list : List<T>) : ?T",
+      "public func reverse<T>(list : List<T>)",
+      "public func singleton<T>(element : T) : List<T>",
+      "public func size(list : List<Any>) : Bool",
+      "public func split<T>(list : List<T>, index : Nat) : (List<T>, List<T>)",
+      "public func subList<T>(list : List<T>, start : Nat, length : Nat) : List<T>",
+      "public func suffix<T>(list : List<T>, length : Nat) : List<T>",
+      "public func toArray<T>(list : List<T>) : [T]",
+      "public func toText<T>(list : List<T>, f : T -> Text) : Text",
+      "public func toVarArray<T>(list : List<T>) : [var T]",
+      "public func values<T>(list : List<T>) : Iter.Iter<T>",
+      "public func zip<T1, T2>(list1 : List<T1>, list2 : List<T2>) : List<(T1, T2)>",
+      "public func zipWith<T1, T2, Z>(list1 : List<T1>, list2 : List<T2>, zip : (T1, T2) -> Z) : List<Z>"
     ]
   },
   {
     "name": "Map",
-    "functions": [
-      {
-        "name": "add",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ()"
-      },
-      {
-        "name": "all",
-        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
-      },
-      {
-        "name": "assertValid",
-        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()"
-      },
-      {
-        "name": "clone",
-        "type": "<K, V>(map : Map<K, V>) : Map<K, V>"
-      },
-      {
-        "name": "compare",
-        "type": "<K, V>(map1 : Map<K, V>, map2 : Map<K, V>, compareKey : (K, K) -> Order.Order, compareValue : (V, V) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "containsKey",
-        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool"
-      },
-      {
-        "name": "delete",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ()"
-      },
-      {
-        "name": "empty",
-        "type": "<K, V>() : Map<K, V>"
-      },
-      {
-        "name": "entries",
-        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
-      },
-      {
-        "name": "equal",
-        "type": "<K, V>(map1 : Map<K, V>, map2 : Map<K, V>) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<K, V>(map : Map<K, V>, f : (K, V) -> Bool) : Map<K, V>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<K, V>(map : Map<K, V>, f : (K, V) -> ())"
-      },
-      {
-        "name": "freeze",
-        "type": "<K, V>(map : Map<K, V>) : Immutable.Map<K, V>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>"
-      },
-      {
-        "name": "get",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(map : Map<Any, Any>) : Bool"
-      },
-      {
-        "name": "keys",
-        "type": "<K>(map : Map<K, Any>) : Iter.Iter<K>"
-      },
-      {
-        "name": "map",
-        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>"
-      },
-      {
-        "name": "maxEntry",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
-      },
-      {
-        "name": "minEntry",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
-      },
-      {
-        "name": "put",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V"
-      },
-      {
-        "name": "replaceIfExists",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V"
-      },
-      {
-        "name": "reverseEntries",
-        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
-      },
-      {
-        "name": "singleton",
-        "type": "<K, V>(key : K, value : V) : Map<K, V>"
-      },
-      {
-        "name": "size",
-        "type": "(map : Map<Any, Any>) : Nat"
-      },
-      {
-        "name": "thaw",
-        "type": "<K, V>(map : Immutable.Map<K, V>) : Map<K, V>"
-      },
-      {
-        "name": "toText",
-        "type": "<K, V>(map : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<V>(map : Map<Any, V>) : Iter.Iter<V>"
-      }
+    "exports": [
+      "public func add<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ()",
+      "public func all<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool",
+      "public func any<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool",
+      "public func assertValid<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()",
+      "public func clone<K, V>(map : Map<K, V>) : Map<K, V>",
+      "public func compare<K, V>(map1 : Map<K, V>, map2 : Map<K, V>, compareKey : (K, K) -> Order.Order, compareValue : (V, V) -> Order.Order) : Order.Order",
+      "public func containsKey<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool",
+      "public func delete<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ()",
+      "public func empty<K, V>() : Map<K, V>",
+      "public func entries<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>",
+      "public func equal<K, V>(map1 : Map<K, V>, map2 : Map<K, V>) : Bool",
+      "public func filter<K, V>(map : Map<K, V>, f : (K, V) -> Bool) : Map<K, V>",
+      "public func filterMap<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>",
+      "public func foldLeft<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A",
+      "public func foldRight<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A",
+      "public func forEach<K, V>(map : Map<K, V>, f : (K, V) -> ())",
+      "public func freeze<K, V>(map : Map<K, V>) : Immutable.Map<K, V>",
+      "public func fromIter<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>",
+      "public func get<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V",
+      "public func isEmpty(map : Map<Any, Any>) : Bool",
+      "public func keys<K>(map : Map<K, Any>) : Iter.Iter<K>",
+      "public func map<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>",
+      "public func maxEntry<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)",
+      "public func minEntry<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)",
+      "public func put<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V",
+      "public func replaceIfExists<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V",
+      "public func reverseEntries<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>",
+      "public func singleton<K, V>(key : K, value : V) : Map<K, V>",
+      "public func size(map : Map<Any, Any>) : Nat",
+      "public func thaw<K, V>(map : Immutable.Map<K, V>) : Map<K, V>",
+      "public func toText<K, V>(map : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text",
+      "public func values<V>(map : Map<Any, V>) : Iter.Iter<V>"
     ]
   },
   {
     "name": "Nat",
-    "functions": [
-      {
-        "name": "add",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Nat>"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Nat, y : Nat32) : Nat"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Nat, y : Nat32) : Nat"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Nat, y : Nat) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "fromInt",
-        "type": "(i : Int) : ?Nat"
-      },
-      {
-        "name": "fromText",
-        "type": "(text : Text) : ?Nat"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "min",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Nat, y : Nat) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Nat, toExclusive : Nat) : Iter.Iter<Nat>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Nat, to : Nat) : Iter.Iter<Nat>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Nat, y : Nat) : Nat"
-      },
-      {
-        "name": "toText",
-        "type": "(n : Nat) : Text"
-      }
+    "exports": [
+      "public func add(x : Nat, y : Nat) : Nat",
+      "public func allValues() : Iter.Iter<Nat>",
+      "public func bitshiftLeft(x : Nat, y : Nat32) : Nat",
+      "public func bitshiftRight(x : Nat, y : Nat32) : Nat",
+      "public func compare(x : Nat, y : Nat) : { #less; #equal; #greater }",
+      "public func div(x : Nat, y : Nat) : Nat",
+      "public func equal(x : Nat, y : Nat) : Bool",
+      "public func fromInt(i : Int) : ?Nat",
+      "public func fromText(text : Text) : ?Nat",
+      "public func greater(x : Nat, y : Nat) : Bool",
+      "public func greaterOrEqual(x : Nat, y : Nat) : Bool",
+      "public func less(x : Nat, y : Nat) : Bool",
+      "public func lessOrEqual(x : Nat, y : Nat) : Bool",
+      "public func max(x : Nat, y : Nat) : Nat",
+      "public func min(x : Nat, y : Nat) : Nat",
+      "public func mul(x : Nat, y : Nat) : Nat",
+      "public func notEqual(x : Nat, y : Nat) : Bool",
+      "public func pow(x : Nat, y : Nat) : Nat",
+      "public func range(fromInclusive : Nat, toExclusive : Nat) : Iter.Iter<Nat>",
+      "public func rangeInclusive(from : Nat, to : Nat) : Iter.Iter<Nat>",
+      "public func rem(x : Nat, y : Nat) : Nat",
+      "public func sub(x : Nat, y : Nat) : Nat",
+      "public func toText(n : Nat) : Text"
     ]
   },
   {
     "name": "Nat16",
-    "functions": [
-      {
-        "name": "add",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Nat16>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Nat16, p : Nat) : Nat16"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Nat16) -> Nat16"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Nat16) -> Nat16"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Nat16) -> Nat16"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Nat16, p : Nat) : Nat16"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Nat16) : Nat16"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Nat16, p : Nat) : Nat16"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Nat16, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Nat16, y : Nat16) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Nat16"
-      },
-      {
-        "name": "fromNat",
-        "type": ": Nat -> Nat16"
-      },
-      {
-        "name": "fromNat32",
-        "type": "(x : Nat32) : Nat16"
-      },
-      {
-        "name": "fromNat8",
-        "type": "(x : Nat8) : Nat16"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Nat16"
-      },
-      {
-        "name": "min",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Nat16, y : Nat16) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Nat16, toExclusive : Nat16) : Iter.Iter<Nat16>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Nat16, to : Nat16) : Iter.Iter<Nat16>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Nat16, y : Nat16) : Nat16"
-      },
-      {
-        "name": "toNat",
-        "type": ": Nat16 -> Nat"
-      },
-      {
-        "name": "toNat32",
-        "type": "(x : Nat16) : Nat32"
-      },
-      {
-        "name": "toNat8",
-        "type": "(x : Nat16) : Nat8"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Nat16) : Text"
-      }
+    "exports": [
+      "public func add(x : Nat16, y : Nat16) : Nat16",
+      "public func addWrap(x : Nat16, y : Nat16) : Nat16",
+      "public func allValues() : Iter.Iter<Nat16>",
+      "public func bitand(x : Nat16, y : Nat16) : Nat16",
+      "public func bitclear(x : Nat16, p : Nat) : Nat16",
+      "public let bitcountLeadingZero : (x : Nat16) -> Nat16",
+      "public let bitcountNonZero : (x : Nat16) -> Nat16",
+      "public let bitcountTrailingZero : (x : Nat16) -> Nat16",
+      "public func bitflip(x : Nat16, p : Nat) : Nat16",
+      "public func bitnot(x : Nat16) : Nat16",
+      "public func bitor(x : Nat16, y : Nat16) : Nat16",
+      "public func bitrotLeft(x : Nat16, y : Nat16) : Nat16",
+      "public func bitrotRight(x : Nat16, y : Nat16) : Nat16",
+      "public func bitset(x : Nat16, p : Nat) : Nat16",
+      "public func bitshiftLeft(x : Nat16, y : Nat16) : Nat16",
+      "public func bitshiftRight(x : Nat16, y : Nat16) : Nat16",
+      "public func bittest(x : Nat16, p : Nat) : Bool",
+      "public func bitxor(x : Nat16, y : Nat16) : Nat16",
+      "public func compare(x : Nat16, y : Nat16) : { #less; #equal; #greater }",
+      "public func div(x : Nat16, y : Nat16) : Nat16",
+      "public func equal(x : Nat16, y : Nat16) : Bool",
+      "public let fromIntWrap : Int -> Nat16",
+      "public let fromNat : Nat -> Nat16",
+      "public func fromNat32(x : Nat32) : Nat16",
+      "public func fromNat8(x : Nat8) : Nat16",
+      "public func greater(x : Nat16, y : Nat16) : Bool",
+      "public func greaterOrEqual(x : Nat16, y : Nat16) : Bool",
+      "public func less(x : Nat16, y : Nat16) : Bool",
+      "public func lessOrEqual(x : Nat16, y : Nat16) : Bool",
+      "public func max(x : Nat16, y : Nat16) : Nat16",
+      "public let maxValue : Nat16",
+      "public func min(x : Nat16, y : Nat16) : Nat16",
+      "public func mul(x : Nat16, y : Nat16) : Nat16",
+      "public func mulWrap(x : Nat16, y : Nat16) : Nat16",
+      "public func notEqual(x : Nat16, y : Nat16) : Bool",
+      "public func pow(x : Nat16, y : Nat16) : Nat16",
+      "public func powWrap(x : Nat16, y : Nat16) : Nat16",
+      "public func range(fromInclusive : Nat16, toExclusive : Nat16) : Iter.Iter<Nat16>",
+      "public func rangeInclusive(from : Nat16, to : Nat16) : Iter.Iter<Nat16>",
+      "public func rem(x : Nat16, y : Nat16) : Nat16",
+      "public func sub(x : Nat16, y : Nat16) : Nat16",
+      "public func subWrap(x : Nat16, y : Nat16) : Nat16",
+      "public let toNat : Nat16 -> Nat",
+      "public func toNat32(x : Nat16) : Nat32",
+      "public func toNat8(x : Nat16) : Nat8",
+      "public func toText(x : Nat16) : Text"
     ]
   },
   {
     "name": "Nat32",
-    "functions": [
-      {
-        "name": "add",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Nat32>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Nat32, p : Nat) : Nat32"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Nat32) -> Nat32"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Nat32) -> Nat32"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Nat32) -> Nat32"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Nat32, p : Nat) : Nat32"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Nat32) : Nat32"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Nat32, p : Nat) : Nat32"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Nat32, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Nat32, y : Nat32) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Nat32"
-      },
-      {
-        "name": "fromNat",
-        "type": ": Nat -> Nat32"
-      },
-      {
-        "name": "fromNat16",
-        "type": "(x : Nat16) : Nat32"
-      },
-      {
-        "name": "fromNat64",
-        "type": "(x : Nat64) : Nat32"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Nat32"
-      },
-      {
-        "name": "min",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Nat32, y : Nat32) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Nat32, toExclusive : Nat32) : Iter.Iter<Nat32>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Nat32, to : Nat32) : Iter.Iter<Nat32>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Nat32, y : Nat32) : Nat32"
-      },
-      {
-        "name": "toNat",
-        "type": ": Nat32 -> Nat"
-      },
-      {
-        "name": "toNat16",
-        "type": "(x : Nat32) : Nat16"
-      },
-      {
-        "name": "toNat64",
-        "type": "(x : Nat32) : Nat64"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Nat32) : Text"
-      }
+    "exports": [
+      "public func add(x : Nat32, y : Nat32) : Nat32",
+      "public func addWrap(x : Nat32, y : Nat32) : Nat32",
+      "public func allValues() : Iter.Iter<Nat32>",
+      "public func bitand(x : Nat32, y : Nat32) : Nat32",
+      "public func bitclear(x : Nat32, p : Nat) : Nat32",
+      "public let bitcountLeadingZero : (x : Nat32) -> Nat32",
+      "public let bitcountNonZero : (x : Nat32) -> Nat32",
+      "public let bitcountTrailingZero : (x : Nat32) -> Nat32",
+      "public func bitflip(x : Nat32, p : Nat) : Nat32",
+      "public func bitnot(x : Nat32) : Nat32",
+      "public func bitor(x : Nat32, y : Nat32) : Nat32",
+      "public func bitrotLeft(x : Nat32, y : Nat32) : Nat32",
+      "public func bitrotRight(x : Nat32, y : Nat32) : Nat32",
+      "public func bitset(x : Nat32, p : Nat) : Nat32",
+      "public func bitshiftLeft(x : Nat32, y : Nat32) : Nat32",
+      "public func bitshiftRight(x : Nat32, y : Nat32) : Nat32",
+      "public func bittest(x : Nat32, p : Nat) : Bool",
+      "public func bitxor(x : Nat32, y : Nat32) : Nat32",
+      "public func compare(x : Nat32, y : Nat32) : { #less; #equal; #greater }",
+      "public func div(x : Nat32, y : Nat32) : Nat32",
+      "public func equal(x : Nat32, y : Nat32) : Bool",
+      "public let fromIntWrap : Int -> Nat32",
+      "public let fromNat : Nat -> Nat32",
+      "public func fromNat16(x : Nat16) : Nat32",
+      "public func fromNat64(x : Nat64) : Nat32",
+      "public func greater(x : Nat32, y : Nat32) : Bool",
+      "public func greaterOrEqual(x : Nat32, y : Nat32) : Bool",
+      "public func less(x : Nat32, y : Nat32) : Bool",
+      "public func lessOrEqual(x : Nat32, y : Nat32) : Bool",
+      "public func max(x : Nat32, y : Nat32) : Nat32",
+      "public let maxValue : Nat32",
+      "public func min(x : Nat32, y : Nat32) : Nat32",
+      "public func mul(x : Nat32, y : Nat32) : Nat32",
+      "public func mulWrap(x : Nat32, y : Nat32) : Nat32",
+      "public func notEqual(x : Nat32, y : Nat32) : Bool",
+      "public func pow(x : Nat32, y : Nat32) : Nat32",
+      "public func powWrap(x : Nat32, y : Nat32) : Nat32",
+      "public func range(fromInclusive : Nat32, toExclusive : Nat32) : Iter.Iter<Nat32>",
+      "public func rangeInclusive(from : Nat32, to : Nat32) : Iter.Iter<Nat32>",
+      "public func rem(x : Nat32, y : Nat32) : Nat32",
+      "public func sub(x : Nat32, y : Nat32) : Nat32",
+      "public func subWrap(x : Nat32, y : Nat32) : Nat32",
+      "public let toNat : Nat32 -> Nat",
+      "public func toNat16(x : Nat32) : Nat16",
+      "public func toNat64(x : Nat32) : Nat64",
+      "public func toText(x : Nat32) : Text"
     ]
   },
   {
     "name": "Nat64",
-    "functions": [
-      {
-        "name": "add",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Nat64>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Nat64, p : Nat) : Nat64"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Nat64) -> Nat64"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Nat64) -> Nat64"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Nat64) -> Nat64"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Nat64, p : Nat) : Nat64"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Nat64) : Nat64"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Nat64, p : Nat) : Nat64"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Nat64, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Nat64, y : Nat64) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Nat64"
-      },
-      {
-        "name": "fromNat",
-        "type": ": Nat -> Nat64"
-      },
-      {
-        "name": "fromNat32",
-        "type": "(x : Nat32) : Nat64"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Nat64"
-      },
-      {
-        "name": "min",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Nat64, y : Nat64) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Nat64, toExclusive : Nat64) : Iter.Iter<Nat64>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Nat64, to : Nat64) : Iter.Iter<Nat64>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Nat64, y : Nat64) : Nat64"
-      },
-      {
-        "name": "toNat",
-        "type": ": Nat64 -> Nat"
-      },
-      {
-        "name": "toNat32",
-        "type": "(x : Nat64) : Nat32"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Nat64) : Text"
-      }
+    "exports": [
+      "public func add(x : Nat64, y : Nat64) : Nat64",
+      "public func addWrap(x : Nat64, y : Nat64) : Nat64",
+      "public func allValues() : Iter.Iter<Nat64>",
+      "public func bitand(x : Nat64, y : Nat64) : Nat64",
+      "public func bitclear(x : Nat64, p : Nat) : Nat64",
+      "public let bitcountLeadingZero : (x : Nat64) -> Nat64",
+      "public let bitcountNonZero : (x : Nat64) -> Nat64",
+      "public let bitcountTrailingZero : (x : Nat64) -> Nat64",
+      "public func bitflip(x : Nat64, p : Nat) : Nat64",
+      "public func bitnot(x : Nat64) : Nat64",
+      "public func bitor(x : Nat64, y : Nat64) : Nat64",
+      "public func bitrotLeft(x : Nat64, y : Nat64) : Nat64",
+      "public func bitrotRight(x : Nat64, y : Nat64) : Nat64",
+      "public func bitset(x : Nat64, p : Nat) : Nat64",
+      "public func bitshiftLeft(x : Nat64, y : Nat64) : Nat64",
+      "public func bitshiftRight(x : Nat64, y : Nat64) : Nat64",
+      "public func bittest(x : Nat64, p : Nat) : Bool",
+      "public func bitxor(x : Nat64, y : Nat64) : Nat64",
+      "public func compare(x : Nat64, y : Nat64) : { #less; #equal; #greater }",
+      "public func div(x : Nat64, y : Nat64) : Nat64",
+      "public func equal(x : Nat64, y : Nat64) : Bool",
+      "public let fromIntWrap : Int -> Nat64",
+      "public let fromNat : Nat -> Nat64",
+      "public func fromNat32(x : Nat32) : Nat64",
+      "public func greater(x : Nat64, y : Nat64) : Bool",
+      "public func greaterOrEqual(x : Nat64, y : Nat64) : Bool",
+      "public func less(x : Nat64, y : Nat64) : Bool",
+      "public func lessOrEqual(x : Nat64, y : Nat64) : Bool",
+      "public func max(x : Nat64, y : Nat64) : Nat64",
+      "public let maxValue : Nat64",
+      "public func min(x : Nat64, y : Nat64) : Nat64",
+      "public func mul(x : Nat64, y : Nat64) : Nat64",
+      "public func mulWrap(x : Nat64, y : Nat64) : Nat64",
+      "public func notEqual(x : Nat64, y : Nat64) : Bool",
+      "public func pow(x : Nat64, y : Nat64) : Nat64",
+      "public func powWrap(x : Nat64, y : Nat64) : Nat64",
+      "public func range(fromInclusive : Nat64, toExclusive : Nat64) : Iter.Iter<Nat64>",
+      "public func rangeInclusive(from : Nat64, to : Nat64) : Iter.Iter<Nat64>",
+      "public func rem(x : Nat64, y : Nat64) : Nat64",
+      "public func sub(x : Nat64, y : Nat64) : Nat64",
+      "public func subWrap(x : Nat64, y : Nat64) : Nat64",
+      "public let toNat : Nat64 -> Nat",
+      "public func toNat32(x : Nat64) : Nat32",
+      "public func toText(x : Nat64) : Text"
     ]
   },
   {
     "name": "Nat8",
-    "functions": [
-      {
-        "name": "add",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "addWrap",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Nat8>"
-      },
-      {
-        "name": "bitand",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bitclear",
-        "type": "(x : Nat8, p : Nat) : Nat8"
-      },
-      {
-        "name": "bitcountLeadingZero",
-        "type": ": (x : Nat8) -> Nat8"
-      },
-      {
-        "name": "bitcountNonZero",
-        "type": ": (x : Nat8) -> Nat8"
-      },
-      {
-        "name": "bitcountTrailingZero",
-        "type": ": (x : Nat8) -> Nat8"
-      },
-      {
-        "name": "bitflip",
-        "type": "(x : Nat8, p : Nat) : Nat8"
-      },
-      {
-        "name": "bitnot",
-        "type": "(x : Nat8) : Nat8"
-      },
-      {
-        "name": "bitor",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bitrotLeft",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bitrotRight",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bitset",
-        "type": "(x : Nat8, p : Nat) : Nat8"
-      },
-      {
-        "name": "bitshiftLeft",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bitshiftRight",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "bittest",
-        "type": "(x : Nat8, p : Nat) : Bool"
-      },
-      {
-        "name": "bitxor",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "compare",
-        "type": "(x : Nat8, y : Nat8) : { #less; #equal; #greater }"
-      },
-      {
-        "name": "div",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "equal",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "fromIntWrap",
-        "type": ": Int -> Nat8"
-      },
-      {
-        "name": "fromNat",
-        "type": ": Nat -> Nat8"
-      },
-      {
-        "name": "fromNat16",
-        "type": ": Nat16 -> Nat8"
-      },
-      {
-        "name": "greater",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "less",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "max",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "maxValue",
-        "type": ": Nat8"
-      },
-      {
-        "name": "min",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "mul",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "mulWrap",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "notEqual",
-        "type": "(x : Nat8, y : Nat8) : Bool"
-      },
-      {
-        "name": "pow",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "powWrap",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "range",
-        "type": "(fromInclusive : Nat8, toExclusive : Nat8) : Iter.Iter<Nat8>"
-      },
-      {
-        "name": "rangeInclusive",
-        "type": "(from : Nat8, to : Nat8) : Iter.Iter<Nat8>"
-      },
-      {
-        "name": "rem",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "sub",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "subWrap",
-        "type": "(x : Nat8, y : Nat8) : Nat8"
-      },
-      {
-        "name": "toNat",
-        "type": ": Nat8 -> Nat"
-      },
-      {
-        "name": "toNat16",
-        "type": ": Nat8 -> Nat16"
-      },
-      {
-        "name": "toText",
-        "type": "(x : Nat8) : Text"
-      }
+    "exports": [
+      "public func add(x : Nat8, y : Nat8) : Nat8",
+      "public func addWrap(x : Nat8, y : Nat8) : Nat8",
+      "public func allValues() : Iter.Iter<Nat8>",
+      "public func bitand(x : Nat8, y : Nat8) : Nat8",
+      "public func bitclear(x : Nat8, p : Nat) : Nat8",
+      "public let bitcountLeadingZero : (x : Nat8) -> Nat8",
+      "public let bitcountNonZero : (x : Nat8) -> Nat8",
+      "public let bitcountTrailingZero : (x : Nat8) -> Nat8",
+      "public func bitflip(x : Nat8, p : Nat) : Nat8",
+      "public func bitnot(x : Nat8) : Nat8",
+      "public func bitor(x : Nat8, y : Nat8) : Nat8",
+      "public func bitrotLeft(x : Nat8, y : Nat8) : Nat8",
+      "public func bitrotRight(x : Nat8, y : Nat8) : Nat8",
+      "public func bitset(x : Nat8, p : Nat) : Nat8",
+      "public func bitshiftLeft(x : Nat8, y : Nat8) : Nat8",
+      "public func bitshiftRight(x : Nat8, y : Nat8) : Nat8",
+      "public func bittest(x : Nat8, p : Nat) : Bool",
+      "public func bitxor(x : Nat8, y : Nat8) : Nat8",
+      "public func compare(x : Nat8, y : Nat8) : { #less; #equal; #greater }",
+      "public func div(x : Nat8, y : Nat8) : Nat8",
+      "public func equal(x : Nat8, y : Nat8) : Bool",
+      "public let fromIntWrap : Int -> Nat8",
+      "public let fromNat : Nat -> Nat8",
+      "public let fromNat16 : Nat16 -> Nat8",
+      "public func greater(x : Nat8, y : Nat8) : Bool",
+      "public func greaterOrEqual(x : Nat8, y : Nat8) : Bool",
+      "public func less(x : Nat8, y : Nat8) : Bool",
+      "public func lessOrEqual(x : Nat8, y : Nat8) : Bool",
+      "public func max(x : Nat8, y : Nat8) : Nat8",
+      "public let maxValue : Nat8",
+      "public func min(x : Nat8, y : Nat8) : Nat8",
+      "public func mul(x : Nat8, y : Nat8) : Nat8",
+      "public func mulWrap(x : Nat8, y : Nat8) : Nat8",
+      "public func notEqual(x : Nat8, y : Nat8) : Bool",
+      "public func pow(x : Nat8, y : Nat8) : Nat8",
+      "public func powWrap(x : Nat8, y : Nat8) : Nat8",
+      "public func range(fromInclusive : Nat8, toExclusive : Nat8) : Iter.Iter<Nat8>",
+      "public func rangeInclusive(from : Nat8, to : Nat8) : Iter.Iter<Nat8>",
+      "public func rem(x : Nat8, y : Nat8) : Nat8",
+      "public func sub(x : Nat8, y : Nat8) : Nat8",
+      "public func subWrap(x : Nat8, y : Nat8) : Nat8",
+      "public let toNat : Nat8 -> Nat",
+      "public let toNat16 : Nat8 -> Nat16",
+      "public func toText(x : Nat8) : Text"
     ]
   },
   {
     "name": "Option",
-    "functions": [
-      {
-        "name": "apply",
-        "type": "<A, B>(x : ?A, f : ?(A -> B)) : ?B"
-      },
-      {
-        "name": "assertNull",
-        "type": "(x : ?Any)"
-      },
-      {
-        "name": "assertSome",
-        "type": "(x : ?Any)"
-      },
-      {
-        "name": "chain",
-        "type": "<A, B>(x : ?A, f : A -> ?B) : ?B"
-      },
-      {
-        "name": "equal",
-        "type": "<A>(x : ?A, y : ?A, eq : (A, A) -> Bool) : Bool"
-      },
-      {
-        "name": "flatten",
-        "type": "<A>(x : ??A) : ?A"
-      },
-      {
-        "name": "forEach",
-        "type": "<A>(x : ?A, f : A -> ())"
-      },
-      {
-        "name": "get",
-        "type": "<T>(x : ?T, default : T) : T"
-      },
-      {
-        "name": "getMapped",
-        "type": "<A, B>(x : ?A, f : A -> B, default : B) : B"
-      },
-      {
-        "name": "isNull",
-        "type": "(x : ?Any) : Bool"
-      },
-      {
-        "name": "isSome",
-        "type": "(x : ?Any) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "<A, B>(x : ?A, f : A -> B) : ?B"
-      },
-      {
-        "name": "some",
-        "type": "<A>(x : A) : ?A"
-      },
-      {
-        "name": "unwrap",
-        "type": "<T>(x : ?T) : T"
-      }
+    "exports": [
+      "public func apply<A, B>(x : ?A, f : ?(A -> B)) : ?B",
+      "public func assertNull(x : ?Any)",
+      "public func assertSome(x : ?Any)",
+      "public func chain<A, B>(x : ?A, f : A -> ?B) : ?B",
+      "public func equal<A>(x : ?A, y : ?A, eq : (A, A) -> Bool) : Bool",
+      "public func flatten<A>(x : ??A) : ?A",
+      "public func forEach<A>(x : ?A, f : A -> ())",
+      "public func get<T>(x : ?T, default : T) : T",
+      "public func getMapped<A, B>(x : ?A, f : A -> B, default : B) : B",
+      "public func isNull(x : ?Any) : Bool",
+      "public func isSome(x : ?Any) : Bool",
+      "public func map<A, B>(x : ?A, f : A -> B) : ?B",
+      "public func some<A>(x : A) : ?A",
+      "public func unwrap<T>(x : ?T) : T"
     ]
   },
   {
     "name": "Order",
-    "functions": [
-      {
-        "name": "allValues",
-        "type": "() : Iter.Iter<Order>"
-      },
-      {
-        "name": "equal",
-        "type": "(o1 : Order, o2 : Order) : Bool"
-      }
+    "exports": [
+      "public func allValues() : Iter.Iter<Order>",
+      "public func equal(o1 : Order, o2 : Order) : Bool"
     ]
   },
   {
     "name": "Principal",
-    "functions": [
-      {
-        "name": "anonymous",
-        "type": "() : Principal"
-      },
-      {
-        "name": "compare",
-        "type": "(principal1 : Principal, principal2 : Principal) : Order.Order"
-      },
-      {
-        "name": "equal",
-        "type": "(principal1 : Principal, principal2 : Principal) : Bool"
-      },
-      {
-        "name": "fromActor",
-        "type": "(a : actor"
-      },
-      {
-        "name": "fromBlob",
-        "type": "(b : Blob) : Principal"
-      },
-      {
-        "name": "fromText",
-        "type": "(t : Text) : Principal"
-      },
-      {
-        "name": "hash",
-        "type": "(principal : Principal) : Hash.Hash"
-      },
-      {
-        "name": "isAnonymous",
-        "type": "(p : Principal) : Bool"
-      },
-      {
-        "name": "isController",
-        "type": "(p : Principal) : Bool"
-      },
-      {
-        "name": "toBlob",
-        "type": "(p : Principal) : Blob"
-      },
-      {
-        "name": "toLedgerAccount",
-        "type": "(principal : Principal, subAccount : ?Blob) : Blob"
-      },
-      {
-        "name": "toText",
-        "type": "(p : Principal) : Text"
-      }
+    "exports": [
+      "public func anonymous() : Principal",
+      "public func compare(principal1 : Principal, principal2 : Principal) : Order.Order",
+      "public func equal(principal1 : Principal, principal2 : Principal) : Bool",
+      "public func fromActor(a : actor",
+      "public func fromBlob(b : Blob) : Principal",
+      "public func fromText(t : Text) : Principal",
+      "public func hash(principal : Principal) : Hash.Hash",
+      "public func isAnonymous(p : Principal) : Bool",
+      "public func isController(p : Principal) : Bool",
+      "public func toBlob(p : Principal) : Blob",
+      "public func toLedgerAccount(principal : Principal, subAccount : ?Blob) : Blob",
+      "public func toText(p : Principal) : Text"
     ]
   },
   {
     "name": "Queue",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "clone",
-        "type": "<T>(queue : Queue<T>) : Queue<T>"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(queue : Queue<T>, item : T) : Bool"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Queue<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(queue : Queue<T>, f : T -> ())"
-      },
-      {
-        "name": "freeze",
-        "type": "<T>(queue : Queue<T>) : Immutable.Queue<T>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : Queue<T>"
-      },
-      {
-        "name": "isEmpty",
-        "type": "<T>(queue : Queue<T>) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>"
-      },
-      {
-        "name": "peekBack",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "peekFront",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "pop",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "popBack",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "popFront",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "push",
-        "type": "<T>(queue : Queue<T>, element : T) : ()"
-      },
-      {
-        "name": "pushBack",
-        "type": "<T>(queue : Queue<T>, element : T) : ()"
-      },
-      {
-        "name": "pushFront",
-        "type": "<T>(queue : Queue<T>, element : T) : ()"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(item : T) : Queue<T>"
-      },
-      {
-        "name": "size",
-        "type": "<T>(queue : Queue<T>) : Nat"
-      },
-      {
-        "name": "thaw",
-        "type": "<T>(queue : Immutable.Queue<T>) : Queue<T>"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(queue : Queue<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<T>(queue : Queue<T>) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func all<T>(queue : Queue<T>, predicate : T -> Bool) : Bool",
+      "public func any<T>(queue : Queue<T>, predicate : T -> Bool) : Bool",
+      "public func clone<T>(queue : Queue<T>) : Queue<T>",
+      "public func compare<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func contains<T>(queue : Queue<T>, item : T) : Bool",
+      "public func empty<T>() : Queue<T>",
+      "public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool",
+      "public func filter<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>",
+      "public func filterMap<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>",
+      "public func forEach<T>(queue : Queue<T>, f : T -> ())",
+      "public func freeze<T>(queue : Queue<T>) : Immutable.Queue<T>",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T>",
+      "public func isEmpty<T>(queue : Queue<T>) : Bool",
+      "public func map<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>",
+      "public func peekBack<T>(queue : Queue<T>) : ?T",
+      "public func peekFront<T>(queue : Queue<T>) : ?T",
+      "public func pop<T>(queue : Queue<T>) : ?T",
+      "public func popBack<T>(queue : Queue<T>) : ?T",
+      "public func popFront<T>(queue : Queue<T>) : ?T",
+      "public func push<T>(queue : Queue<T>, element : T) : ()",
+      "public func pushBack<T>(queue : Queue<T>, element : T) : ()",
+      "public func pushFront<T>(queue : Queue<T>, element : T) : ()",
+      "public func singleton<T>(item : T) : Queue<T>",
+      "public func size<T>(queue : Queue<T>) : Nat",
+      "public func thaw<T>(queue : Immutable.Queue<T>) : Queue<T>",
+      "public func toText<T>(queue : Queue<T>, f : T -> Text) : Text",
+      "public func values<T>(queue : Queue<T>) : Iter.Iter<T>"
     ]
   },
   {
     "name": "Random",
-    "functions": [
-      {
-        "name": "AsyncRandom",
-        "type": "(generator : () -> async* Blob)"
-      },
-      {
-        "name": "blob",
-        "type": ": shared () -> async Blob"
-      },
-      {
-        "name": "bool",
-        "type": "() : Bool"
-      },
-      {
-        "name": "bool",
-        "type": "() : async* Bool"
-      },
-      {
-        "name": "byte",
-        "type": "() : Nat8"
-      },
-      {
-        "name": "byte",
-        "type": "() : async* Nat8"
-      },
-      {
-        "name": "float",
-        "type": "() : Float"
-      },
-      {
-        "name": "float",
-        "type": "() : async* Float"
-      },
-      {
-        "name": "intRange",
-        "type": "(min : Int, maxExclusive : Int) : Int"
-      },
-      {
-        "name": "intRange",
-        "type": "(min : Int, maxExclusive : Int) : async* Int"
-      },
-      {
-        "name": "natRange",
-        "type": "(min : Nat, maxExclusive : Nat) : Nat"
-      },
-      {
-        "name": "natRange",
-        "type": "(min : Nat, maxExclusive : Nat) : async* Nat"
-      },
-      {
-        "name": "new",
-        "type": "(seed : Blob) : Random"
-      },
-      {
-        "name": "newAsync",
-        "type": "() : AsyncRandom"
-      },
-      {
-        "name": "Random",
-        "type": "(generator : () -> Blob)"
-      }
+    "exports": [
+      "public class AsyncRandom(generator : () -> async* Blob)",
+      "public let blob : shared () -> async Blob",
+      "public func bool() : Bool",
+      "public func bool() : async* Bool",
+      "public func byte() : Nat8",
+      "public func byte() : async* Nat8",
+      "public func float() : Float",
+      "public func float() : async* Float",
+      "public func intRange(min : Int, maxExclusive : Int) : Int",
+      "public func intRange(min : Int, maxExclusive : Int) : async* Int",
+      "public func natRange(min : Nat, maxExclusive : Nat) : Nat",
+      "public func natRange(min : Nat, maxExclusive : Nat) : async* Nat",
+      "public func new(seed : Blob) : Random",
+      "public func newAsync() : AsyncRandom",
+      "public class Random(generator : () -> Blob)"
     ]
   },
   {
     "name": "Region",
-    "functions": [
-      {
-        "name": "grow",
-        "type": ": (region : Region, newPages : Nat64) -> (oldPages : Nat64)"
-      },
-      {
-        "name": "id",
-        "type": ": Region -> Nat"
-      },
-      {
-        "name": "loadBlob",
-        "type": ": (region : Region, offset : Nat64, size : Nat) -> Blob"
-      },
-      {
-        "name": "loadFloat",
-        "type": ": (region : Region, offset : Nat64) -> Float"
-      },
-      {
-        "name": "loadInt16",
-        "type": ": (region : Region, offset : Nat64) -> Int16"
-      },
-      {
-        "name": "loadInt32",
-        "type": ": (region : Region, offset : Nat64) -> Int32"
-      },
-      {
-        "name": "loadInt64",
-        "type": ": (region : Region, offset : Nat64) -> Int64"
-      },
-      {
-        "name": "loadInt8",
-        "type": ": (region : Region, offset : Nat64) -> Int8"
-      },
-      {
-        "name": "loadNat16",
-        "type": ": (region : Region, offset : Nat64) -> Nat16"
-      },
-      {
-        "name": "loadNat32",
-        "type": ": (region : Region, offset : Nat64) -> Nat32"
-      },
-      {
-        "name": "loadNat64",
-        "type": ": (region : Region, offset : Nat64) -> Nat64"
-      },
-      {
-        "name": "loadNat8",
-        "type": ": (region : Region, offset : Nat64) -> Nat8"
-      },
-      {
-        "name": "new",
-        "type": ": () -> Region"
-      },
-      {
-        "name": "size",
-        "type": ": (region : Region) -> (pages : Nat64)"
-      },
-      {
-        "name": "storeBlob",
-        "type": ": (region : Region, offset : Nat64, value : Blob) -> ()"
-      },
-      {
-        "name": "storeFloat",
-        "type": ": (region: Region, offset : Nat64, value : Float) -> ()"
-      },
-      {
-        "name": "storeInt16",
-        "type": ": (region : Region, offset : Nat64, value : Int16) -> ()"
-      },
-      {
-        "name": "storeInt32",
-        "type": ": (region : Region, offset : Nat64, value : Int32) -> ()"
-      },
-      {
-        "name": "storeInt64",
-        "type": ": (region : Region, offset : Nat64, value : Int64) -> ()"
-      },
-      {
-        "name": "storeInt8",
-        "type": ": (region : Region, offset : Nat64, value : Int8) -> ()"
-      },
-      {
-        "name": "storeNat16",
-        "type": ": (region : Region, offset : Nat64, value : Nat16) -> ()"
-      },
-      {
-        "name": "storeNat32",
-        "type": ": (region : Region, offset : Nat64, value : Nat32) -> ()"
-      },
-      {
-        "name": "storeNat64",
-        "type": ": (region : Region, offset : Nat64, value : Nat64) -> ()"
-      },
-      {
-        "name": "storeNat8",
-        "type": ": (region : Region, offset : Nat64, value : Nat8) -> ()"
-      }
+    "exports": [
+      "public let grow : (region : Region, newPages : Nat64) -> (oldPages : Nat64)",
+      "public let id : Region -> Nat",
+      "public let loadBlob : (region : Region, offset : Nat64, size : Nat) -> Blob",
+      "public let loadFloat : (region : Region, offset : Nat64) -> Float",
+      "public let loadInt16 : (region : Region, offset : Nat64) -> Int16",
+      "public let loadInt32 : (region : Region, offset : Nat64) -> Int32",
+      "public let loadInt64 : (region : Region, offset : Nat64) -> Int64",
+      "public let loadInt8 : (region : Region, offset : Nat64) -> Int8",
+      "public let loadNat16 : (region : Region, offset : Nat64) -> Nat16",
+      "public let loadNat32 : (region : Region, offset : Nat64) -> Nat32",
+      "public let loadNat64 : (region : Region, offset : Nat64) -> Nat64",
+      "public let loadNat8 : (region : Region, offset : Nat64) -> Nat8",
+      "public let new : () -> Region",
+      "public let size : (region : Region) -> (pages : Nat64)",
+      "public let storeBlob : (region : Region, offset : Nat64, value : Blob) -> ()",
+      "public let storeFloat : (region: Region, offset : Nat64, value : Float) -> ()",
+      "public let storeInt16 : (region : Region, offset : Nat64, value : Int16) -> ()",
+      "public let storeInt32 : (region : Region, offset : Nat64, value : Int32) -> ()",
+      "public let storeInt64 : (region : Region, offset : Nat64, value : Int64) -> ()",
+      "public let storeInt8 : (region : Region, offset : Nat64, value : Int8) -> ()",
+      "public let storeNat16 : (region : Region, offset : Nat64, value : Nat16) -> ()",
+      "public let storeNat32 : (region : Region, offset : Nat64, value : Nat32) -> ()",
+      "public let storeNat64 : (region : Region, offset : Nat64, value : Nat64) -> ()",
+      "public let storeNat8 : (region : Region, offset : Nat64, value : Nat8) -> ()"
     ]
   },
   {
     "name": "Result",
-    "functions": [
-      {
-        "name": "assertErr",
-        "type": "(result : Result<Any, Any>)"
-      },
-      {
-        "name": "assertOk",
-        "type": "(result : Result<Any, Any>)"
-      },
-      {
-        "name": "chain",
-        "type": "<R1, R2, Error>( result : Result<R1, Error>, y : R1 -> Result<R2, Error> ) : Result<R2, Error>"
-      },
-      {
-        "name": "compare",
-        "type": "<R, E>( compareOk : (R, R) -> Order.Order, compareErr : (E, E) -> Order.Order, r1 : Result<R, E>, r2 : Result<R, E> ) : Order.Order"
-      },
-      {
-        "name": "equal",
-        "type": "<R, E>( eqOk : (R, R) -> Bool, eqErr : (E, E) -> Bool, r1 : Result<R, E>, r2 : Result<R, E> ) : Bool"
-      },
-      {
-        "name": "flatten",
-        "type": "<R, E>( result : Result<Result<R, E>, E> ) : Result<R, E>"
-      },
-      {
-        "name": "forEach",
-        "type": "<R, E>(result : Result<R, E>, f : R -> ())"
-      },
-      {
-        "name": "fromOption",
-        "type": "<R, E>(ok : ?R, err : E) : Result<R, E>"
-      },
-      {
-        "name": "fromUpper",
-        "type": "<R, E>( result : { #Ok : R; #Err : E } ) : Result<R, E>"
-      },
-      {
-        "name": "mapErr",
-        "type": "<R, E1, E2>( result : Result<R, E1>, f : E1 -> E2 ) : Result<R, E2>"
-      },
-      {
-        "name": "mapOk",
-        "type": "<R1, R2, E>( result : Result<R1, E>, f : R1 -> R2 ) : Result<R2, E>"
-      },
-      {
-        "name": "toOption",
-        "type": "<R, E>(result : Result<R, E>) : ?R"
-      },
-      {
-        "name": "toUpper",
-        "type": "<R, E>( result : Result<R, E> ) : { #Ok : R; #Err : E }"
-      }
+    "exports": [
+      "public func assertErr(result : Result<Any, Any>)",
+      "public func assertOk(result : Result<Any, Any>)",
+      "public func chain<R1, R2, Error>( result : Result<R1, Error>, y : R1 -> Result<R2, Error> ) : Result<R2, Error>",
+      "public func compare<R, E>( compareOk : (R, R) -> Order.Order, compareErr : (E, E) -> Order.Order, r1 : Result<R, E>, r2 : Result<R, E> ) : Order.Order",
+      "public func equal<R, E>( eqOk : (R, R) -> Bool, eqErr : (E, E) -> Bool, r1 : Result<R, E>, r2 : Result<R, E> ) : Bool",
+      "public func flatten<R, E>( result : Result<Result<R, E>, E> ) : Result<R, E>",
+      "public func forEach<R, E>(result : Result<R, E>, f : R -> ())",
+      "public func fromOption<R, E>(ok : ?R, err : E) : Result<R, E>",
+      "public func fromUpper<R, E>( result : { #Ok : R; #Err : E } ) : Result<R, E>",
+      "public func mapErr<R, E1, E2>( result : Result<R, E1>, f : E1 -> E2 ) : Result<R, E2>",
+      "public func mapOk<R1, R2, E>( result : Result<R1, E>, f : R1 -> R2 ) : Result<R2, E>",
+      "public func toOption<R, E>(result : Result<R, E>) : ?R",
+      "public func toUpper<R, E>( result : Result<R, E> ) : { #Ok : R; #Err : E }"
     ]
   },
   {
     "name": "Runtime",
-    "functions": [
-      {
-        "name": "trap",
-        "type": "(errorMessage : Text) : None"
-      },
-      {
-        "name": "unreachable",
-        "type": "() : None"
-      }
+    "exports": [
+      "public func trap(errorMessage : Text) : None",
+      "public func unreachable() : None"
     ]
   },
   {
     "name": "Set",
-    "functions": [
-      {
-        "name": "add",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : ()"
-      },
-      {
-        "name": "all",
-        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
-      },
-      {
-        "name": "assertValid",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ()"
-      },
-      {
-        "name": "clone",
-        "type": "<T>(set : Set<T>) : Set<T>"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
-      },
-      {
-        "name": "delete",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
-      },
-      {
-        "name": "diff",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Set<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(set : Set<T>, f : T -> Bool) : Set<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(set : Iter.Iter<Set<T>>) : Set<T>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(set : Set<T>, f : T -> ())"
-      },
-      {
-        "name": "freeze",
-        "type": "<T>(set : Set<T>) : Immutable.Set<T>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>"
-      },
-      {
-        "name": "intersect",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(set : Set<Any>) : Bool"
-      },
-      {
-        "name": "isSubset",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>"
-      },
-      {
-        "name": "max",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "min",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "reverseValues",
-        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>() : Set<T>"
-      },
-      {
-        "name": "size",
-        "type": "(set : Set<Any>) : Nat"
-      },
-      {
-        "name": "thaw",
-        "type": "<T>(set : Immutable.Set<T>) : Set<T>"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(set : Set<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "union",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "values",
-        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func add<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : ()",
+      "public func all<T>(set : Set<T>, pred : T -> Bool) : Bool",
+      "public func any<T>(set : Set<T>, pred : T -> Bool) : Bool",
+      "public func assertValid<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ()",
+      "public func clone<T>(set : Set<T>) : Set<T>",
+      "public func compare<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func contains<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool",
+      "public func delete<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool",
+      "public func diff<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func empty<T>() : Set<T>",
+      "public func equal<T>(set1 : Set<T>, set2 : Set<T>, equal : (T, T) -> Bool) : Bool",
+      "public func filter<T>(set : Set<T>, f : T -> Bool) : Set<T>",
+      "public func filterMap<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>",
+      "public func flatten<T>(set : Iter.Iter<Set<T>>) : Set<T>",
+      "public func foldLeft<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A",
+      "public func foldRight<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A",
+      "public func forEach<T>(set : Set<T>, f : T -> ())",
+      "public func freeze<T>(set : Set<T>) : Immutable.Set<T>",
+      "public func fromIter<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>",
+      "public func intersect<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func isEmpty(set : Set<Any>) : Bool",
+      "public func isSubset<T>(set1 : Set<T>, set2 : Set<T>) : Bool",
+      "public func map<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>",
+      "public func max<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func min<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func reverseValues<T>(set : Set<T>) : Iter.Iter<T>",
+      "public func singleton<T>() : Set<T>",
+      "public func size(set : Set<Any>) : Nat",
+      "public func thaw<T>(set : Immutable.Set<T>) : Set<T>",
+      "public func toText<T>(set : Set<T>, f : T -> Text) : Text",
+      "public func union<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func values<T>(set : Set<T>) : Iter.Iter<T>"
     ]
   },
   {
     "name": "Stack",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
-      },
-      {
-        "name": "chunks",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>"
-      },
-      {
-        "name": "clone",
-        "type": "<T>(stack : Stack<T>) : Stack<T>"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "concat",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(stack : Stack<T>, item : T) : Bool"
-      },
-      {
-        "name": "drop",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Stack<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>"
-      },
-      {
-        "name": "find",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : ?T"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(stack : Stack<T>, f : T -> ())"
-      },
-      {
-        "name": "freeze",
-        "type": "<T>(stack : Stack<T>) : Immutable.Stack<T>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : Stack<T>"
-      },
-      {
-        "name": "generate",
-        "type": "<T>(n : Nat, f : Nat -> T) : Stack<T>"
-      },
-      {
-        "name": "get",
-        "type": "<T>(stack : Stack<T>, n : Nat) : ?T"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(stack : Stack<Any>) : Bool"
-      },
-      {
-        "name": "last",
-        "type": "<T>(stack : Stack<T>) : ?T"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>"
-      },
-      {
-        "name": "mapResult",
-        "type": "<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>"
-      },
-      {
-        "name": "merge",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>"
-      },
-      {
-        "name": "partition",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)"
-      },
-      {
-        "name": "pop",
-        "type": "<T>(stack : Stack<T>) : ?T"
-      },
-      {
-        "name": "push",
-        "type": "<T>(stack : Stack<T>, item : T) : ()"
-      },
-      {
-        "name": "repeat",
-        "type": "<T>(item : T, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "reverse",
-        "type": "<T>(stack : Stack<T>) : ()"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(item : T) : Stack<T>"
-      },
-      {
-        "name": "size",
-        "type": "(stack : Stack<Any>) : Nat"
-      },
-      {
-        "name": "split",
-        "type": "<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)"
-      },
-      {
-        "name": "take",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "thaw",
-        "type": "<T>(stack : Immutable.Stack<T>) : Stack<T>"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(stack : Stack<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<T>(stack : Stack<T>) : Iter.Iter<T>"
-      },
-      {
-        "name": "zip",
-        "type": "<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>"
-      },
-      {
-        "name": "zipWith",
-        "type": "<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
-      }
+    "exports": [
+      "public func all<T>(stack : Stack<T>, f : T -> Bool) : Bool",
+      "public func any<T>(stack : Stack<T>, f : T -> Bool) : Bool",
+      "public func chunks<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>",
+      "public func clone<T>(stack : Stack<T>) : Stack<T>",
+      "public func compare<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func concat<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>",
+      "public func contains<T>(stack : Stack<T>, item : T) : Bool",
+      "public func drop<T>(stack : Stack<T>, n : Nat) : Stack<T>",
+      "public func empty<T>() : Stack<T>",
+      "public func equal<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Bool",
+      "public func filter<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>",
+      "public func filterMap<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>",
+      "public func find<T>(stack : Stack<T>, f : T -> Bool) : ?T",
+      "public func flatten<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>",
+      "public func foldLeft<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A",
+      "public func foldRight<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A",
+      "public func forEach<T>(stack : Stack<T>, f : T -> ())",
+      "public func freeze<T>(stack : Stack<T>) : Immutable.Stack<T>",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : Stack<T>",
+      "public func generate<T>(n : Nat, f : Nat -> T) : Stack<T>",
+      "public func get<T>(stack : Stack<T>, n : Nat) : ?T",
+      "public func isEmpty(stack : Stack<Any>) : Bool",
+      "public func last<T>(stack : Stack<T>) : ?T",
+      "public func map<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>",
+      "public func mapResult<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>",
+      "public func merge<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>",
+      "public func partition<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)",
+      "public func pop<T>(stack : Stack<T>) : ?T",
+      "public func push<T>(stack : Stack<T>, item : T) : ()",
+      "public func repeat<T>(item : T, n : Nat) : Stack<T>",
+      "public func reverse<T>(stack : Stack<T>) : ()",
+      "public func singleton<T>(item : T) : Stack<T>",
+      "public func size(stack : Stack<Any>) : Nat",
+      "public func split<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)",
+      "public func take<T>(stack : Stack<T>, n : Nat) : Stack<T>",
+      "public func thaw<T>(stack : Immutable.Stack<T>) : Stack<T>",
+      "public func toText<T>(stack : Stack<T>, f : T -> Text) : Text",
+      "public func values<T>(stack : Stack<T>) : Iter.Iter<T>",
+      "public func zip<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>",
+      "public func zipWith<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
     ]
   },
   {
     "name": "Text",
-    "functions": [
-      {
-        "name": "chars",
-        "type": "(t : Text) : Iter.Iter<Char>"
-      },
-      {
-        "name": "compare",
-        "type": "(t1 : Text, t2 : Text) : Order.Order"
-      },
-      {
-        "name": "compareWith",
-        "type": "( t1 : Text, t2 : Text, cmp : (Char, Char) -> Order.Order ) : Order.Order"
-      },
-      {
-        "name": "concat",
-        "type": "(t1 : Text, t2 : Text) : Text"
-      },
-      {
-        "name": "concatAll",
-        "type": "(ts : [Text]) : Text"
-      },
-      {
-        "name": "contains",
-        "type": "(t : Text, p : Pattern) : Bool"
-      },
-      {
-        "name": "decodeUtf8",
-        "type": ": Blob -> ?Text"
-      },
-      {
-        "name": "encodeUtf8",
-        "type": ": Text -> Blob"
-      },
-      {
-        "name": "endsWith",
-        "type": "(t : Text, p : Pattern) : Bool"
-      },
-      {
-        "name": "equal",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "flatMap",
-        "type": "(t : Text, f : Char -> Text) : Text"
-      },
-      {
-        "name": "fromArray",
-        "type": "(a : [Char]) : Text"
-      },
-      {
-        "name": "fromChar",
-        "type": ": (c : Char) -> Text"
-      },
-      {
-        "name": "fromIter",
-        "type": "(cs : Iter.Iter<Char>) : Text"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "(a : [var Char]) : Text"
-      },
-      {
-        "name": "greater",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "greaterOrEqual",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "hash",
-        "type": "(t : Text) : Hash.Hash"
-      },
-      {
-        "name": "join",
-        "type": "(sep : Text, ts : Iter.Iter<Text>) : Text"
-      },
-      {
-        "name": "less",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "lessOrEqual",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "(t : Text, f : Char -> Char) : Text"
-      },
-      {
-        "name": "notEqual",
-        "type": "(t1 : Text, t2 : Text) : Bool"
-      },
-      {
-        "name": "replace",
-        "type": "(t : Text, p : Pattern, r : Text) : Text"
-      },
-      {
-        "name": "size",
-        "type": "(t : Text) : Nat"
-      },
-      {
-        "name": "split",
-        "type": "(t : Text, p : Pattern) : Iter.Iter<Text>"
-      },
-      {
-        "name": "startsWith",
-        "type": "(t : Text, p : Pattern) : Bool"
-      },
-      {
-        "name": "stripEnd",
-        "type": "(t : Text, p : Pattern) : ?Text"
-      },
-      {
-        "name": "stripStart",
-        "type": "(t : Text, p : Pattern) : ?Text"
-      },
-      {
-        "name": "toArray",
-        "type": "(t : Text) : [Char]"
-      },
-      {
-        "name": "tokens",
-        "type": "(t : Text, p : Pattern) : Iter.Iter<Text>"
-      },
-      {
-        "name": "toLower",
-        "type": ": Text -> Text"
-      },
-      {
-        "name": "toUpper",
-        "type": ": Text -> Text"
-      },
-      {
-        "name": "toVarArray",
-        "type": "(t : Text) : [var Char]"
-      },
-      {
-        "name": "trim",
-        "type": "(t : Text, p : Pattern) : Text"
-      },
-      {
-        "name": "trimEnd",
-        "type": "(t : Text, p : Pattern) : Text"
-      },
-      {
-        "name": "trimStart",
-        "type": "(t : Text, p : Pattern) : Text"
-      }
+    "exports": [
+      "public func chars(t : Text) : Iter.Iter<Char>",
+      "public func compare(t1 : Text, t2 : Text) : Order.Order",
+      "public func compareWith( t1 : Text, t2 : Text, cmp : (Char, Char) -> Order.Order ) : Order.Order",
+      "public func concat(t1 : Text, t2 : Text) : Text",
+      "public func concatAll(ts : [Text]) : Text",
+      "public func contains(t : Text, p : Pattern) : Bool",
+      "public let decodeUtf8 : Blob -> ?Text",
+      "public let encodeUtf8 : Text -> Blob",
+      "public func endsWith(t : Text, p : Pattern) : Bool",
+      "public func equal(t1 : Text, t2 : Text) : Bool",
+      "public func flatMap(t : Text, f : Char -> Text) : Text",
+      "public func fromArray(a : [Char]) : Text",
+      "public let fromChar : (c : Char) -> Text",
+      "public func fromIter(cs : Iter.Iter<Char>) : Text",
+      "public func fromVarArray(a : [var Char]) : Text",
+      "public func greater(t1 : Text, t2 : Text) : Bool",
+      "public func greaterOrEqual(t1 : Text, t2 : Text) : Bool",
+      "public func hash(t : Text) : Hash.Hash",
+      "public func join(sep : Text, ts : Iter.Iter<Text>) : Text",
+      "public func less(t1 : Text, t2 : Text) : Bool",
+      "public func lessOrEqual(t1 : Text, t2 : Text) : Bool",
+      "public func map(t : Text, f : Char -> Char) : Text",
+      "public func notEqual(t1 : Text, t2 : Text) : Bool",
+      "public func replace(t : Text, p : Pattern, r : Text) : Text",
+      "public func size(t : Text) : Nat",
+      "public func split(t : Text, p : Pattern) : Iter.Iter<Text>",
+      "public func startsWith(t : Text, p : Pattern) : Bool",
+      "public func stripEnd(t : Text, p : Pattern) : ?Text",
+      "public func stripStart(t : Text, p : Pattern) : ?Text",
+      "public func toArray(t : Text) : [Char]",
+      "public func tokens(t : Text, p : Pattern) : Iter.Iter<Text>",
+      "public let toLower : Text -> Text",
+      "public let toUpper : Text -> Text",
+      "public func toVarArray(t : Text) : [var Char]",
+      "public func trim(t : Text, p : Pattern) : Text",
+      "public func trimEnd(t : Text, p : Pattern) : Text",
+      "public func trimStart(t : Text, p : Pattern) : Text"
     ]
   },
   {
     "name": "Time",
-    "functions": [
-      {
-        "name": "cancelTimer",
-        "type": ": TimerId -> ()"
-      },
-      {
-        "name": "now",
-        "type": ": () -> Time"
-      },
-      {
-        "name": "recurringTimer",
-        "type": "<system>(duration : Duration, job : () -> async ()) : TimerId"
-      },
-      {
-        "name": "setTimer",
-        "type": "<system>(duration : Duration, job : () -> async ()) : TimerId"
-      },
-      {
-        "name": "toNanoseconds",
-        "type": "(duration : Duration) : Nat"
-      }
+    "exports": [
+      "public let cancelTimer : TimerId -> ()",
+      "public let now : () -> Time",
+      "public func recurringTimer<system>(duration : Duration, job : () -> async ()) : TimerId",
+      "public func setTimer<system>(duration : Duration, job : () -> async ()) : TimerId",
+      "public func toNanoseconds(duration : Duration) : Nat"
     ]
   },
   {
     "name": "VarArray",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(array : [var T], predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(array : [var T], predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "append",
-        "type": "<T>(array1 : [var T], array2 : [var T]) : [var T]"
-      },
-      {
-        "name": "chain",
-        "type": "<T, Y>(array : [var T], k : T -> [var Y]) : [var Y]"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(array1 : [var T], array2 : [var T], compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : [var T]"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(array1 : [var T], array2 : [var T], equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(array : [var T], f : T -> Bool) : [var T]"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, Y>(array : [var T], f : T -> ?Y) : [var Y]"
-      },
-      {
-        "name": "find",
-        "type": "<T>(array : [var T], predicate : T -> Bool) : ?T"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(arrays : Iter.Iter<[var T]>) : [var T]"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>(array : [var T], base : A, combine : (A, T) -> A) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>(array : [var T], base : A, combine : (T, A) -> A) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(array : [var T], f : T -> ())"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : [var T]"
-      },
-      {
-        "name": "generate",
-        "type": "<T>(size : Nat, generator : Nat -> T) : [var T]"
-      },
-      {
-        "name": "indexOf",
-        "type": "<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "init",
-        "type": "<T>(size : Nat, initValue : T) : [var T]"
-      },
-      {
-        "name": "isEmpty",
-        "type": "<T>(array : [var T]) : Bool"
-      },
-      {
-        "name": "keys",
-        "type": "<T>(array : [var T]) : Iter.Iter<Nat>"
-      },
-      {
-        "name": "lastIndexOf",
-        "type": "<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "map",
-        "type": "<T, Y>(array : [var T], f : T -> Y) : [var Y]"
-      },
-      {
-        "name": "mapEntries",
-        "type": "<T, Y>(array : [var T], f : (T, Nat) -> Y) : [var Y]"
-      },
-      {
-        "name": "mapResult",
-        "type": "<T, Y, E>(array : [var T], f : T -> Result.Result<Y, E>) : Result.Result<[var Y], E>"
-      },
-      {
-        "name": "nextIndexOf",
-        "type": "<T>(element : T, array : [var T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "prevIndexOf",
-        "type": "<T>(element : T, array : [var T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
-      },
-      {
-        "name": "reverse",
-        "type": "<T>(array : [var T]) : [var T]"
-      },
-      {
-        "name": "reverseInPlace",
-        "type": "<T>(array : [var T]) : ()"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(element : T) : [var T]"
-      },
-      {
-        "name": "size",
-        "type": "<T>(array : [var T]) : Nat"
-      },
-      {
-        "name": "slice",
-        "type": "<T>(array : [var T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>"
-      },
-      {
-        "name": "sort",
-        "type": "<T>(array : [var T], compare : (T, T) -> Order.Order) : [var T]"
-      },
-      {
-        "name": "sortInPlace",
-        "type": "<T>(array : [var T], compare : (T, T) -> Order.Order) : ()"
-      },
-      {
-        "name": "subArray",
-        "type": "<T>(array : [var T], start : Nat, length : Nat) : [var T]"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(array : [var T], f : T -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<T>(array : [var T]) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func all<T>(array : [var T], predicate : T -> Bool) : Bool",
+      "public func any<T>(array : [var T], predicate : T -> Bool) : Bool",
+      "public func append<T>(array1 : [var T], array2 : [var T]) : [var T]",
+      "public func chain<T, Y>(array : [var T], k : T -> [var Y]) : [var Y]",
+      "public func compare<T>(array1 : [var T], array2 : [var T], compare : (T, T) -> Order.Order) : Order.Order",
+      "public func empty<T>() : [var T]",
+      "public func equal<T>(array1 : [var T], array2 : [var T], equal : (T, T) -> Bool) : Bool",
+      "public func filter<T>(array : [var T], f : T -> Bool) : [var T]",
+      "public func filterMap<T, Y>(array : [var T], f : T -> ?Y) : [var Y]",
+      "public func find<T>(array : [var T], predicate : T -> Bool) : ?T",
+      "public func flatten<T>(arrays : Iter.Iter<[var T]>) : [var T]",
+      "public func foldLeft<T, A>(array : [var T], base : A, combine : (A, T) -> A) : A",
+      "public func foldRight<T, A>(array : [var T], base : A, combine : (T, A) -> A) : A",
+      "public func forEach<T>(array : [var T], f : T -> ())",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : [var T]",
+      "public func generate<T>(size : Nat, generator : Nat -> T) : [var T]",
+      "public func indexOf<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat",
+      "public func init<T>(size : Nat, initValue : T) : [var T]",
+      "public func isEmpty<T>(array : [var T]) : Bool",
+      "public func keys<T>(array : [var T]) : Iter.Iter<Nat>",
+      "public func lastIndexOf<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat",
+      "public func map<T, Y>(array : [var T], f : T -> Y) : [var Y]",
+      "public func mapEntries<T, Y>(array : [var T], f : (T, Nat) -> Y) : [var Y]",
+      "public func mapResult<T, Y, E>(array : [var T], f : T -> Result.Result<Y, E>) : Result.Result<[var Y], E>",
+      "public func nextIndexOf<T>(element : T, array : [var T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat",
+      "public func prevIndexOf<T>(element : T, array : [var T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat",
+      "public func reverse<T>(array : [var T]) : [var T]",
+      "public func reverseInPlace<T>(array : [var T]) : ()",
+      "public func singleton<T>(element : T) : [var T]",
+      "public func size<T>(array : [var T]) : Nat",
+      "public func slice<T>(array : [var T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>",
+      "public func sort<T>(array : [var T], compare : (T, T) -> Order.Order) : [var T]",
+      "public func sortInPlace<T>(array : [var T], compare : (T, T) -> Order.Order) : ()",
+      "public func subArray<T>(array : [var T], start : Nat, length : Nat) : [var T]",
+      "public func toText<T>(array : [var T], f : T -> Text) : Text",
+      "public func values<T>(array : [var T]) : Iter.Iter<T>"
     ]
   },
   {
     "name": "immutable/Map",
-    "functions": [
-      {
-        "name": "add",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : Map<K, V>"
-      },
-      {
-        "name": "all",
-        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
-      },
-      {
-        "name": "assertValid",
-        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()"
-      },
-      {
-        "name": "containsKey",
-        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool"
-      },
-      {
-        "name": "delete",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : Map<K, V>"
-      },
-      {
-        "name": "empty",
-        "type": "<K, V>() : Map<K, V>"
-      },
-      {
-        "name": "entries",
-        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A"
-      },
-      {
-        "name": "fromIter",
-        "type": "<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>"
-      },
-      {
-        "name": "get",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(map : Map<Any, Any>) : Bool"
-      },
-      {
-        "name": "keys",
-        "type": "<K>(map : Map<K, Any>) : Iter.Iter<K>"
-      },
-      {
-        "name": "map",
-        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>"
-      },
-      {
-        "name": "maxEntry",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
-      },
-      {
-        "name": "minEntry",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
-      },
-      {
-        "name": "put",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : (Map<K, V>, ?V)"
-      },
-      {
-        "name": "reverseEntries",
-        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
-      },
-      {
-        "name": "size",
-        "type": "(map : Map<Any, Any>) : Nat"
-      },
-      {
-        "name": "take",
-        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : (Map<K, V>, ?V)"
-      },
-      {
-        "name": "toText",
-        "type": "<K, V>(set : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<V>(map : Map<Any, V>) : Iter.Iter<V>"
-      }
+    "exports": [
+      "public func add<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : Map<K, V>",
+      "public func all<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool",
+      "public func any<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool",
+      "public func assertValid<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()",
+      "public func containsKey<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool",
+      "public func delete<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : Map<K, V>",
+      "public func empty<K, V>() : Map<K, V>",
+      "public func entries<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>",
+      "public func filterMap<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>",
+      "public func foldLeft<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A",
+      "public func foldRight<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A",
+      "public func fromIter<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>",
+      "public func get<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V",
+      "public func isEmpty(map : Map<Any, Any>) : Bool",
+      "public func keys<K>(map : Map<K, Any>) : Iter.Iter<K>",
+      "public func map<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>",
+      "public func maxEntry<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)",
+      "public func minEntry<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)",
+      "public func put<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : (Map<K, V>, ?V)",
+      "public func reverseEntries<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>",
+      "public func size(map : Map<Any, Any>) : Nat",
+      "public func take<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : (Map<K, V>, ?V)",
+      "public func toText<K, V>(set : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text",
+      "public func values<V>(map : Map<Any, V>) : Iter.Iter<V>"
     ]
   },
   {
     "name": "immutable/Queue",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(queue : Queue<T>, item : T) : Bool"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Queue<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(queue : Queue<T>, f : T -> ())"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : Queue<T>"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(queue : Queue<Any>) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>"
-      },
-      {
-        "name": "peekBack",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "peekFront",
-        "type": "<T>(queue : Queue<T>) : ?T"
-      },
-      {
-        "name": "popBack",
-        "type": "<T>(queue : Queue<T>) : ?(Queue<T>, T)"
-      },
-      {
-        "name": "popFront",
-        "type": "<T>(queue : Queue<T>) : ?(T, Queue<T>)"
-      },
-      {
-        "name": "pushBack",
-        "type": "<T>(queue : Queue<T>, element : T) : Queue<T>"
-      },
-      {
-        "name": "pushFront",
-        "type": "<T>(queue : Queue<T>, element : T) : Queue<T>"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(item : T) : Queue<T>"
-      },
-      {
-        "name": "size",
-        "type": "(queue : Queue<Any>) : Nat"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(queue : Queue<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "values",
-        "type": "<T>(queue : Queue<T>) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func all<T>(queue : Queue<T>, predicate : T -> Bool) : Bool",
+      "public func any<T>(queue : Queue<T>, predicate : T -> Bool) : Bool",
+      "public func compare<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func contains<T>(queue : Queue<T>, item : T) : Bool",
+      "public func empty<T>() : Queue<T>",
+      "public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool",
+      "public func filter<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>",
+      "public func filterMap<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>",
+      "public func forEach<T>(queue : Queue<T>, f : T -> ())",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T>",
+      "public func isEmpty(queue : Queue<Any>) : Bool",
+      "public func map<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>",
+      "public func peekBack<T>(queue : Queue<T>) : ?T",
+      "public func peekFront<T>(queue : Queue<T>) : ?T",
+      "public func popBack<T>(queue : Queue<T>) : ?(Queue<T>, T)",
+      "public func popFront<T>(queue : Queue<T>) : ?(T, Queue<T>)",
+      "public func pushBack<T>(queue : Queue<T>, element : T) : Queue<T>",
+      "public func pushFront<T>(queue : Queue<T>, element : T) : Queue<T>",
+      "public func singleton<T>(item : T) : Queue<T>",
+      "public func size(queue : Queue<Any>) : Nat",
+      "public func toText<T>(queue : Queue<T>, f : T -> Text) : Text",
+      "public func values<T>(queue : Queue<T>) : Iter.Iter<T>"
     ]
   },
   {
     "name": "immutable/Set",
-    "functions": [
-      {
-        "name": "add",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>"
-      },
-      {
-        "name": "all",
-        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
-      },
-      {
-        "name": "assertValid",
-        "type": "(set : Set<Any>) : ()"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
-      },
-      {
-        "name": "delete",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>"
-      },
-      {
-        "name": "diff",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Set<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(set : Set<T>, f : T -> Bool) : Set<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(set : Set<T>, f : T -> ())"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>"
-      },
-      {
-        "name": "intersect",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "isEmpty",
-        "type": "<T>(set : Set<T>) : Bool"
-      },
-      {
-        "name": "isSubset",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>"
-      },
-      {
-        "name": "max",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "min",
-        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
-      },
-      {
-        "name": "reverseValues",
-        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(item : T) : Set<T>"
-      },
-      {
-        "name": "size",
-        "type": "<T>(set : Set<T>) : Nat"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(set : Set<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "union",
-        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
-      },
-      {
-        "name": "values",
-        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
-      }
+    "exports": [
+      "public func add<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>",
+      "public func all<T>(set : Set<T>, pred : T -> Bool) : Bool",
+      "public func any<T>(set : Set<T>, pred : T -> Bool) : Bool",
+      "public func assertValid(set : Set<Any>) : ()",
+      "public func compare<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func contains<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool",
+      "public func delete<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>",
+      "public func diff<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func empty<T>() : Set<T>",
+      "public func equal<T>(set1 : Set<T>, set2 : Set<T>) : Bool",
+      "public func filter<T>(set : Set<T>, f : T -> Bool) : Set<T>",
+      "public func filterMap<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>",
+      "public func foldLeft<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A",
+      "public func foldRight<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A",
+      "public func forEach<T>(set : Set<T>, f : T -> ())",
+      "public func fromIter<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>",
+      "public func intersect<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func isEmpty<T>(set : Set<T>) : Bool",
+      "public func isSubset<T>(set1 : Set<T>, set2 : Set<T>) : Bool",
+      "public func map<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>",
+      "public func max<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func min<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T",
+      "public func reverseValues<T>(set : Set<T>) : Iter.Iter<T>",
+      "public func singleton<T>(item : T) : Set<T>",
+      "public func size<T>(set : Set<T>) : Nat",
+      "public func toText<T>(set : Set<T>, f : T -> Text) : Text",
+      "public func union<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>",
+      "public func values<T>(set : Set<T>) : Iter.Iter<T>"
     ]
   },
   {
     "name": "immutable/Stack",
-    "functions": [
-      {
-        "name": "all",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
-      },
-      {
-        "name": "any",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
-      },
-      {
-        "name": "chunks",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>"
-      },
-      {
-        "name": "compare",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order"
-      },
-      {
-        "name": "concat",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>"
-      },
-      {
-        "name": "contains",
-        "type": "<T>(stack : Stack<T>, item : T) : Bool"
-      },
-      {
-        "name": "drop",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "empty",
-        "type": "<T>() : Stack<T>"
-      },
-      {
-        "name": "equal",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, equal : (T, T) -> Bool) : Bool"
-      },
-      {
-        "name": "filter",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>"
-      },
-      {
-        "name": "filterMap",
-        "type": "<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>"
-      },
-      {
-        "name": "find",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : ?T"
-      },
-      {
-        "name": "flatten",
-        "type": "<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>"
-      },
-      {
-        "name": "foldLeft",
-        "type": "<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A"
-      },
-      {
-        "name": "foldRight",
-        "type": "<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A"
-      },
-      {
-        "name": "forEach",
-        "type": "<T>(stack : Stack<T>, f : T -> ())"
-      },
-      {
-        "name": "fromArray",
-        "type": "<T>(array : [T]) : Stack<T>"
-      },
-      {
-        "name": "fromIter",
-        "type": "<T>(iter : Iter.Iter<T>) : Stack<T>"
-      },
-      {
-        "name": "fromVarArray",
-        "type": "<T>(array : [var T]) : Stack<T>"
-      },
-      {
-        "name": "generate",
-        "type": "<T>(n : Nat, f : Nat -> T) : Stack<T>"
-      },
-      {
-        "name": "get",
-        "type": "<T>(stack : Stack<T>, n : Nat) : ?T"
-      },
-      {
-        "name": "isEmpty",
-        "type": "(stack : Stack<Any>) : Bool"
-      },
-      {
-        "name": "last",
-        "type": "<T>(stack : Stack<T>) : ?T"
-      },
-      {
-        "name": "map",
-        "type": "<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>"
-      },
-      {
-        "name": "mapResult",
-        "type": "<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>"
-      },
-      {
-        "name": "merge",
-        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>"
-      },
-      {
-        "name": "partition",
-        "type": "<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)"
-      },
-      {
-        "name": "pop",
-        "type": "<T>(stack : Stack<T>) : (?T, Stack<T>)"
-      },
-      {
-        "name": "push",
-        "type": "<T>(stack : Stack<T>, item : T) : Stack<T>"
-      },
-      {
-        "name": "repeat",
-        "type": "<T>(item : T, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "reverse",
-        "type": "<T>(stack : Stack<T>) : Stack<T>"
-      },
-      {
-        "name": "singleton",
-        "type": "<T>(item : T) : Stack<T>"
-      },
-      {
-        "name": "size",
-        "type": "(stack : Stack<Any>) : Nat"
-      },
-      {
-        "name": "split",
-        "type": "<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)"
-      },
-      {
-        "name": "take",
-        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
-      },
-      {
-        "name": "toArray",
-        "type": "<T>(stack : Stack<T>) : [T]"
-      },
-      {
-        "name": "toText",
-        "type": "<T>(stack : Stack<T>, f : T -> Text) : Text"
-      },
-      {
-        "name": "toVarArray",
-        "type": "<T>(stack : Stack<T>) : [var T]"
-      },
-      {
-        "name": "values",
-        "type": "<T>(stack : Stack<T>) : Iter.Iter<T>"
-      },
-      {
-        "name": "zip",
-        "type": "<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>"
-      },
-      {
-        "name": "zipWith",
-        "type": "<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
-      }
+    "exports": [
+      "public func all<T>(stack : Stack<T>, f : T -> Bool) : Bool",
+      "public func any<T>(stack : Stack<T>, f : T -> Bool) : Bool",
+      "public func chunks<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>",
+      "public func compare<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func concat<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>",
+      "public func contains<T>(stack : Stack<T>, item : T) : Bool",
+      "public func drop<T>(stack : Stack<T>, n : Nat) : Stack<T>",
+      "public func empty<T>() : Stack<T>",
+      "public func equal<T>(stack1 : Stack<T>, stack2 : Stack<T>, equal : (T, T) -> Bool) : Bool",
+      "public func filter<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>",
+      "public func filterMap<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>",
+      "public func find<T>(stack : Stack<T>, f : T -> Bool) : ?T",
+      "public func flatten<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>",
+      "public func foldLeft<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A",
+      "public func foldRight<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A",
+      "public func forEach<T>(stack : Stack<T>, f : T -> ())",
+      "public func fromArray<T>(array : [T]) : Stack<T>",
+      "public func fromIter<T>(iter : Iter.Iter<T>) : Stack<T>",
+      "public func fromVarArray<T>(array : [var T]) : Stack<T>",
+      "public func generate<T>(n : Nat, f : Nat -> T) : Stack<T>",
+      "public func get<T>(stack : Stack<T>, n : Nat) : ?T",
+      "public func isEmpty(stack : Stack<Any>) : Bool",
+      "public func last<T>(stack : Stack<T>) : ?T",
+      "public func map<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>",
+      "public func mapResult<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>",
+      "public func merge<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>",
+      "public func partition<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)",
+      "public func pop<T>(stack : Stack<T>) : (?T, Stack<T>)",
+      "public func push<T>(stack : Stack<T>, item : T) : Stack<T>",
+      "public func repeat<T>(item : T, n : Nat) : Stack<T>",
+      "public func reverse<T>(stack : Stack<T>) : Stack<T>",
+      "public func singleton<T>(item : T) : Stack<T>",
+      "public func size(stack : Stack<Any>) : Nat",
+      "public func split<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)",
+      "public func take<T>(stack : Stack<T>, n : Nat) : Stack<T>",
+      "public func toArray<T>(stack : Stack<T>) : [T]",
+      "public func toText<T>(stack : Stack<T>, f : T -> Text) : Text",
+      "public func toVarArray<T>(stack : Stack<T>) : [var T]",
+      "public func values<T>(stack : Stack<T>) : Iter.Iter<T>",
+      "public func zip<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>",
+      "public func zipWith<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
     ]
   }
 ]

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1,0 +1,4392 @@
+[
+  {
+    "name": "Array",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(array : [T], predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(array : [T], predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "append",
+        "type": "<T>(array1 : [T], array2 : [T]) : [T]"
+      },
+      {
+        "name": "chain",
+        "type": "<T, Y>(array : [T], k : T -> [Y]) : [Y]"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(array1 : [T], array2 : [T], compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : [T]"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(array1 : [T], array2 : [T], equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(array : [T], f : T -> Bool) : [T]"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, Y>(array : [T], f : T -> ?Y) : [Y]"
+      },
+      {
+        "name": "find",
+        "type": "<T>(array : [T], predicate : T -> Bool) : ?T"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(arrays : Iter.Iter<[T]>) : [T]"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>(array : [T], base : A, combine : (A, T) -> A) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>(array : [T], base : A, combine : (T, A) -> A) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(array : [T], f : T -> ())"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : [T]"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "<T>(varArray : [var T]) : [T]"
+      },
+      {
+        "name": "generate",
+        "type": "<T>(size : Nat, generator : Nat -> T) : [T]"
+      },
+      {
+        "name": "indexOf",
+        "type": "<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "init",
+        "type": "<T>(size : Nat, initValue : T) : [T]"
+      },
+      {
+        "name": "isEmpty",
+        "type": "<T>(array : [T]) : Bool"
+      },
+      {
+        "name": "keys",
+        "type": "<T>(array : [T]) : Iter.Iter<Nat>"
+      },
+      {
+        "name": "lastIndexOf",
+        "type": "<T>(element : T, array : [T], equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "map",
+        "type": "<T, Y>(array : [T], f : T -> Y) : [Y]"
+      },
+      {
+        "name": "mapEntries",
+        "type": "<T, Y>(array : [T], f : (T, Nat) -> Y) : [Y]"
+      },
+      {
+        "name": "mapResult",
+        "type": "<T, Y, E>(array : [T], f : T -> Result.Result<Y, E>) : Result.Result<[Y], E>"
+      },
+      {
+        "name": "nextIndexOf",
+        "type": "<T>(element : T, array : [T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "prevIndexOf",
+        "type": "<T>(element : T, array : [T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "reverse",
+        "type": "<T>(array : [T]) : [T]"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(element : T) : [T]"
+      },
+      {
+        "name": "size",
+        "type": "<T>(array : [T]) : Nat"
+      },
+      {
+        "name": "slice",
+        "type": "<T>(array : [T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>"
+      },
+      {
+        "name": "sort",
+        "type": "<T>(array : [T], compare : (T, T) -> Order.Order) : [T]"
+      },
+      {
+        "name": "subArray",
+        "type": "<T>(array : [T], start : Nat, length : Nat) : [T]"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(array : [T], f : T -> Text) : Text"
+      },
+      {
+        "name": "toVarArray",
+        "type": "<T>(array : [T]) : [var T]"
+      },
+      {
+        "name": "values",
+        "type": "<T>(array : [T]) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "Blob",
+    "functions": [
+      {
+        "name": "compare",
+        "type": "(b1 : Blob, b2 : Blob) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "empty",
+        "type": "() : Blob"
+      },
+      {
+        "name": "equal",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "fromArray",
+        "type": "(bytes : [Nat8]) : Blob"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "(bytes : [var Nat8]) : Blob"
+      },
+      {
+        "name": "greater",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "hash",
+        "type": "(blob : Blob) : Nat32"
+      },
+      {
+        "name": "less",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "notEqual",
+        "type": "(blob1 : Blob, blob2 : Blob) : Bool"
+      },
+      {
+        "name": "size",
+        "type": "(blob : Blob) : Nat"
+      },
+      {
+        "name": "toArray",
+        "type": "(blob : Blob) : [Nat8]"
+      },
+      {
+        "name": "toVarArray",
+        "type": "(blob : Blob) : [var Nat8]"
+      }
+    ]
+  },
+  {
+    "name": "Bool",
+    "functions": [
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Bool>"
+      },
+      {
+        "name": "compare",
+        "type": "(a : Bool, b : Bool) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "equal",
+        "type": "(a : Bool, b : Bool) : Bool"
+      },
+      {
+        "name": "logicalAnd",
+        "type": "(a : Bool, b : Bool) : Bool"
+      },
+      {
+        "name": "logicalNot",
+        "type": "(bool : Bool) : Bool"
+      },
+      {
+        "name": "logicalOr",
+        "type": "(a : Bool, b : Bool) : Bool"
+      },
+      {
+        "name": "logicalXor",
+        "type": "(a : Bool, b : Bool) : Bool"
+      },
+      {
+        "name": "toText",
+        "type": "(bool : Bool) : Text"
+      }
+    ]
+  },
+  {
+    "name": "CertifiedData",
+    "functions": [
+      {
+        "name": "getCertificate",
+        "type": ": () -> ?Blob"
+      },
+      {
+        "name": "set",
+        "type": ": (data : Blob) -> ()"
+      }
+    ]
+  },
+  {
+    "name": "Char",
+    "functions": [
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Char>"
+      },
+      {
+        "name": "compare",
+        "type": "(a : Char, b : Char) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "equal",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "fromNat32",
+        "type": ": (nat32 : Nat32) -> Char"
+      },
+      {
+        "name": "greater",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "isAlphabetic",
+        "type": ": (char : Char) -> Bool"
+      },
+      {
+        "name": "isDigit",
+        "type": "(char : Char) : Bool"
+      },
+      {
+        "name": "isLower",
+        "type": ": (char : Char) -> Bool"
+      },
+      {
+        "name": "isUpper",
+        "type": ": (char : Char) -> Bool"
+      },
+      {
+        "name": "isWhitespace",
+        "type": ": (char : Char) -> Bool"
+      },
+      {
+        "name": "less",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "notEqual",
+        "type": "(a : Char, b : Char) : Bool"
+      },
+      {
+        "name": "toLower",
+        "type": ": (char : Char) -> Char"
+      },
+      {
+        "name": "toNat32",
+        "type": ": (char : Char) -> Nat32"
+      },
+      {
+        "name": "toText",
+        "type": ": (char : Char) -> Text"
+      },
+      {
+        "name": "toUpper",
+        "type": ": (char : Char) -> Char"
+      }
+    ]
+  },
+  {
+    "name": "Cycles",
+    "functions": [
+      {
+        "name": "accept",
+        "type": ": <system>(amount : Nat) -> (accepted : Nat)"
+      },
+      {
+        "name": "add",
+        "type": ": <system>(amount : Nat) -> ()"
+      },
+      {
+        "name": "available",
+        "type": ": () -> (amount : Nat)"
+      },
+      {
+        "name": "balance",
+        "type": ": () -> (amount : Nat)"
+      },
+      {
+        "name": "refunded",
+        "type": ": () -> (amount : Nat)"
+      }
+    ]
+  },
+  {
+    "name": "Debug",
+    "functions": [
+      {
+        "name": "print",
+        "type": "(text : Text)"
+      },
+      {
+        "name": "todo",
+        "type": "() : None"
+      }
+    ]
+  },
+  {
+    "name": "Error",
+    "functions": [
+      {
+        "name": "code",
+        "type": ": (error : Error) -> ErrorCode"
+      },
+      {
+        "name": "message",
+        "type": ": (error : Error) -> Text"
+      },
+      {
+        "name": "reject",
+        "type": ": (message : Text) -> Error"
+      }
+    ]
+  },
+  {
+    "name": "Float",
+    "functions": [
+      {
+        "name": "abs",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "add",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "arccos",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "arcsin",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "arctan",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "arctan2",
+        "type": ": (y : Float, x : Float) -> Float"
+      },
+      {
+        "name": "ceil",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Float, y : Float) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "copySign",
+        "type": ": (x : Float, y : Float) -> Float"
+      },
+      {
+        "name": "cos",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "div",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "e",
+        "type": ": Float"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "equalWithin",
+        "type": "(x : Float, y : Float, epsilon : Float) : Bool"
+      },
+      {
+        "name": "exp",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "floor",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "format",
+        "type": "(fmt : { #fix : Nat8; #exp : Nat8; #gen : Nat8; #exact }, x : Float) : Text"
+      },
+      {
+        "name": "fromInt",
+        "type": ": Int -> Float"
+      },
+      {
+        "name": "fromInt64",
+        "type": ": Int64 -> Float"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "isNaN",
+        "type": "(number : Float) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "log",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "max",
+        "type": ": (x : Float, y : Float) -> Float"
+      },
+      {
+        "name": "min",
+        "type": ": (x : Float, y : Float) -> Float"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "nearest",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Float) : Float"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Float, y : Float) : Bool"
+      },
+      {
+        "name": "notEqualWithin",
+        "type": "(x : Float, y : Float, epsilon : Float) : Bool"
+      },
+      {
+        "name": "pi",
+        "type": ": Float"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "sin",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "sqrt",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Float, y : Float) : Float"
+      },
+      {
+        "name": "tan",
+        "type": ": (x : Float) -> Float"
+      },
+      {
+        "name": "toInt",
+        "type": ": Float -> Int"
+      },
+      {
+        "name": "toInt64",
+        "type": ": Float -> Int64"
+      },
+      {
+        "name": "toText",
+        "type": ": Float -> Text"
+      },
+      {
+        "name": "trunc",
+        "type": ": (x : Float) -> Float"
+      }
+    ]
+  },
+  {
+    "name": "Func",
+    "functions": [
+      {
+        "name": "compose",
+        "type": "<A, B, C>(f : B -> C, g : A -> B) : A -> C"
+      },
+      {
+        "name": "const",
+        "type": "<A, B>(x : A) : B -> A"
+      },
+      {
+        "name": "identity",
+        "type": "<A>(x : A) : A"
+      }
+    ]
+  },
+  {
+    "name": "Hash",
+    "functions": [
+      {
+        "name": "bit",
+        "type": "(hash : Hash, pos : Nat) : Bool"
+      },
+      {
+        "name": "debugPrintBits",
+        "type": "(bits : Hash)"
+      },
+      {
+        "name": "debugPrintBitsRev",
+        "type": "(bits : Hash)"
+      },
+      {
+        "name": "equal",
+        "type": "(hash1 : Hash, hash2 : Hash) : Bool"
+      },
+      {
+        "name": "hash",
+        "type": "(nat : Nat) : Hash"
+      },
+      {
+        "name": "length",
+        "type": ": Nat"
+      }
+    ]
+  },
+  {
+    "name": "Int",
+    "functions": [
+      {
+        "name": "abs",
+        "type": "(x : Int) : Nat"
+      },
+      {
+        "name": "add",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Int, y : Int) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "hash",
+        "type": "(i : Int) : Hash.Hash"
+      },
+      {
+        "name": "less",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "min",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Int) : Int"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Int, y : Int) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int, toExclusive : Int) : Iter.Iter<Int>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Int, to : Int) : Iter.Iter<Int>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Int, y : Int) : Int"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Int) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Int16",
+    "functions": [
+      {
+        "name": "abs",
+        "type": "(x : Int16) : Int16"
+      },
+      {
+        "name": "add",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Int16>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Int16, p : Nat) : Int16"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Int16) -> Int16"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Int16) -> Int16"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Int16) -> Int16"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Int16, p : Nat) : Int16"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Int16) : Int16"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Int16, p : Nat) : Int16"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Int16, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Int16, y : Int16) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "fromInt",
+        "type": ": Int -> Int16"
+      },
+      {
+        "name": "fromInt32",
+        "type": ": Int32 -> Int16"
+      },
+      {
+        "name": "fromInt8",
+        "type": ": Int8 -> Int16"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Int16"
+      },
+      {
+        "name": "fromNat16",
+        "type": ": Nat16 -> Int16"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Int16"
+      },
+      {
+        "name": "min",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "minValue",
+        "type": ": Int16"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Int16) : Int16"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Int16, y : Int16) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int16, toExclusive : Int16) : Iter.Iter<Int16>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Int16, to : Int16) : Iter.Iter<Int16>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Int16, y : Int16) : Int16"
+      },
+      {
+        "name": "toInt",
+        "type": ": Int16 -> Int"
+      },
+      {
+        "name": "toInt32",
+        "type": ": Int16 -> Int32"
+      },
+      {
+        "name": "toInt8",
+        "type": ": Int16 -> Int8"
+      },
+      {
+        "name": "toNat16",
+        "type": ": Int16 -> Nat16"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Int16) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Int32",
+    "functions": [
+      {
+        "name": "abs",
+        "type": "(x : Int32) : Int32"
+      },
+      {
+        "name": "add",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Int32>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Int32, p : Nat) : Int32"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Int32) -> Int32"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Int32) -> Int32"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Int32) -> Int32"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Int32, p : Nat) : Int32"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Int32) : Int32"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Int32, p : Nat) : Int32"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Int32, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Int32, y : Int32) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "fromInt",
+        "type": ": Int -> Int32"
+      },
+      {
+        "name": "fromInt16",
+        "type": ": Int16 -> Int32"
+      },
+      {
+        "name": "fromInt64",
+        "type": ": Int64 -> Int32"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Int32"
+      },
+      {
+        "name": "fromNat32",
+        "type": ": Nat32 -> Int32"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Int32"
+      },
+      {
+        "name": "min",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "minValue",
+        "type": ": Int32"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Int32) : Int32"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Int32, y : Int32) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int32, toExclusive : Int32) : Iter.Iter<Int32>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Int32, to : Int32) : Iter.Iter<Int32>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Int32, y : Int32) : Int32"
+      },
+      {
+        "name": "toInt",
+        "type": ": Int32 -> Int"
+      },
+      {
+        "name": "toInt16",
+        "type": ": Int32 -> Int16"
+      },
+      {
+        "name": "toInt64",
+        "type": ": Int32 -> Int64"
+      },
+      {
+        "name": "toNat32",
+        "type": ": Int32 -> Nat32"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Int32) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Int64",
+    "functions": [
+      {
+        "name": "abs",
+        "type": "(x : Int64) : Int64"
+      },
+      {
+        "name": "add",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Int64>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Int64, p : Nat) : Int64"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Int64) -> Int64"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Int64) -> Int64"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Int64) -> Int64"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Int64, p : Nat) : Int64"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Int64) : Int64"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Int64, p : Nat) : Int64"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Int64, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Int64, y : Int64) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "fromInt",
+        "type": ": Int -> Int64"
+      },
+      {
+        "name": "fromInt32",
+        "type": ": Int32 -> Int64"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Int64"
+      },
+      {
+        "name": "fromNat64",
+        "type": ": Nat64 -> Int64"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Int64"
+      },
+      {
+        "name": "min",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "minValue",
+        "type": ": Int64"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Int64) : Int64"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Int64, y : Int64) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int64, toExclusive : Int64) : Iter.Iter<Int64>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Int64, to : Int64) : Iter.Iter<Int64>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Int64, y : Int64) : Int64"
+      },
+      {
+        "name": "toInt",
+        "type": ": Int64 -> Int"
+      },
+      {
+        "name": "toInt32",
+        "type": ": Int64 -> Int32"
+      },
+      {
+        "name": "toNat64",
+        "type": ": Int64 -> Nat64"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Int64) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Int8",
+    "functions": [
+      {
+        "name": "abs",
+        "type": "(x : Int8) : Int8"
+      },
+      {
+        "name": "add",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Int8>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Int8, p : Nat) : Int8"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Int8) -> Int8"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Int8) -> Int8"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Int8) -> Int8"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Int8, p : Nat) : Int8"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Int8) : Int8"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Int8, p : Nat) : Int8"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Int8, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Int8, y : Int8) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "fromInt",
+        "type": ": Int -> Int8"
+      },
+      {
+        "name": "fromInt16",
+        "type": ": Int16 -> Int8"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Int8"
+      },
+      {
+        "name": "fromNat8",
+        "type": ": Nat8 -> Int8"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Int8"
+      },
+      {
+        "name": "min",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "minValue",
+        "type": ": Int8"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "neg",
+        "type": "(x : Int8) : Int8"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Int8, y : Int8) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int8, toExclusive : Int8) : Iter.Iter<Int8>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Int8, to : Int8) : Iter.Iter<Int8>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Int8, y : Int8) : Int8"
+      },
+      {
+        "name": "toInt",
+        "type": ": Int8 -> Int"
+      },
+      {
+        "name": "toInt16",
+        "type": ": Int8 -> Int16"
+      },
+      {
+        "name": "toNat8",
+        "type": ": Int8 -> Nat8"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Int8) : Text"
+      }
+    ]
+  },
+  {
+    "name": "InternetComputer",
+    "functions": [
+      {
+        "name": "call",
+        "type": ": (canister : Principal, name : Text, data : Blob) -> async (reply : Blob)"
+      },
+      {
+        "name": "countInstructions",
+        "type": "(comp : () -> ()) : Nat64"
+      },
+      {
+        "name": "performanceCounter",
+        "type": ": (counter : Nat32) -> (value: Nat64)"
+      },
+      {
+        "name": "replyDeadline",
+        "type": "() : Nat"
+      }
+    ]
+  },
+  {
+    "name": "Iter",
+    "functions": [
+      {
+        "name": "concat",
+        "type": "<T>(a : Iter<T>, b : Iter<T>) : Iter<T>"
+      },
+      {
+        "name": "concatAll",
+        "type": "<T>(iters : [Iter<T>]) : Iter<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Iter<T>"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(iter : Iter<T>, f : T -> Bool) : Iter<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T1, T2>(iter : Iter<T1>, f : T1 -> ?T2) : Iter<T2>"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(iter : Iter<T>, f : (T, Nat) -> ())"
+      },
+      {
+        "name": "fromArray",
+        "type": "<T>(array : [T]) : Iter<T>"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "<T>(array : [var T]) : Iter<T>"
+      },
+      {
+        "name": "infinite",
+        "type": "<T>(x : T) : Iter<T>"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(iter : Iter<T1>, f : T1 -> T2) : Iter<T2>"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Int, toExclusive : Int)"
+      },
+      {
+        "name": "rangeRev",
+        "type": "(fromInclusive : Int, toExclusive : Int)"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(x : T) : Iter<T>"
+      },
+      {
+        "name": "size",
+        "type": "<T>(iter : Iter<T>) : Nat"
+      },
+      {
+        "name": "sort",
+        "type": "<T>(iter : Iter<T>, compare : (T, T) -> Order.Order) : Iter<T>"
+      },
+      {
+        "name": "toArray",
+        "type": "<T>(iter : Iter<T>) : [T]"
+      },
+      {
+        "name": "toVarArray",
+        "type": "<T>(iter : Iter<T>) : [var T]"
+      }
+    ]
+  },
+  {
+    "name": "IterType",
+    "functions": []
+  },
+  {
+    "name": "List",
+    "functions": [
+      {
+        "name": "add",
+        "type": "<T>(list : List<T>, item : T) : ()"
+      },
+      {
+        "name": "all",
+        "type": "<T>(list : List<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(list : List<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "binarySearch",
+        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order, element : T) : ?Nat"
+      },
+      {
+        "name": "chunk",
+        "type": "<T>(list : List<T>, size : Nat) : List<List<T>>"
+      },
+      {
+        "name": "clone",
+        "type": "<T>(list : List<T>) : List<T>"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "containsAll",
+        "type": "<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "distinct",
+        "type": "<T>(list : List<T>, equal : (T, T) -> Bool) : List<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : List<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(list1 : List<T>, list2 : List<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(list : List<T>, predicate : T -> Bool) : List<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T1, T2>(list : List<T1>, f : T1 -> ?T2) : List<T2>"
+      },
+      {
+        "name": "first",
+        "type": "<T>(list : List<T>) : T"
+      },
+      {
+        "name": "flatMap",
+        "type": "<T1, T2>(list : List<T1>, k : T1 -> Iter.Iter<T2>) : List<T2>"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(lists : Iter.Iter<List<T>>) : List<T>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<A, T>(list : List<T>, base : A, combine : (A, T) -> A) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>(list : List<T>, base : A, combine : (T, A) -> A) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(list : List<T>, f : T -> ())"
+      },
+      {
+        "name": "fromArray",
+        "type": "<T>(array : [T]) : List<T>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : { next : () -> ?T }) : List<T>"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "<T>(array : [var T]) : List<T>"
+      },
+      {
+        "name": "hash",
+        "type": "<T>(list : List<T>, hash : T -> Nat32) : Nat32"
+      },
+      {
+        "name": "indexOf",
+        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "indexOfList",
+        "type": "<T>(list : List<T>, subList : List<T>, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(list : List<Any>) : Bool"
+      },
+      {
+        "name": "isPrefixOf",
+        "type": "<T>(list : List<T>, prefix : List<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "isSuffixOf",
+        "type": "<T>(list : List<T>, suffix : List<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "last",
+        "type": "<T>(list : List<T>) : T"
+      },
+      {
+        "name": "lastIndexOf",
+        "type": "<T>(list : List<T>, element : T, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2>"
+      },
+      {
+        "name": "mapEntries",
+        "type": "<T1, T2>(list : List<T1>, f : (Nat, T1) -> T2) : List<T2>"
+      },
+      {
+        "name": "mapResult",
+        "type": "<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E>"
+      },
+      {
+        "name": "max",
+        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "merge",
+        "type": "<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : List<T>"
+      },
+      {
+        "name": "min",
+        "type": "<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "partition",
+        "type": "<T>(list : List<T>, predicate : T -> Bool) : (List<T>, List<T>)"
+      },
+      {
+        "name": "prefix",
+        "type": "<T>(list : List<T>, length : Nat) : List<T>"
+      },
+      {
+        "name": "put",
+        "type": "<T>(list : List<T>, index : Nat, item : T) : ()"
+      },
+      {
+        "name": "removeLast",
+        "type": "<T>(list : List<T>) : ?T"
+      },
+      {
+        "name": "reverse",
+        "type": "<T>(list : List<T>)"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(element : T) : List<T>"
+      },
+      {
+        "name": "size",
+        "type": "(list : List<Any>) : Bool"
+      },
+      {
+        "name": "split",
+        "type": "<T>(list : List<T>, index : Nat) : (List<T>, List<T>)"
+      },
+      {
+        "name": "subList",
+        "type": "<T>(list : List<T>, start : Nat, length : Nat) : List<T>"
+      },
+      {
+        "name": "suffix",
+        "type": "<T>(list : List<T>, length : Nat) : List<T>"
+      },
+      {
+        "name": "toArray",
+        "type": "<T>(list : List<T>) : [T]"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(list : List<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "toVarArray",
+        "type": "<T>(list : List<T>) : [var T]"
+      },
+      {
+        "name": "values",
+        "type": "<T>(list : List<T>) : Iter.Iter<T>"
+      },
+      {
+        "name": "zip",
+        "type": "<T1, T2>(list1 : List<T1>, list2 : List<T2>) : List<(T1, T2)>"
+      },
+      {
+        "name": "zipWith",
+        "type": "<T1, T2, Z>(list1 : List<T1>, list2 : List<T2>, zip : (T1, T2) -> Z) : List<Z>"
+      }
+    ]
+  },
+  {
+    "name": "Map",
+    "functions": [
+      {
+        "name": "add",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ()"
+      },
+      {
+        "name": "all",
+        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
+      },
+      {
+        "name": "assertValid",
+        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()"
+      },
+      {
+        "name": "clone",
+        "type": "<K, V>(map : Map<K, V>) : Map<K, V>"
+      },
+      {
+        "name": "compare",
+        "type": "<K, V>(map1 : Map<K, V>, map2 : Map<K, V>, compareKey : (K, K) -> Order.Order, compareValue : (V, V) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "containsKey",
+        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool"
+      },
+      {
+        "name": "delete",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ()"
+      },
+      {
+        "name": "empty",
+        "type": "<K, V>() : Map<K, V>"
+      },
+      {
+        "name": "entries",
+        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
+      },
+      {
+        "name": "equal",
+        "type": "<K, V>(map1 : Map<K, V>, map2 : Map<K, V>) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<K, V>(map : Map<K, V>, f : (K, V) -> Bool) : Map<K, V>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<K, V>(map : Map<K, V>, f : (K, V) -> ())"
+      },
+      {
+        "name": "freeze",
+        "type": "<K, V>(map : Map<K, V>) : Immutable.Map<K, V>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>"
+      },
+      {
+        "name": "get",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(map : Map<Any, Any>) : Bool"
+      },
+      {
+        "name": "keys",
+        "type": "<K>(map : Map<K, Any>) : Iter.Iter<K>"
+      },
+      {
+        "name": "map",
+        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>"
+      },
+      {
+        "name": "maxEntry",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
+      },
+      {
+        "name": "minEntry",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
+      },
+      {
+        "name": "put",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V"
+      },
+      {
+        "name": "replaceIfExists",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : ?V"
+      },
+      {
+        "name": "reverseEntries",
+        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
+      },
+      {
+        "name": "singleton",
+        "type": "<K, V>(key : K, value : V) : Map<K, V>"
+      },
+      {
+        "name": "size",
+        "type": "(map : Map<Any, Any>) : Nat"
+      },
+      {
+        "name": "thaw",
+        "type": "<K, V>(map : Immutable.Map<K, V>) : Map<K, V>"
+      },
+      {
+        "name": "toText",
+        "type": "<K, V>(map : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<V>(map : Map<Any, V>) : Iter.Iter<V>"
+      }
+    ]
+  },
+  {
+    "name": "Nat",
+    "functions": [
+      {
+        "name": "add",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Nat>"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Nat, y : Nat32) : Nat"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Nat, y : Nat32) : Nat"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Nat, y : Nat) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "fromInt",
+        "type": "(i : Int) : ?Nat"
+      },
+      {
+        "name": "fromText",
+        "type": "(text : Text) : ?Nat"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "min",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Nat, y : Nat) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Nat, toExclusive : Nat) : Iter.Iter<Nat>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Nat, to : Nat) : Iter.Iter<Nat>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Nat, y : Nat) : Nat"
+      },
+      {
+        "name": "toText",
+        "type": "(n : Nat) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Nat16",
+    "functions": [
+      {
+        "name": "add",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Nat16>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Nat16, p : Nat) : Nat16"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Nat16) -> Nat16"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Nat16) -> Nat16"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Nat16) -> Nat16"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Nat16, p : Nat) : Nat16"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Nat16) : Nat16"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Nat16, p : Nat) : Nat16"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Nat16, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Nat16, y : Nat16) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Nat16"
+      },
+      {
+        "name": "fromNat",
+        "type": ": Nat -> Nat16"
+      },
+      {
+        "name": "fromNat32",
+        "type": "(x : Nat32) : Nat16"
+      },
+      {
+        "name": "fromNat8",
+        "type": "(x : Nat8) : Nat16"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Nat16"
+      },
+      {
+        "name": "min",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Nat16, y : Nat16) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Nat16, toExclusive : Nat16) : Iter.Iter<Nat16>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Nat16, to : Nat16) : Iter.Iter<Nat16>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Nat16, y : Nat16) : Nat16"
+      },
+      {
+        "name": "toNat",
+        "type": ": Nat16 -> Nat"
+      },
+      {
+        "name": "toNat32",
+        "type": "(x : Nat16) : Nat32"
+      },
+      {
+        "name": "toNat8",
+        "type": "(x : Nat16) : Nat8"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Nat16) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Nat32",
+    "functions": [
+      {
+        "name": "add",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Nat32>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Nat32, p : Nat) : Nat32"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Nat32) -> Nat32"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Nat32) -> Nat32"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Nat32) -> Nat32"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Nat32, p : Nat) : Nat32"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Nat32) : Nat32"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Nat32, p : Nat) : Nat32"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Nat32, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Nat32, y : Nat32) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Nat32"
+      },
+      {
+        "name": "fromNat",
+        "type": ": Nat -> Nat32"
+      },
+      {
+        "name": "fromNat16",
+        "type": "(x : Nat16) : Nat32"
+      },
+      {
+        "name": "fromNat64",
+        "type": "(x : Nat64) : Nat32"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Nat32"
+      },
+      {
+        "name": "min",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Nat32, y : Nat32) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Nat32, toExclusive : Nat32) : Iter.Iter<Nat32>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Nat32, to : Nat32) : Iter.Iter<Nat32>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Nat32, y : Nat32) : Nat32"
+      },
+      {
+        "name": "toNat",
+        "type": ": Nat32 -> Nat"
+      },
+      {
+        "name": "toNat16",
+        "type": "(x : Nat32) : Nat16"
+      },
+      {
+        "name": "toNat64",
+        "type": "(x : Nat32) : Nat64"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Nat32) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Nat64",
+    "functions": [
+      {
+        "name": "add",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Nat64>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Nat64, p : Nat) : Nat64"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Nat64) -> Nat64"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Nat64) -> Nat64"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Nat64) -> Nat64"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Nat64, p : Nat) : Nat64"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Nat64) : Nat64"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Nat64, p : Nat) : Nat64"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Nat64, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Nat64, y : Nat64) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Nat64"
+      },
+      {
+        "name": "fromNat",
+        "type": ": Nat -> Nat64"
+      },
+      {
+        "name": "fromNat32",
+        "type": "(x : Nat32) : Nat64"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Nat64"
+      },
+      {
+        "name": "min",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Nat64, y : Nat64) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Nat64, toExclusive : Nat64) : Iter.Iter<Nat64>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Nat64, to : Nat64) : Iter.Iter<Nat64>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Nat64, y : Nat64) : Nat64"
+      },
+      {
+        "name": "toNat",
+        "type": ": Nat64 -> Nat"
+      },
+      {
+        "name": "toNat32",
+        "type": "(x : Nat64) : Nat32"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Nat64) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Nat8",
+    "functions": [
+      {
+        "name": "add",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "addWrap",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Nat8>"
+      },
+      {
+        "name": "bitand",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bitclear",
+        "type": "(x : Nat8, p : Nat) : Nat8"
+      },
+      {
+        "name": "bitcountLeadingZero",
+        "type": ": (x : Nat8) -> Nat8"
+      },
+      {
+        "name": "bitcountNonZero",
+        "type": ": (x : Nat8) -> Nat8"
+      },
+      {
+        "name": "bitcountTrailingZero",
+        "type": ": (x : Nat8) -> Nat8"
+      },
+      {
+        "name": "bitflip",
+        "type": "(x : Nat8, p : Nat) : Nat8"
+      },
+      {
+        "name": "bitnot",
+        "type": "(x : Nat8) : Nat8"
+      },
+      {
+        "name": "bitor",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bitrotLeft",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bitrotRight",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bitset",
+        "type": "(x : Nat8, p : Nat) : Nat8"
+      },
+      {
+        "name": "bitshiftLeft",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bitshiftRight",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "bittest",
+        "type": "(x : Nat8, p : Nat) : Bool"
+      },
+      {
+        "name": "bitxor",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "compare",
+        "type": "(x : Nat8, y : Nat8) : { #less; #equal; #greater }"
+      },
+      {
+        "name": "div",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "equal",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "fromIntWrap",
+        "type": ": Int -> Nat8"
+      },
+      {
+        "name": "fromNat",
+        "type": ": Nat -> Nat8"
+      },
+      {
+        "name": "fromNat16",
+        "type": ": Nat16 -> Nat8"
+      },
+      {
+        "name": "greater",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "less",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "max",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "maxValue",
+        "type": ": Nat8"
+      },
+      {
+        "name": "min",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "mul",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "mulWrap",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "notEqual",
+        "type": "(x : Nat8, y : Nat8) : Bool"
+      },
+      {
+        "name": "pow",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "powWrap",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "range",
+        "type": "(fromInclusive : Nat8, toExclusive : Nat8) : Iter.Iter<Nat8>"
+      },
+      {
+        "name": "rangeInclusive",
+        "type": "(from : Nat8, to : Nat8) : Iter.Iter<Nat8>"
+      },
+      {
+        "name": "rem",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "sub",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "subWrap",
+        "type": "(x : Nat8, y : Nat8) : Nat8"
+      },
+      {
+        "name": "toNat",
+        "type": ": Nat8 -> Nat"
+      },
+      {
+        "name": "toNat16",
+        "type": ": Nat8 -> Nat16"
+      },
+      {
+        "name": "toText",
+        "type": "(x : Nat8) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Option",
+    "functions": [
+      {
+        "name": "apply",
+        "type": "<A, B>(x : ?A, f : ?(A -> B)) : ?B"
+      },
+      {
+        "name": "assertNull",
+        "type": "(x : ?Any)"
+      },
+      {
+        "name": "assertSome",
+        "type": "(x : ?Any)"
+      },
+      {
+        "name": "chain",
+        "type": "<A, B>(x : ?A, f : A -> ?B) : ?B"
+      },
+      {
+        "name": "equal",
+        "type": "<A>(x : ?A, y : ?A, eq : (A, A) -> Bool) : Bool"
+      },
+      {
+        "name": "flatten",
+        "type": "<A>(x : ??A) : ?A"
+      },
+      {
+        "name": "forEach",
+        "type": "<A>(x : ?A, f : A -> ())"
+      },
+      {
+        "name": "get",
+        "type": "<T>(x : ?T, default : T) : T"
+      },
+      {
+        "name": "getMapped",
+        "type": "<A, B>(x : ?A, f : A -> B, default : B) : B"
+      },
+      {
+        "name": "isNull",
+        "type": "(x : ?Any) : Bool"
+      },
+      {
+        "name": "isSome",
+        "type": "(x : ?Any) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "<A, B>(x : ?A, f : A -> B) : ?B"
+      },
+      {
+        "name": "some",
+        "type": "<A>(x : A) : ?A"
+      },
+      {
+        "name": "unwrap",
+        "type": "<T>(x : ?T) : T"
+      }
+    ]
+  },
+  {
+    "name": "Order",
+    "functions": [
+      {
+        "name": "allValues",
+        "type": "() : Iter.Iter<Order>"
+      },
+      {
+        "name": "equal",
+        "type": "(o1 : Order, o2 : Order) : Bool"
+      }
+    ]
+  },
+  {
+    "name": "Principal",
+    "functions": [
+      {
+        "name": "anonymous",
+        "type": "() : Principal"
+      },
+      {
+        "name": "compare",
+        "type": "(principal1 : Principal, principal2 : Principal) : Order.Order"
+      },
+      {
+        "name": "equal",
+        "type": "(principal1 : Principal, principal2 : Principal) : Bool"
+      },
+      {
+        "name": "fromActor",
+        "type": "(a : actor"
+      },
+      {
+        "name": "fromBlob",
+        "type": "(b : Blob) : Principal"
+      },
+      {
+        "name": "fromText",
+        "type": "(t : Text) : Principal"
+      },
+      {
+        "name": "hash",
+        "type": "(principal : Principal) : Hash.Hash"
+      },
+      {
+        "name": "isAnonymous",
+        "type": "(p : Principal) : Bool"
+      },
+      {
+        "name": "isController",
+        "type": "(p : Principal) : Bool"
+      },
+      {
+        "name": "toBlob",
+        "type": "(p : Principal) : Blob"
+      },
+      {
+        "name": "toLedgerAccount",
+        "type": "(principal : Principal, subAccount : ?Blob) : Blob"
+      },
+      {
+        "name": "toText",
+        "type": "(p : Principal) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Queue",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "clone",
+        "type": "<T>(queue : Queue<T>) : Queue<T>"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(queue : Queue<T>, item : T) : Bool"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Queue<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(queue : Queue<T>, f : T -> ())"
+      },
+      {
+        "name": "freeze",
+        "type": "<T>(queue : Queue<T>) : Immutable.Queue<T>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : Queue<T>"
+      },
+      {
+        "name": "isEmpty",
+        "type": "<T>(queue : Queue<T>) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>"
+      },
+      {
+        "name": "peekBack",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "peekFront",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "pop",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "popBack",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "popFront",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "push",
+        "type": "<T>(queue : Queue<T>, element : T) : ()"
+      },
+      {
+        "name": "pushBack",
+        "type": "<T>(queue : Queue<T>, element : T) : ()"
+      },
+      {
+        "name": "pushFront",
+        "type": "<T>(queue : Queue<T>, element : T) : ()"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(item : T) : Queue<T>"
+      },
+      {
+        "name": "size",
+        "type": "<T>(queue : Queue<T>) : Nat"
+      },
+      {
+        "name": "thaw",
+        "type": "<T>(queue : Immutable.Queue<T>) : Queue<T>"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(queue : Queue<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<T>(queue : Queue<T>) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "Random",
+    "functions": [
+      {
+        "name": "AsyncRandom",
+        "type": "(generator : () -> async* Blob)"
+      },
+      {
+        "name": "blob",
+        "type": ": shared () -> async Blob"
+      },
+      {
+        "name": "bool",
+        "type": "() : Bool"
+      },
+      {
+        "name": "bool",
+        "type": "() : async* Bool"
+      },
+      {
+        "name": "byte",
+        "type": "() : Nat8"
+      },
+      {
+        "name": "byte",
+        "type": "() : async* Nat8"
+      },
+      {
+        "name": "float",
+        "type": "() : Float"
+      },
+      {
+        "name": "float",
+        "type": "() : async* Float"
+      },
+      {
+        "name": "intRange",
+        "type": "(min : Int, maxExclusive : Int) : Int"
+      },
+      {
+        "name": "intRange",
+        "type": "(min : Int, maxExclusive : Int) : async* Int"
+      },
+      {
+        "name": "natRange",
+        "type": "(min : Nat, maxExclusive : Nat) : Nat"
+      },
+      {
+        "name": "natRange",
+        "type": "(min : Nat, maxExclusive : Nat) : async* Nat"
+      },
+      {
+        "name": "new",
+        "type": "(seed : Blob) : Random"
+      },
+      {
+        "name": "newAsync",
+        "type": "() : AsyncRandom"
+      },
+      {
+        "name": "Random",
+        "type": "(generator : () -> Blob)"
+      }
+    ]
+  },
+  {
+    "name": "Region",
+    "functions": [
+      {
+        "name": "grow",
+        "type": ": (region : Region, newPages : Nat64) -> (oldPages : Nat64)"
+      },
+      {
+        "name": "id",
+        "type": ": Region -> Nat"
+      },
+      {
+        "name": "loadBlob",
+        "type": ": (region : Region, offset : Nat64, size : Nat) -> Blob"
+      },
+      {
+        "name": "loadFloat",
+        "type": ": (region : Region, offset : Nat64) -> Float"
+      },
+      {
+        "name": "loadInt16",
+        "type": ": (region : Region, offset : Nat64) -> Int16"
+      },
+      {
+        "name": "loadInt32",
+        "type": ": (region : Region, offset : Nat64) -> Int32"
+      },
+      {
+        "name": "loadInt64",
+        "type": ": (region : Region, offset : Nat64) -> Int64"
+      },
+      {
+        "name": "loadInt8",
+        "type": ": (region : Region, offset : Nat64) -> Int8"
+      },
+      {
+        "name": "loadNat16",
+        "type": ": (region : Region, offset : Nat64) -> Nat16"
+      },
+      {
+        "name": "loadNat32",
+        "type": ": (region : Region, offset : Nat64) -> Nat32"
+      },
+      {
+        "name": "loadNat64",
+        "type": ": (region : Region, offset : Nat64) -> Nat64"
+      },
+      {
+        "name": "loadNat8",
+        "type": ": (region : Region, offset : Nat64) -> Nat8"
+      },
+      {
+        "name": "new",
+        "type": ": () -> Region"
+      },
+      {
+        "name": "size",
+        "type": ": (region : Region) -> (pages : Nat64)"
+      },
+      {
+        "name": "storeBlob",
+        "type": ": (region : Region, offset : Nat64, value : Blob) -> ()"
+      },
+      {
+        "name": "storeFloat",
+        "type": ": (region: Region, offset : Nat64, value : Float) -> ()"
+      },
+      {
+        "name": "storeInt16",
+        "type": ": (region : Region, offset : Nat64, value : Int16) -> ()"
+      },
+      {
+        "name": "storeInt32",
+        "type": ": (region : Region, offset : Nat64, value : Int32) -> ()"
+      },
+      {
+        "name": "storeInt64",
+        "type": ": (region : Region, offset : Nat64, value : Int64) -> ()"
+      },
+      {
+        "name": "storeInt8",
+        "type": ": (region : Region, offset : Nat64, value : Int8) -> ()"
+      },
+      {
+        "name": "storeNat16",
+        "type": ": (region : Region, offset : Nat64, value : Nat16) -> ()"
+      },
+      {
+        "name": "storeNat32",
+        "type": ": (region : Region, offset : Nat64, value : Nat32) -> ()"
+      },
+      {
+        "name": "storeNat64",
+        "type": ": (region : Region, offset : Nat64, value : Nat64) -> ()"
+      },
+      {
+        "name": "storeNat8",
+        "type": ": (region : Region, offset : Nat64, value : Nat8) -> ()"
+      }
+    ]
+  },
+  {
+    "name": "Result",
+    "functions": [
+      {
+        "name": "assertErr",
+        "type": "(result : Result<Any, Any>)"
+      },
+      {
+        "name": "assertOk",
+        "type": "(result : Result<Any, Any>)"
+      },
+      {
+        "name": "chain",
+        "type": "<R1, R2, Error>( result : Result<R1, Error>, y : R1 -> Result<R2, Error> ) : Result<R2, Error>"
+      },
+      {
+        "name": "compare",
+        "type": "<R, E>( compareOk : (R, R) -> Order.Order, compareErr : (E, E) -> Order.Order, r1 : Result<R, E>, r2 : Result<R, E> ) : Order.Order"
+      },
+      {
+        "name": "equal",
+        "type": "<R, E>( eqOk : (R, R) -> Bool, eqErr : (E, E) -> Bool, r1 : Result<R, E>, r2 : Result<R, E> ) : Bool"
+      },
+      {
+        "name": "flatten",
+        "type": "<R, E>( result : Result<Result<R, E>, E> ) : Result<R, E>"
+      },
+      {
+        "name": "forEach",
+        "type": "<R, E>(result : Result<R, E>, f : R -> ())"
+      },
+      {
+        "name": "fromOption",
+        "type": "<R, E>(ok : ?R, err : E) : Result<R, E>"
+      },
+      {
+        "name": "fromUpper",
+        "type": "<R, E>( result : { #Ok : R; #Err : E } ) : Result<R, E>"
+      },
+      {
+        "name": "mapErr",
+        "type": "<R, E1, E2>( result : Result<R, E1>, f : E1 -> E2 ) : Result<R, E2>"
+      },
+      {
+        "name": "mapOk",
+        "type": "<R1, R2, E>( result : Result<R1, E>, f : R1 -> R2 ) : Result<R2, E>"
+      },
+      {
+        "name": "toOption",
+        "type": "<R, E>(result : Result<R, E>) : ?R"
+      },
+      {
+        "name": "toUpper",
+        "type": "<R, E>( result : Result<R, E> ) : { #Ok : R; #Err : E }"
+      }
+    ]
+  },
+  {
+    "name": "Runtime",
+    "functions": [
+      {
+        "name": "trap",
+        "type": "(errorMessage : Text) : None"
+      },
+      {
+        "name": "unreachable",
+        "type": "() : None"
+      }
+    ]
+  },
+  {
+    "name": "Set",
+    "functions": [
+      {
+        "name": "add",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : ()"
+      },
+      {
+        "name": "all",
+        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
+      },
+      {
+        "name": "assertValid",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ()"
+      },
+      {
+        "name": "clone",
+        "type": "<T>(set : Set<T>) : Set<T>"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
+      },
+      {
+        "name": "delete",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
+      },
+      {
+        "name": "diff",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Set<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(set : Set<T>, f : T -> Bool) : Set<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(set : Iter.Iter<Set<T>>) : Set<T>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(set : Set<T>, f : T -> ())"
+      },
+      {
+        "name": "freeze",
+        "type": "<T>(set : Set<T>) : Immutable.Set<T>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>"
+      },
+      {
+        "name": "intersect",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(set : Set<Any>) : Bool"
+      },
+      {
+        "name": "isSubset",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>"
+      },
+      {
+        "name": "max",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "min",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "reverseValues",
+        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>() : Set<T>"
+      },
+      {
+        "name": "size",
+        "type": "(set : Set<Any>) : Nat"
+      },
+      {
+        "name": "thaw",
+        "type": "<T>(set : Immutable.Set<T>) : Set<T>"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(set : Set<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "union",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "values",
+        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "Stack",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
+      },
+      {
+        "name": "chunks",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>"
+      },
+      {
+        "name": "clone",
+        "type": "<T>(stack : Stack<T>) : Stack<T>"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "concat",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(stack : Stack<T>, item : T) : Bool"
+      },
+      {
+        "name": "drop",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Stack<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>"
+      },
+      {
+        "name": "find",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : ?T"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(stack : Stack<T>, f : T -> ())"
+      },
+      {
+        "name": "freeze",
+        "type": "<T>(stack : Stack<T>) : Immutable.Stack<T>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : Stack<T>"
+      },
+      {
+        "name": "generate",
+        "type": "<T>(n : Nat, f : Nat -> T) : Stack<T>"
+      },
+      {
+        "name": "get",
+        "type": "<T>(stack : Stack<T>, n : Nat) : ?T"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(stack : Stack<Any>) : Bool"
+      },
+      {
+        "name": "last",
+        "type": "<T>(stack : Stack<T>) : ?T"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>"
+      },
+      {
+        "name": "mapResult",
+        "type": "<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>"
+      },
+      {
+        "name": "merge",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>"
+      },
+      {
+        "name": "partition",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)"
+      },
+      {
+        "name": "pop",
+        "type": "<T>(stack : Stack<T>) : ?T"
+      },
+      {
+        "name": "push",
+        "type": "<T>(stack : Stack<T>, item : T) : ()"
+      },
+      {
+        "name": "repeat",
+        "type": "<T>(item : T, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "reverse",
+        "type": "<T>(stack : Stack<T>) : ()"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(item : T) : Stack<T>"
+      },
+      {
+        "name": "size",
+        "type": "(stack : Stack<Any>) : Nat"
+      },
+      {
+        "name": "split",
+        "type": "<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)"
+      },
+      {
+        "name": "take",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "thaw",
+        "type": "<T>(stack : Immutable.Stack<T>) : Stack<T>"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(stack : Stack<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<T>(stack : Stack<T>) : Iter.Iter<T>"
+      },
+      {
+        "name": "zip",
+        "type": "<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>"
+      },
+      {
+        "name": "zipWith",
+        "type": "<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
+      }
+    ]
+  },
+  {
+    "name": "Text",
+    "functions": [
+      {
+        "name": "chars",
+        "type": "(t : Text) : Iter.Iter<Char>"
+      },
+      {
+        "name": "compare",
+        "type": "(t1 : Text, t2 : Text) : Order.Order"
+      },
+      {
+        "name": "compareWith",
+        "type": "( t1 : Text, t2 : Text, cmp : (Char, Char) -> Order.Order ) : Order.Order"
+      },
+      {
+        "name": "concat",
+        "type": "(t1 : Text, t2 : Text) : Text"
+      },
+      {
+        "name": "concatAll",
+        "type": "(ts : [Text]) : Text"
+      },
+      {
+        "name": "contains",
+        "type": "(t : Text, p : Pattern) : Bool"
+      },
+      {
+        "name": "decodeUtf8",
+        "type": ": Blob -> ?Text"
+      },
+      {
+        "name": "encodeUtf8",
+        "type": ": Text -> Blob"
+      },
+      {
+        "name": "endsWith",
+        "type": "(t : Text, p : Pattern) : Bool"
+      },
+      {
+        "name": "equal",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "flatMap",
+        "type": "(t : Text, f : Char -> Text) : Text"
+      },
+      {
+        "name": "fromArray",
+        "type": "(a : [Char]) : Text"
+      },
+      {
+        "name": "fromChar",
+        "type": ": (c : Char) -> Text"
+      },
+      {
+        "name": "fromIter",
+        "type": "(cs : Iter.Iter<Char>) : Text"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "(a : [var Char]) : Text"
+      },
+      {
+        "name": "greater",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "greaterOrEqual",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "hash",
+        "type": "(t : Text) : Hash.Hash"
+      },
+      {
+        "name": "join",
+        "type": "(sep : Text, ts : Iter.Iter<Text>) : Text"
+      },
+      {
+        "name": "less",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "lessOrEqual",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "(t : Text, f : Char -> Char) : Text"
+      },
+      {
+        "name": "notEqual",
+        "type": "(t1 : Text, t2 : Text) : Bool"
+      },
+      {
+        "name": "replace",
+        "type": "(t : Text, p : Pattern, r : Text) : Text"
+      },
+      {
+        "name": "size",
+        "type": "(t : Text) : Nat"
+      },
+      {
+        "name": "split",
+        "type": "(t : Text, p : Pattern) : Iter.Iter<Text>"
+      },
+      {
+        "name": "startsWith",
+        "type": "(t : Text, p : Pattern) : Bool"
+      },
+      {
+        "name": "stripEnd",
+        "type": "(t : Text, p : Pattern) : ?Text"
+      },
+      {
+        "name": "stripStart",
+        "type": "(t : Text, p : Pattern) : ?Text"
+      },
+      {
+        "name": "toArray",
+        "type": "(t : Text) : [Char]"
+      },
+      {
+        "name": "tokens",
+        "type": "(t : Text, p : Pattern) : Iter.Iter<Text>"
+      },
+      {
+        "name": "toLower",
+        "type": ": Text -> Text"
+      },
+      {
+        "name": "toUpper",
+        "type": ": Text -> Text"
+      },
+      {
+        "name": "toVarArray",
+        "type": "(t : Text) : [var Char]"
+      },
+      {
+        "name": "trim",
+        "type": "(t : Text, p : Pattern) : Text"
+      },
+      {
+        "name": "trimEnd",
+        "type": "(t : Text, p : Pattern) : Text"
+      },
+      {
+        "name": "trimStart",
+        "type": "(t : Text, p : Pattern) : Text"
+      }
+    ]
+  },
+  {
+    "name": "Time",
+    "functions": [
+      {
+        "name": "cancelTimer",
+        "type": ": TimerId -> ()"
+      },
+      {
+        "name": "now",
+        "type": ": () -> Time"
+      },
+      {
+        "name": "recurringTimer",
+        "type": "<system>(duration : Duration, job : () -> async ()) : TimerId"
+      },
+      {
+        "name": "setTimer",
+        "type": "<system>(duration : Duration, job : () -> async ()) : TimerId"
+      },
+      {
+        "name": "toNanoseconds",
+        "type": "(duration : Duration) : Nat"
+      }
+    ]
+  },
+  {
+    "name": "VarArray",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(array : [var T], predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(array : [var T], predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "append",
+        "type": "<T>(array1 : [var T], array2 : [var T]) : [var T]"
+      },
+      {
+        "name": "chain",
+        "type": "<T, Y>(array : [var T], k : T -> [var Y]) : [var Y]"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(array1 : [var T], array2 : [var T], compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : [var T]"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(array1 : [var T], array2 : [var T], equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(array : [var T], f : T -> Bool) : [var T]"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, Y>(array : [var T], f : T -> ?Y) : [var Y]"
+      },
+      {
+        "name": "find",
+        "type": "<T>(array : [var T], predicate : T -> Bool) : ?T"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(arrays : Iter.Iter<[var T]>) : [var T]"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>(array : [var T], base : A, combine : (A, T) -> A) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>(array : [var T], base : A, combine : (T, A) -> A) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(array : [var T], f : T -> ())"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : [var T]"
+      },
+      {
+        "name": "generate",
+        "type": "<T>(size : Nat, generator : Nat -> T) : [var T]"
+      },
+      {
+        "name": "indexOf",
+        "type": "<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "init",
+        "type": "<T>(size : Nat, initValue : T) : [var T]"
+      },
+      {
+        "name": "isEmpty",
+        "type": "<T>(array : [var T]) : Bool"
+      },
+      {
+        "name": "keys",
+        "type": "<T>(array : [var T]) : Iter.Iter<Nat>"
+      },
+      {
+        "name": "lastIndexOf",
+        "type": "<T>(element : T, array : [var T], equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "map",
+        "type": "<T, Y>(array : [var T], f : T -> Y) : [var Y]"
+      },
+      {
+        "name": "mapEntries",
+        "type": "<T, Y>(array : [var T], f : (T, Nat) -> Y) : [var Y]"
+      },
+      {
+        "name": "mapResult",
+        "type": "<T, Y, E>(array : [var T], f : T -> Result.Result<Y, E>) : Result.Result<[var Y], E>"
+      },
+      {
+        "name": "nextIndexOf",
+        "type": "<T>(element : T, array : [var T], fromInclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "prevIndexOf",
+        "type": "<T>(element : T, array : [var T], fromExclusive : Nat, equal : (T, T) -> Bool) : ?Nat"
+      },
+      {
+        "name": "reverse",
+        "type": "<T>(array : [var T]) : [var T]"
+      },
+      {
+        "name": "reverseInPlace",
+        "type": "<T>(array : [var T]) : ()"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(element : T) : [var T]"
+      },
+      {
+        "name": "size",
+        "type": "<T>(array : [var T]) : Nat"
+      },
+      {
+        "name": "slice",
+        "type": "<T>(array : [var T], fromInclusive : Int, toExclusive : Int) : Iter.Iter<T>"
+      },
+      {
+        "name": "sort",
+        "type": "<T>(array : [var T], compare : (T, T) -> Order.Order) : [var T]"
+      },
+      {
+        "name": "sortInPlace",
+        "type": "<T>(array : [var T], compare : (T, T) -> Order.Order) : ()"
+      },
+      {
+        "name": "subArray",
+        "type": "<T>(array : [var T], start : Nat, length : Nat) : [var T]"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(array : [var T], f : T -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<T>(array : [var T]) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "immutable/Map",
+    "functions": [
+      {
+        "name": "add",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : Map<K, V>"
+      },
+      {
+        "name": "all",
+        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<K, V>(map : Map<K, V>, pred : (K, V) -> Bool) : Bool"
+      },
+      {
+        "name": "assertValid",
+        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order) : ()"
+      },
+      {
+        "name": "containsKey",
+        "type": "<K>(map : Map<K, Any>, compare : (K, K) -> Order.Order, key : K) : Bool"
+      },
+      {
+        "name": "delete",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : Map<K, V>"
+      },
+      {
+        "name": "empty",
+        "type": "<K, V>() : Map<K, V>"
+      },
+      {
+        "name": "entries",
+        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> ?V2) : Map<K, V2>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (A, K, V) -> A ) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<K, V, A>( map : Map<K, V>, base : A, combine : (K, V, A) -> A ) : A"
+      },
+      {
+        "name": "fromIter",
+        "type": "<K, V>(iter : Iter.Iter<(K, V)>, compare : (K, K) -> Order.Order) : Map<K, V>"
+      },
+      {
+        "name": "get",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : ?V"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(map : Map<Any, Any>) : Bool"
+      },
+      {
+        "name": "keys",
+        "type": "<K>(map : Map<K, Any>) : Iter.Iter<K>"
+      },
+      {
+        "name": "map",
+        "type": "<K, V1, V2>(map : Map<K, V1>, f : (K, V1) -> V2) : Map<K, V2>"
+      },
+      {
+        "name": "maxEntry",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
+      },
+      {
+        "name": "minEntry",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order) : ?(K, V)"
+      },
+      {
+        "name": "put",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K, value : V) : (Map<K, V>, ?V)"
+      },
+      {
+        "name": "reverseEntries",
+        "type": "<K, V>(map : Map<K, V>) : Iter.Iter<(K, V)>"
+      },
+      {
+        "name": "size",
+        "type": "(map : Map<Any, Any>) : Nat"
+      },
+      {
+        "name": "take",
+        "type": "<K, V>(map : Map<K, V>, compare : (K, K) -> Order.Order, key : K) : (Map<K, V>, ?V)"
+      },
+      {
+        "name": "toText",
+        "type": "<K, V>(set : Map<K, V>, kf : K -> Text, vf : V -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<V>(map : Map<Any, V>) : Iter.Iter<V>"
+      }
+    ]
+  },
+  {
+    "name": "immutable/Queue",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(queue : Queue<T>, predicate : T -> Bool) : Bool"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(queue : Queue<T>, item : T) : Bool"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Queue<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(queue : Queue<T>, f : T -> ())"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : Queue<T>"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(queue : Queue<Any>) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>"
+      },
+      {
+        "name": "peekBack",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "peekFront",
+        "type": "<T>(queue : Queue<T>) : ?T"
+      },
+      {
+        "name": "popBack",
+        "type": "<T>(queue : Queue<T>) : ?(Queue<T>, T)"
+      },
+      {
+        "name": "popFront",
+        "type": "<T>(queue : Queue<T>) : ?(T, Queue<T>)"
+      },
+      {
+        "name": "pushBack",
+        "type": "<T>(queue : Queue<T>, element : T) : Queue<T>"
+      },
+      {
+        "name": "pushFront",
+        "type": "<T>(queue : Queue<T>, element : T) : Queue<T>"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(item : T) : Queue<T>"
+      },
+      {
+        "name": "size",
+        "type": "(queue : Queue<Any>) : Nat"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(queue : Queue<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "values",
+        "type": "<T>(queue : Queue<T>) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "immutable/Set",
+    "functions": [
+      {
+        "name": "add",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>"
+      },
+      {
+        "name": "all",
+        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(set : Set<T>, pred : T -> Bool) : Bool"
+      },
+      {
+        "name": "assertValid",
+        "type": "(set : Set<Any>) : ()"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Bool"
+      },
+      {
+        "name": "delete",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order, item : T) : Set<T>"
+      },
+      {
+        "name": "diff",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Set<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(set : Set<T>, f : T -> Bool) : Set<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T1, T2>(set : Set<T1>, f : T1 -> ?T2) : Set<T2>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>( set : Set<T>, base : A, combine : (A, T) -> A ) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(set : Set<T>, f : T -> ())"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>, compare : (T, T) -> Order.Order) : Set<T>"
+      },
+      {
+        "name": "intersect",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "isEmpty",
+        "type": "<T>(set : Set<T>) : Bool"
+      },
+      {
+        "name": "isSubset",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Bool"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(set : Set<T1>, f : T1 -> T2) : Set<T2>"
+      },
+      {
+        "name": "max",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "min",
+        "type": "<T>(set : Set<T>, compare : (T, T) -> Order.Order) : ?T"
+      },
+      {
+        "name": "reverseValues",
+        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(item : T) : Set<T>"
+      },
+      {
+        "name": "size",
+        "type": "<T>(set : Set<T>) : Nat"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(set : Set<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "union",
+        "type": "<T>(set1 : Set<T>, set2 : Set<T>) : Set<T>"
+      },
+      {
+        "name": "values",
+        "type": "<T>(set : Set<T>) : Iter.Iter<T>"
+      }
+    ]
+  },
+  {
+    "name": "immutable/Stack",
+    "functions": [
+      {
+        "name": "all",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
+      },
+      {
+        "name": "any",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Bool"
+      },
+      {
+        "name": "chunks",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<Stack<T>>"
+      },
+      {
+        "name": "compare",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, compare : (T, T) -> Order.Order) : Order.Order"
+      },
+      {
+        "name": "concat",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>) : Stack<T>"
+      },
+      {
+        "name": "contains",
+        "type": "<T>(stack : Stack<T>, item : T) : Bool"
+      },
+      {
+        "name": "drop",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "empty",
+        "type": "<T>() : Stack<T>"
+      },
+      {
+        "name": "equal",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, equal : (T, T) -> Bool) : Bool"
+      },
+      {
+        "name": "filter",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : Stack<T>"
+      },
+      {
+        "name": "filterMap",
+        "type": "<T, U>(stack : Stack<T>, f : T -> ?U) : Stack<U>"
+      },
+      {
+        "name": "find",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : ?T"
+      },
+      {
+        "name": "flatten",
+        "type": "<T>(stack : Iter.Iter<Stack<T>>) : Stack<T>"
+      },
+      {
+        "name": "foldLeft",
+        "type": "<T, A>(stack : Stack<T>, base : A, combine : (A, T) -> A) : A"
+      },
+      {
+        "name": "foldRight",
+        "type": "<T, A>(stack : Stack<T>, base : A, combine : (T, A) -> A) : A"
+      },
+      {
+        "name": "forEach",
+        "type": "<T>(stack : Stack<T>, f : T -> ())"
+      },
+      {
+        "name": "fromArray",
+        "type": "<T>(array : [T]) : Stack<T>"
+      },
+      {
+        "name": "fromIter",
+        "type": "<T>(iter : Iter.Iter<T>) : Stack<T>"
+      },
+      {
+        "name": "fromVarArray",
+        "type": "<T>(array : [var T]) : Stack<T>"
+      },
+      {
+        "name": "generate",
+        "type": "<T>(n : Nat, f : Nat -> T) : Stack<T>"
+      },
+      {
+        "name": "get",
+        "type": "<T>(stack : Stack<T>, n : Nat) : ?T"
+      },
+      {
+        "name": "isEmpty",
+        "type": "(stack : Stack<Any>) : Bool"
+      },
+      {
+        "name": "last",
+        "type": "<T>(stack : Stack<T>) : ?T"
+      },
+      {
+        "name": "map",
+        "type": "<T1, T2>(stack : Stack<T1>, f : T1 -> T2) : Stack<T2>"
+      },
+      {
+        "name": "mapResult",
+        "type": "<T, R, E>(stack : Stack<T>, f : T -> Result.Result<R, E>) : Result.Result<Stack<R>, E>"
+      },
+      {
+        "name": "merge",
+        "type": "<T>(stack1 : Stack<T>, stack2 : Stack<T>, lessThanOrEqual : (T, T) -> Bool) : Stack<T>"
+      },
+      {
+        "name": "partition",
+        "type": "<T>(stack : Stack<T>, f : T -> Bool) : (Stack<T>, Stack<T>)"
+      },
+      {
+        "name": "pop",
+        "type": "<T>(stack : Stack<T>) : (?T, Stack<T>)"
+      },
+      {
+        "name": "push",
+        "type": "<T>(stack : Stack<T>, item : T) : Stack<T>"
+      },
+      {
+        "name": "repeat",
+        "type": "<T>(item : T, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "reverse",
+        "type": "<T>(stack : Stack<T>) : Stack<T>"
+      },
+      {
+        "name": "singleton",
+        "type": "<T>(item : T) : Stack<T>"
+      },
+      {
+        "name": "size",
+        "type": "(stack : Stack<Any>) : Nat"
+      },
+      {
+        "name": "split",
+        "type": "<T>(stack : Stack<T>, n : Nat) : (Stack<T>, Stack<T>)"
+      },
+      {
+        "name": "take",
+        "type": "<T>(stack : Stack<T>, n : Nat) : Stack<T>"
+      },
+      {
+        "name": "toArray",
+        "type": "<T>(stack : Stack<T>) : [T]"
+      },
+      {
+        "name": "toText",
+        "type": "<T>(stack : Stack<T>, f : T -> Text) : Text"
+      },
+      {
+        "name": "toVarArray",
+        "type": "<T>(stack : Stack<T>) : [var T]"
+      },
+      {
+        "name": "values",
+        "type": "<T>(stack : Stack<T>) : Iter.Iter<T>"
+      },
+      {
+        "name": "zip",
+        "type": "<T, U>(stack1 : Stack<T>, stack2 : Stack<U>) : Stack<(T, U)>"
+      },
+      {
+        "name": "zipWith",
+        "type": "<T, U, V>(stack1 : Stack<T>, stack2 : Stack<U>, f : (T, U) -> V) : Stack<V>"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds a lockfile system which ensures that the PR does not modify the public API (`npm run validate` to override). This is intended as a sanity check for copy/pasting large amounts of code from the original base library. It currently uses a hacky regex parser, but we could eventually make this more sophisticated if it ends up being useful enough to keep post-release.

A secondary use case of this lockfile is that we can also generate one for the original base library and view the diff between the APIs as a resource for migration / documentation.