### PR TITLE
bugfix: fix broken Set.clone

### DIFF
--- a/src/Map.mo
+++ b/src/Map.mo
@@ -2109,14 +2109,14 @@ module {
   // Additional functionality compared to original source.
 
   func mapData<K, V1, V2>(data : Data<K, V1>, project : (K, V1) -> V2) : Data<K, V2> {
-      { kvs = VarArray.map<?(K, V1), ?(K, V2)>(
-         data.kvs,
-         func entry {
-	   switch entry {
-             case (?kv) ?(kv.0, project kv);
-	     case null null;
-	   }});
-        var count = data.count };
+    { kvs = VarArray.map<?(K, V1), ?(K, V2)>(
+      data.kvs,
+      func entry {
+      switch entry {
+        case (?kv) ?(kv.0, project kv);
+        case null null;
+      }});
+      var count = data.count };
   };
 
   func mapNode<K, V1, V2>(node : Node<K, V1>, project : (K, V1) -> V2) : Node<K, V2> {

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -188,7 +188,7 @@ module {
   /// Runtime: `O(1)`.
   /// Space: `O(1)`.
   public func singleton<T>(element : T) : Set<T> {
-    let elements = VarArray.repeat<?(K, V)>(null, btreeOrder - 1);
+    let elements = VarArray.repeat<?T>(null, btreeOrder - 1);
     elements[0] := ?element;
     {
       var root =
@@ -390,7 +390,7 @@ module {
       case (#promote({ element = promotedElement; leftChild; rightChild })) {
         let elements = VarArray.repeat<?T>(null, btreeOrder - 1);
 	elements[0] := ?promotedElement;
-	let children = VarArray.repeat<?T>(null, btreeOrder);
+	let children = VarArray.repeat<?Node<T>>(null, btreeOrder);
 	children[0] := ?leftChild;
 	children[1] := ?rightChild;
         set.root := #internal({

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -2096,15 +2096,19 @@ module {
   };
 
   // Additional functionality compared to original source.
+
+  func cloneData<T>(data : Data<T>) : Data<T> {
+    { elements = VarArray.clone(data.elements);
+      var count = data.count };
+  };
+
   func cloneNode<T>(node : Node<T>) : Node<T> {
     switch node {
-      case (#leaf _) { node };
+      case (#leaf { data }) {
+        #leaf { data = cloneData(data) }
+      };
       case (#internal { data; children }) {
-        let clonedElements = VarArray.map<?T, ?T>(data.elements, func element { element });
-        let clonedData = {
-          elements = clonedElements;
-          var count = data.count
-        };
+        let clonedData = cloneData(data);
         let clonedChildren = VarArray.map<?Node<T>, ?Node<T>>(
           children,
           func child {

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -164,7 +164,7 @@ module {
     {
       var root = #leaf({
         data = {
-          elements = VarArray.tabulate<?T>(btreeOrder - 1, func(index) { null });
+          elements = VarArray.repeat<?T>(null, btreeOrder - 1);
           var count = 0
         }
       });
@@ -188,22 +188,11 @@ module {
   /// Runtime: `O(1)`.
   /// Space: `O(1)`.
   public func singleton<T>(element : T) : Set<T> {
+    let elements = VarArray.repeat<?(K, V)>(null, btreeOrder - 1);
+    elements[0] := ?element;
     {
-      var root = #leaf({
-        data = {
-          elements = VarArray.tabulate<?T>(
-            btreeOrder - 1,
-            func(index) {
-              if (index == 0) {
-                ?element
-              } else {
-                null
-              }
-            }
-          );
-          var count = 1
-        }
-      });
+      var root =
+        #leaf({ data = { elements; var count = 1 } });
       var size = 1
     }
   };
@@ -399,24 +388,14 @@ module {
         // keep size
       };
       case (#promote({ element = promotedElement; leftChild; rightChild })) {
+        let elements = VarArray.repeat<?T>(null, btreeOrder - 1);
+	elements[0] := ?promotedElement;
+	let children = VarArray.repeat<?T>(null, btreeOrder);
+	children[0] := ?leftChild;
+	children[1] := ?rightChild;
         set.root := #internal({
-          data = {
-            elements = VarArray.tabulate<?T>(
-              btreeOrder - 1,
-              func(i) {
-                if (i == 0) { ?promotedElement } else { null }
-              }
-            );
-            var count = 1
-          };
-          children = VarArray.tabulate<?(Node<T>)>(
-            btreeOrder,
-            func(i) {
-              if (i == 0) { ?leftChild } else if (i == 1) { ?rightChild } else {
-                null
-              }
-            }
-          )
+          data = { elements; var count = 1 };
+          children;
         });
         // promotion always comes from inserting a new element, so increment the tree size counter
         set.size += 1

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -306,7 +306,7 @@ run(
           let original = Map.singleton<Nat, Text>(0, "0");
           let clone = Map.clone(original);
           ignore Map.put(original, Nat.compare, 0, "1");
-	  assert (Map.get(clone, Nat.compare, 0) == ?"0");
+          assert (Map.get(clone, Nat.compare, 0) == ?"0");
           Map.size(clone)
         },
         M.equals(T.nat(1))
@@ -709,14 +709,14 @@ run(
           let original = smallMap();
           let copy = smallMap();
           let clone = Map.clone(original);
-	  let keys = Iter.toArray(Map.keys(original));
-	  for (key in keys.values()) {
-            ignore Map.put(original, Nat.compare, 0, "X");
-	  };
-	  for (key in keys.values()) {
+          let keys = Iter.toArray(Map.keys(original));
+          for (key in keys.values()) {
+            ignore Map.put(original, Nat.compare, key, "X");
+          };
+          for (key in keys.values()) {
             assert Map.get(clone, Nat.compare, key) ==
-  	           Map.get(copy, Nat.compare, key)
-	  };
+                   Map.get(copy, Nat.compare, key)
+          };
           Map.size(clone)
         },
         M.equals(T.nat(smallSize))),
@@ -1046,7 +1046,7 @@ run(
             };
             text #= "(" # Nat.toText(index) # ", " # Nat.toText(index) # ")"
           };
-	  text #= "}";
+          text #= "}";
           M.equals(T.text(text))
         }
       ),
@@ -1267,31 +1267,31 @@ run(
        test(
         "add disjoint",
         do {
-	  let map = Map.empty<Nat, Text>();
-	  Map.add(map, Nat.compare, 0, "0");
-	  Map.add(map, Nat.compare, 1, "1");
-	  Map.size(map)
-	},
+          let map = Map.empty<Nat, Text>();
+          Map.add(map, Nat.compare, 0, "0");
+          Map.add(map, Nat.compare, 1, "1");
+          Map.size(map)
+        },
         M.equals(T.nat(2))
       ),
       test(
         "put existing",
         do {
-	  let map = Map.empty<Nat, Text>();
-	  Map.put(map, Nat.compare, 0, "0");
-	  Map.put(map, Nat.compare, 0, "Zero");
-	  Map.get(map, Nat.compare, 0)
-	},
+          let map = Map.empty<Nat, Text>();
+          Map.put(map, Nat.compare, 0, "0");
+          Map.put(map, Nat.compare, 0, "Zero");
+          Map.get(map, Nat.compare, 0)
+        },
         M.equals(T.optional(T.textTestable, ?"Zero"))
       ),
       test(
         "update existing",
         do {
-	  let map = Map.empty<Nat, Text>();
-	  Map.put(map, Nat.compare, 0, "0");
-	  Map.update(map, Nat.compare, 0, "Zero");
-	  Map.get(map, Nat.compare, 0)
-	},
+          let map = Map.empty<Nat, Text>();
+          Map.put(map, Nat.compare, 0, "0");
+          Map.update(map, Nat.compare, 0, "Zero");
+          Map.get(map, Nat.compare, 0)
+        },
         M.equals(T.optional(T.textTestable, ?"Zero"))
       ),
       // TODO: test traps (checked manually)
@@ -1299,21 +1299,21 @@ run(
       test(
         "update absent",
         do {
-	  let map = Map.empty<Nat, Text>();
-	  Map.update(map, Nat.compare, 0, "Zero"); // traps
-	  assert false;
-	  Map.size(map);
-	},
+          let map = Map.empty<Nat, Text>();
+          Map.update(map, Nat.compare, 0, "Zero"); // traps
+          assert false;
+          Map.size(map);
+        },
         M.equals(T.nat(0))
       ),
       test(
         "add existing traps",
         do {
-	  let map = Map.empty<Nat, Text>();
+          let map = Map.empty<Nat, Text>();
           Map.add(map, Nat.compare, 0, "0");
-	  Map.add(map, Nat.compare, 0, "Zero"); // traps
-	  Map.get(map, Nat.compare, 0)
-	},
+          Map.add(map, Nat.compare, 0, "Zero"); // traps
+          Map.get(map, Nat.compare, 0)
+        },
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
       */

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -25,6 +25,17 @@ run(
         M.equals(T.bool(true))
       ),
       test(
+        "clone no alias",
+        do {
+          let original = Set.empty<Nat>();
+          let clone = Set.clone(original);
+          Set.add(original, Nat.compare, 0);
+	  assert Set.size(original) == 1;
+          Set.size(clone)
+        },
+        M.equals(T.nat(0))
+      ),
+      test(
         "clone",
         do {
           let original = Set.empty<Nat>();
@@ -332,6 +343,20 @@ run(
           let original = Set.singleton<Nat>(0);
           let clone = Set.clone(original);
           assert (Set.equal(original, clone, Nat.equal));
+          Set.size(clone)
+        },
+        M.equals(T.nat(1))
+      ),
+      test(
+        "clone no alias",
+        do {
+          let original = Set.singleton<Nat>(0);
+	  assert Set.size(original) == 1;
+          let clone = Set.clone(original);
+          Set.delete(original, Nat.compare, 0);
+	  assert Set.size(original) == 0;
+  	  assert not Set.contains(original, Nat.compare, 0);
+	  assert Set.contains(clone, Nat.compare, 0);
           Set.size(clone)
         },
         M.equals(T.nat(1))
@@ -816,6 +841,23 @@ run(
         },
         M.equals(T.nat(smallSize))
       ),
+      test(
+        "clone no alias",
+        do {
+          let original = smallSet();
+          let copy = smallSet();
+          let clone = Set.clone(original);
+	  let keys = Iter.toArray(Set.values(original));
+	  for (key in keys.values()) {
+            Set.delete(original, Nat.compare, key);
+	  };
+	  for (key in keys.values()) {
+            assert Set.contains(clone, Nat.compare, key) ==
+  	           Set.contains(copy, Nat.compare, key)
+	  };
+          Set.size(clone)
+        },
+        M.equals(T.nat(smallSize))),
       test(
         "iterate forward",
         Iter.toArray(Set.values(smallSet())),

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -30,7 +30,7 @@ run(
           let original = Set.empty<Nat>();
           let clone = Set.clone(original);
           Set.add(original, Nat.compare, 0);
-	  assert Set.size(original) == 1;
+          assert Set.size(original) == 1;
           Set.size(clone)
         },
         M.equals(T.nat(0))
@@ -351,12 +351,12 @@ run(
         "clone no alias",
         do {
           let original = Set.singleton<Nat>(0);
-	  assert Set.size(original) == 1;
+          assert Set.size(original) == 1;
           let clone = Set.clone(original);
           Set.delete(original, Nat.compare, 0);
-	  assert Set.size(original) == 0;
-  	  assert not Set.contains(original, Nat.compare, 0);
-	  assert Set.contains(clone, Nat.compare, 0);
+          assert Set.size(original) == 0;
+          assert not Set.contains(original, Nat.compare, 0);
+          assert Set.contains(clone, Nat.compare, 0);
           Set.size(clone)
         },
         M.equals(T.nat(1))
@@ -847,14 +847,14 @@ run(
           let original = smallSet();
           let copy = smallSet();
           let clone = Set.clone(original);
-	  let keys = Iter.toArray(Set.values(original));
-	  for (key in keys.values()) {
+          let keys = Iter.toArray(Set.values(original));
+          for (key in keys.values()) {
             Set.delete(original, Nat.compare, key);
-	  };
-	  for (key in keys.values()) {
+          };
+          for (key in keys.values()) {
             assert Set.contains(clone, Nat.compare, key) ==
-  	           Set.contains(copy, Nat.compare, key)
-	  };
+                   Set.contains(copy, Nat.compare, key)
+          };
           Set.size(clone)
         },
         M.equals(T.nat(smallSize))),


### PR DESCRIPTION
Similar to #150 (clone was failing to clone data in #leaf constructors, leading to accidental sharing).

Also, optimise VarArray.tabulate to VarArray.repeat.