### PR TITLE
Rewrite `pure/Queue` tests to use `test` package

### DIFF
--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -24,9 +24,8 @@ import Iter "../Iter";
 import List "List";
 import Order "../Order";
 import Types "../Types";
-import { todo } "../Debug";
 
-module Queue /* FIXME */ {
+module Queue {
   type List<T> = Types.Pure.List<T>;
 
   /// Double-ended queue data type.
@@ -146,7 +145,7 @@ module Queue /* FIXME */ {
     else switch list {
       case null (null, null);
       case (?(h, t)) {
-        let (f, b) = takeDrop(t, n - 1);
+        let (f, b) = takeDrop(t, n - 1 : Nat);
         (?(h, f), b)
       }
     };
@@ -289,8 +288,20 @@ module Queue /* FIXME */ {
   public func values<T>(queue : Queue<T>) : Iter.Iter<T> =
     Iter.concat(List.values(queue.0), List.values(List.reverse(queue.2)));
 
-  public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool {
-    todo()
+  public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>, equal : (T, T) -> Bool) : Bool {
+    if (queue1.1 != queue2.1) {
+      return false;
+    };
+    let (iter1, iter2) = (values(queue1), values(queue2));
+    loop {
+      switch (iter1.next(), iter2.next()) {
+        case (null, null) { return true };
+        case (?v1, ?v2) {
+          if (not equal(v1, v2)) { return false };
+        };
+        case (_, _) { return false };
+      };
+    };
   };
 
   public func all<T>(queue : Queue<T>, predicate : T -> Bool) : Bool {
@@ -322,7 +333,7 @@ module Queue /* FIXME */ {
   };
 
   public func filterMap<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U> {
-    let (fr, n, b) = queue;
+    let (fr, _n, b) = queue;
     let front = List.filterMap(fr, f);
     let back = List.filterMap(b, f);
     (front, List.size front + List.size back, back)

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -1,14 +1,9 @@
-import Suite "mo:matchers/Suite";
-import T "mo:matchers/Testable";
-import M "mo:matchers/Matchers";
-
-import Prim "mo:prim";
 import Queue "../../src/pure/Queue";
 import Array "../../src/Array";
 import Nat "../../src/Nat";
 import Iter "../../src/Iter";
-
-let { run; test; suite } = Suite;
+import Prim "mo:prim";
+import { suite; test; expect } = "mo:test";
 
 func iterateForward<T>(deque : Queue.Queue<T>) : Iter.Iter<T> {
   var current = deque;
@@ -55,35 +50,6 @@ func toText(deque : Queue.Queue<Nat>) : Text {
   text
 };
 
-let natQueueTestable : T.Testable<Queue.Queue<Nat>> = object {
-  public func display(deque : Queue.Queue<Nat>) : Text {
-    toText(deque)
-  };
-  public func equals(first : Queue.Queue<Nat>, second : Queue.Queue<Nat>) : Bool {
-    Array.equal(Iter.toArray(iterateForward(first)), Iter.toArray(iterateForward(second)), Nat.equal)
-  }
-};
-
-func matchFrontRemoval(element : Nat, remainder : Queue.Queue<Nat>) : M.Matcher<?(Nat, Queue.Queue<Nat>)> {
-  let testable = T.tuple2Testable(T.natTestable, natQueueTestable);
-  M.equals(T.optional(testable, ?(element, remainder)))
-};
-
-func matchEmptyFrontRemoval() : M.Matcher<?(Nat, Queue.Queue<Nat>)> {
-  let testable = T.tuple2Testable(T.natTestable, natQueueTestable);
-  M.equals(T.optional(testable, null : ?(Nat, Queue.Queue<Nat>)))
-};
-
-func matchBackRemoval(remainder : Queue.Queue<Nat>, element : Nat) : M.Matcher<?(Queue.Queue<Nat>, Nat)> {
-  let testable = T.tuple2Testable(natQueueTestable, T.natTestable);
-  M.equals(T.optional(testable, ?(remainder, element)))
-};
-
-func matchEmptyBackRemoval() : M.Matcher<?(Queue.Queue<Nat>, Nat)> {
-  let testable = T.tuple2Testable(natQueueTestable, T.natTestable);
-  M.equals(T.optional(testable, null : ?(Queue.Queue<Nat>, Nat)))
-};
-
 func reduceFront<T>(deque : Queue.Queue<T>, amount : Nat) : Queue.Queue<T> {
   var current = deque;
   for (_ in Nat.range(0, amount)) {
@@ -106,101 +72,133 @@ func reduceBack<T>(deque : Queue.Queue<T>, amount : Nat) : Queue.Queue<T> {
   current
 };
 
-/* --------------------------------------- */
-
 var deque = Queue.empty<Nat>();
 
-run(
-  suite(
-    "construct",
-    [
-      test(
-        "empty",
-        Queue.isEmpty(deque),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "iterate forward",
-        Iter.toArray(iterateForward(deque)),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      ),
-      test(
-        "iterate backward",
-        Iter.toArray(iterateBackward(deque)),
-        M.equals(T.array<Nat>(T.natTestable, []))
-      ),
-      test(
-        "peek front",
-        Queue.peekFront(deque),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      ),
-      test(
-        "peek back",
-        Queue.peekBack(deque),
-        M.equals(T.optional(T.natTestable, null : ?Nat))
-      ),
-      test(
-        "pop front",
-        Queue.popFront(deque),
-        matchEmptyFrontRemoval()
-      ),
-      test(
-        "pop back",
-        Queue.popBack(deque),
-        matchEmptyBackRemoval()
-      )
-    ]
-  )
-);
+suite(
+  "construct",
+  func() {
+    test(
+      "empty",
+      func() {
+        expect.bool(Queue.isEmpty(deque)).isTrue()
+      }
+    );
 
-/* --------------------------------------- */
+    test(
+      "iterate forward",
+      func() {
+        expect.array<Nat>(Iter.toArray(iterateForward(deque)), Nat.toText, Nat.equal).size(0)
+      }
+    );
+
+    test(
+      "iterate backward",
+      func() {
+        expect.array(Iter.toArray(iterateBackward(deque)), Nat.toText, Nat.equal).size(0)
+      }
+    );
+
+    test(
+      "peek front",
+      func() {
+        expect.option(Queue.peekFront(deque), Nat.toText, Nat.equal).isNull()
+      }
+    );
+
+    test(
+      "peek back",
+      func() {
+        expect.option(Queue.peekBack(deque), Nat.toText, Nat.equal).isNull()
+      }
+    );
+
+    test(
+      "pop front",
+      func() {
+        expect.option<(Nat, Queue.Queue<Nat>)>(
+          Queue.popFront(deque),
+          func(n, _) = Nat.toText(n),
+          func(a, b) = a.0 == b.0
+        ).isNull()
+      }
+    );
+
+    test(
+      "pop back",
+      func() {
+        expect.option<(Queue.Queue<Nat>, Nat)>(
+          Queue.popBack(deque),
+          func(_, n) = Nat.toText(n),
+          func(a, b) = a.1 == b.1
+        ).isNull()
+      }
+    )
+  }
+);
 
 deque := Queue.pushFront(Queue.empty<Nat>(), 1);
 
-run(
-  suite(
-    "single item",
-    [
-      test(
-        "not empty",
-        Queue.isEmpty(deque),
-        M.equals(T.bool(false))
-      ),
-      test(
-        "iterate forward",
-        Iter.toArray(iterateForward(deque)),
-        M.equals(T.array(T.natTestable, [1]))
-      ),
-      test(
-        "iterate backward",
-        Iter.toArray(iterateBackward(deque)),
-        M.equals(T.array(T.natTestable, [1]))
-      ),
-      test(
-        "peek front",
-        Queue.peekFront(deque),
-        M.equals(T.optional(T.natTestable, ?1))
-      ),
-      test(
-        "peek back",
-        Queue.peekBack(deque),
-        M.equals(T.optional(T.natTestable, ?1))
-      ),
-      test(
-        "pop front",
-        Queue.popFront(deque),
-        matchFrontRemoval(1, Queue.empty())
-      ),
-      test(
-        "pop back",
-        Queue.popBack(deque),
-        matchBackRemoval(Queue.empty(), 1)
-      )
-    ]
-  )
-);
+suite(
+  "single item",
+  func() {
+    test(
+      "not empty",
+      func() {
+        expect.bool(Queue.isEmpty(deque)).isFalse()
+      }
+    );
 
-/* --------------------------------------- */
+    test(
+      "iterate forward",
+      func() {
+        expect.array(Iter.toArray(iterateForward(deque)), Nat.toText, Nat.equal).equal([1])
+      }
+    );
+
+    test(
+      "iterate backward",
+      func() {
+        expect.array(Iter.toArray(iterateBackward(deque)), Nat.toText, Nat.equal).equal([1])
+      }
+    );
+
+    test(
+      "peek front",
+      func() {
+        expect.option(Queue.peekFront(deque), Nat.toText, Nat.equal).equal(?1)
+      }
+    );
+
+    test(
+      "peek back",
+      func() {
+        expect.option(Queue.peekBack(deque), Nat.toText, Nat.equal).equal(?1)
+      }
+    );
+
+    test(
+      "pop front",
+      func() {
+        expect.option<(Nat, Queue.Queue<Nat>)>(
+          Queue.popFront(deque),
+          func(n, _) = Nat.toText(n),
+          func(a, b) = a.0 == b.0
+        ).equal(?(1, Queue.empty()))
+      }
+    );
+
+    test(
+      "pop back",
+      func() {
+        expect.option<(Queue.Queue<Nat>, Nat)>(
+          Queue.popBack(deque),
+          func(_, n) = Nat.toText(n),
+          func(a, b) = a.1 == b.1
+        ).equal(?(Queue.empty(), 1))
+      }
+    )
+  }
+);
 
 let testSize = 100;
 
@@ -214,75 +212,92 @@ func populateForward(from : Nat, to : Nat) : Queue.Queue<Nat> {
 
 deque := populateForward(1, testSize);
 
-run(
-  suite(
-    "forward insertion",
-    [
-      test(
-        "not empty",
-        Queue.isEmpty(deque),
-        M.equals(T.bool(false))
-      ),
-      test(
-        "iterate forward",
-        Iter.toArray(iterateForward(deque)),
-        M.equals(
-          T.array(
-            T.natTestable,
-            Array.tabulate(
-              testSize,
-              func(index : Nat) : Nat {
-                testSize - index
-              }
-            )
-          )
-        )
-      ),
-      test(
-        "iterate backward",
-        Iter.toArray(iterateBackward(deque)),
-        M.equals(
-          T.array(
-            T.natTestable,
-            Array.tabulate(
-              testSize,
-              func(index : Nat) : Nat {
-                index + 1
-              }
-            )
-          )
-        )
-      ),
-      test(
-        "peek front",
-        Queue.peekFront(deque),
-        M.equals(T.optional(T.natTestable, ?testSize))
-      ),
-      test(
-        "peek back",
-        Queue.peekBack(deque),
-        M.equals(T.optional(T.natTestable, ?1))
-      ),
-      test(
-        "pop front",
-        Queue.popFront(deque),
-        matchFrontRemoval(testSize, populateForward(1, testSize - 1))
-      ),
-      test(
-        "empty after front removal",
-        Queue.isEmpty(reduceFront(deque, testSize)),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "empty after front removal",
-        Queue.isEmpty(reduceBack(deque, testSize)),
-        M.equals(T.bool(true))
-      )
-    ]
-  )
-);
+suite(
+  "forward insertion",
+  func() {
+    test(
+      "not empty",
+      func() {
+        expect.bool(Queue.isEmpty(deque)).isFalse()
+      }
+    );
 
-/* --------------------------------------- */
+    test(
+      "iterate forward",
+      func() {
+        expect.array(
+          Iter.toArray(iterateForward(deque)),
+          Nat.toText,
+          Nat.equal
+        ).equal(
+          Array.tabulate(
+            testSize,
+            func(index : Nat) : Nat {
+              testSize - index
+            }
+          )
+        )
+      }
+    );
+
+    test(
+      "iterate backward",
+      func() {
+        expect.array(
+          Iter.toArray(iterateBackward(deque)),
+          Nat.toText,
+          Nat.equal
+        ).equal(
+          Array.tabulate(
+            testSize,
+            func(index : Nat) : Nat {
+              index + 1
+            }
+          )
+        )
+      }
+    );
+
+    test(
+      "peek front",
+      func() {
+        expect.option(Queue.peekFront(deque), Nat.toText, Nat.equal).equal(?testSize)
+      }
+    );
+
+    test(
+      "peek back",
+      func() {
+        expect.option(Queue.peekBack(deque), Nat.toText, Nat.equal).equal(?1)
+      }
+    );
+
+    test(
+      "pop front",
+      func() {
+        expect.option<(Nat, Queue.Queue<Nat>)>(
+          Queue.popFront(deque),
+          func(n, _) = Nat.toText(n),
+          func(a, b) = a.0 == b.0
+        ).equal(?(testSize, populateForward(1, testSize - 1)))
+      }
+    );
+
+    test(
+      "empty after front removal",
+      func() {
+        expect.bool(Queue.isEmpty(reduceFront(deque, testSize))).isTrue()
+      }
+    );
+
+    test(
+      "empty after back removal",
+      func() {
+        expect.bool(Queue.isEmpty(reduceBack(deque, testSize))).isTrue()
+      }
+    )
+  }
+);
 
 func populateBackward(from : Nat, to : Nat) : Queue.Queue<Nat> {
   var deque = Queue.empty<Nat>();
@@ -294,80 +309,103 @@ func populateBackward(from : Nat, to : Nat) : Queue.Queue<Nat> {
 
 deque := populateBackward(1, testSize);
 
-run(
-  suite(
-    "backward insertion",
-    [
-      test(
-        "not empty",
-        Queue.isEmpty(deque),
-        M.equals(T.bool(false))
-      ),
-      test(
-        "iterate forward",
-        Iter.toArray(iterateForward(deque)),
-        M.equals(
-          T.array(
-            T.natTestable,
-            Array.tabulate(
-              testSize,
-              func(index : Nat) : Nat {
-                index + 1
-              }
-            )
-          )
-        )
-      ),
-      test(
-        "iterate backward",
-        Iter.toArray(iterateBackward(deque)),
-        M.equals(
-          T.array(
-            T.natTestable,
-            Array.tabulate(
-              testSize,
-              func(index : Nat) : Nat {
-                testSize - index
-              }
-            )
-          )
-        )
-      ),
-      test(
-        "peek front",
-        Queue.peekFront(deque),
-        M.equals(T.optional(T.natTestable, ?1))
-      ),
-      test(
-        "peek back",
-        Queue.peekBack(deque),
-        M.equals(T.optional(T.natTestable, ?testSize))
-      ),
-      test(
-        "pop front",
-        Queue.popFront(deque),
-        matchFrontRemoval(1, populateBackward(2, testSize))
-      ),
-      test(
-        "pop back",
-        Queue.popBack(deque),
-        matchBackRemoval(populateBackward(1, testSize - 1), testSize)
-      ),
-      test(
-        "empty after front removal",
-        Queue.isEmpty(reduceFront(deque, testSize)),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "empty after front removal",
-        Queue.isEmpty(reduceBack(deque, testSize)),
-        M.equals(T.bool(true))
-      )
-    ]
-  )
-);
+suite(
+  "backward insertion",
+  func() {
+    test(
+      "not empty",
+      func() {
+        expect.bool(Queue.isEmpty(deque)).isFalse()
+      }
+    );
 
-/* --------------------------------------- */
+    test(
+      "iterate forward",
+      func() {
+        expect.array(
+          Iter.toArray(iterateForward(deque)),
+          Nat.toText,
+          Nat.equal
+        ).equal(
+          Array.tabulate(
+            testSize,
+            func(index : Nat) : Nat {
+              index + 1
+            }
+          )
+        )
+      }
+    );
+
+    test(
+      "iterate backward",
+      func() {
+        expect.array(
+          Iter.toArray(iterateBackward(deque)),
+          Nat.toText,
+          Nat.equal
+        ).equal(
+          Array.tabulate(
+            testSize,
+            func(index : Nat) : Nat {
+              testSize - index
+            }
+          )
+        )
+      }
+    );
+
+    test(
+      "peek front",
+      func() {
+        expect.option(Queue.peekFront(deque), Nat.toText, Nat.equal).equal(?1)
+      }
+    );
+
+    test(
+      "peek back",
+      func() {
+        expect.option(Queue.peekBack(deque), Nat.toText, Nat.equal).equal(?testSize)
+      }
+    );
+
+    test(
+      "pop front",
+      func() {
+        expect.option<(Nat, Queue.Queue<Nat>)>(
+          Queue.popFront(deque),
+          func(n, _) = Nat.toText(n),
+          func(a, b) = a.0 == b.0
+        ).equal(?(1, populateBackward(2, testSize)))
+      }
+    );
+
+    test(
+      "pop back",
+      func() {
+        expect.option<(Queue.Queue<Nat>, Nat)>(
+          Queue.popBack(deque),
+          func(_, n) = Nat.toText(n),
+          func(a, b) = a.1 == b.1
+        ).equal(?(populateBackward(1, testSize - 1), testSize))
+      }
+    );
+
+    test(
+      "empty after front removal",
+      func() {
+        expect.bool(Queue.isEmpty(reduceFront(deque, testSize))).isTrue()
+      }
+    );
+
+    test(
+      "empty after back removal",
+      func() {
+        expect.bool(Queue.isEmpty(reduceBack(deque, testSize))).isTrue()
+      }
+    )
+  }
+);
 
 object Random {
   var number = 4711;
@@ -417,55 +455,68 @@ func randomRemoval(deque : Queue.Queue<Nat>, amount : Nat) : Queue.Queue<Nat> {
 
 deque := randomPopulate(testSize);
 
-run(
-  suite(
-    "random insertion",
-    [
-      test(
-        "not empty",
-        Queue.isEmpty(deque),
-        M.equals(T.bool(false))
-      ),
-      test(
-        "correct order",
-        isSorted(deque),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "consistent iteration",
-        Iter.toArray(iterateForward(deque)),
-        M.equals(T.array(T.natTestable, Array.reverse(Iter.toArray(iterateBackward(deque)))))
-      ),
-      test(
-        "random quarter removal",
-        isSorted(randomRemoval(deque, testSize / 4)),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "random half removal",
-        isSorted(randomRemoval(deque, testSize / 2)),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "random three quarter removal",
-        isSorted(randomRemoval(deque, testSize * 3 / 4)),
-        M.equals(T.bool(true))
-      ),
-      test(
-        "random total removal",
-        Queue.isEmpty(randomRemoval(deque, testSize)),
-        M.equals(T.bool(true))
-      )
-    ]
-  )
-);
+suite(
+  "random insertion",
+  func() {
+    test(
+      "not empty",
+      func() {
+        expect.bool(Queue.isEmpty(deque)).isFalse()
+      }
+    );
 
-/* --------------------------------------- */
+    test(
+      "correct order",
+      func() {
+        expect.bool(isSorted(deque)).isTrue()
+      }
+    );
+
+    test(
+      "consistent iteration",
+      func() {
+        expect.array(
+          Iter.toArray(iterateForward(deque)),
+          Nat.toText,
+          Nat.equal
+        ).equal(Array.reverse(Iter.toArray(iterateBackward(deque))))
+      }
+    );
+
+    test(
+      "random quarter removal",
+      func() {
+        expect.bool(isSorted(randomRemoval(deque, testSize / 4))).isTrue()
+      }
+    );
+
+    test(
+      "random half removal",
+      func() {
+        expect.bool(isSorted(randomRemoval(deque, testSize / 2))).isTrue()
+      }
+    );
+
+    test(
+      "random three quarter removal",
+      func() {
+        expect.bool(isSorted(randomRemoval(deque, testSize * 3 / 4))).isTrue()
+      }
+    );
+
+    test(
+      "random total removal",
+      func() {
+        expect.bool(Queue.isEmpty(randomRemoval(deque, testSize))).isTrue()
+      }
+    )
+  }
+);
 
 func randomInsertionDeletion(steps : Nat) : Queue.Queue<Nat> {
   var current = Queue.empty<Nat>();
   var size = 0;
-  for (number in Nat.range(1, steps)) {
+  for (number in Nat.range(0, steps - 1)) {
     let random = Random.next();
     current := switch (random % 4) {
       case 0 {
@@ -507,15 +558,14 @@ func randomInsertionDeletion(steps : Nat) : Queue.Queue<Nat> {
   current
 };
 
-run(
-  suite(
-    "completely random",
-    [
-      test(
-        "random insertion and deletion",
-        isSorted(randomInsertionDeletion(1000)),
-        M.equals(T.bool(true))
-      )
-    ]
-  )
+suite(
+  "completely random",
+  func() {
+    test(
+      "random insertion and deletion",
+      func() {
+        expect.bool(isSorted(randomInsertionDeletion(1000))).isTrue()
+      }
+    )
+  }
 )

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1297,7 +1297,7 @@
       "public func compare<T>(queue1 : Queue<T>, queue2 : Queue<T>, compare : (T, T) -> Order.Order) : Order.Order",
       "public func contains<T>(queue : Queue<T>, equal : (T, T) -> Bool, item : T) : Bool",
       "public func empty<T>() : Queue<T>",
-      "public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>) : Bool",
+      "public func equal<T>(queue1 : Queue<T>, queue2 : Queue<T>, equal : (T, T) -> Bool) : Bool",
       "public func filter<T>(queue : Queue<T>, f : T -> Bool) : Queue<T>",
       "public func filterMap<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>",
       "public func forEach<T>(queue : Queue<T>, f : T -> ())",


### PR DESCRIPTION
Improves the readability of the `pure/Queue` tests and console output in addition to a few minor fixes.