### PR TITLE
chore: fix forward declarations of Pure.Map/Set (avoiding classing Tree types)

### DIFF
--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -70,11 +70,11 @@ module {
     let iter = values(queue);
     var current = pureQueue;
     loop {
-      switch(iter.next()) {
+      switch (iter.next()) {
         case null { return current };
-        case (?val) { current := PureQueue.pushBack(current, val) };
-      };
-    };
+        case (?val) { current := PureQueue.pushBack(current, val) }
+      }
+    }
   };
 
   /// Converts an immutable, purely functional queue to a mutable queue.
@@ -97,11 +97,11 @@ module {
     let queue = empty<T>();
     let iter = PureQueue.values(pureQueue);
     loop {
-      switch(iter.next()) {
+      switch (iter.next()) {
         case null { return queue };
-        case (?val) { pushBack(queue, val) };
-      };
-    };
+        case (?val) { pushBack(queue, val) }
+      }
+    }
   };
 
   /// Create a new empty mutable double-ended queue.

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -136,17 +136,17 @@ module {
 
     public module Map {
       public type Map<K, V> = {
-	size : Nat;
-	root : Tree<K, V>
+        size : Nat;
+        root : Tree<K, V>
       };
       public type Tree<K, V> = {
-	#red : (Tree<K, V>, K, V, Tree<K, V>);
-	#black : (Tree<K, V>, K, V, Tree<K, V>);
-	#leaf
+        #red : (Tree<K, V>, K, V, Tree<K, V>);
+        #black : (Tree<K, V>, K, V, Tree<K, V>);
+        #leaf
       };
 
     };
-    public type Map<K,V> = Map.Map<K, V>;
+    public type Map<K, V> = Map.Map<K, V>;
 
     public type Queue<T> = (List<T>, Nat, List<T>);
 
@@ -157,7 +157,7 @@ module {
         #leaf
       };
 
-      public type Set<T> = { size : Nat; root : Tree<T> };
+      public type Set<T> = { size : Nat; root : Tree<T> }
     };
 
     public type Set<T> = Set.Set<T>;

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -115,6 +115,7 @@ module {
       var size : Nat
     }
   };
+
   public type Map<K, V> = Map.Map<K, V>;
 
   public module Stack {
@@ -131,21 +132,35 @@ module {
   public type Stack<T> = Stack.Stack<T>;
 
   public module Pure {
-
     public type List<T> = ?(T, List<T>);
 
-    public type Map<K, V> = {
-      size : Nat;
-      root : Tree<K, V>
-    };
+    public module Map {
+      public type Map<K, V> = {
+	size : Nat;
+	root : Tree<K, V>
+      };
+      public type Tree<K, V> = {
+	#red : (Tree<K, V>, K, V, Tree<K, V>);
+	#black : (Tree<K, V>, K, V, Tree<K, V>);
+	#leaf
+      };
 
-    public type Tree<K, V> = {
-      #red : (Tree<K, V>, K, V, Tree<K, V>);
-      #black : (Tree<K, V>, K, V, Tree<K, V>);
-      #leaf
     };
+    public type Map<K,V> = Map.Map<K, V>;
 
     public type Queue<T> = (List<T>, Nat, List<T>);
-    public type Set<T> = () // Placeholder
+
+    public module Set {
+      public type Tree<T> = {
+        #red : (Tree<T>, T, Tree<T>);
+        #black : (Tree<T>, T, Tree<T>);
+        #leaf
+      };
+
+      public type Set<T> = { size : Nat; root : Tree<T> };
+    };
+
+    public type Set<T> = Set.Set<T>;
+
   }
 }

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -58,7 +58,6 @@ import Runtime "../Runtime";
 // TODO: Do we want clone or clear, just to match imperative API?
 // inline Tree type, remove Types.Pure.Tree?
 
-
 module {
 
   public type Map<K, V> = Types.Pure.Map<K, V>;

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -54,16 +54,16 @@ import Iter "../Iter";
 import Types "../Types";
 import Runtime "../Runtime";
 
-// inline Internal?
+// TODO: inline Internal?
+// TODO: Do we want clone or clear, just to match imperative API?
 // inline Tree type, remove Types.Pure.Tree?
 
-// Do we want clone and clear, just to match imperative API?
 
 module {
 
   public type Map<K, V> = Types.Pure.Map<K, V>;
 
-  type Tree<K, V> = Types.Pure.Tree<K, V>;
+  type Tree<K, V> = Types.Pure.Map.Tree<K, V>;
 
   /// Create a new empty immutable key-value map.
   ///
@@ -678,7 +678,6 @@ module {
     combine : (A, K, V) -> A
   ) : A = Internal.foldLeft(map.root, base, combine);
 
-  // TODO: base last?
   /// Collapses the elements in the `map` into a single value by starting with `base`
   /// and progressively combining keys and values into `base` with `combine`. Iteration runs
   /// right to left.

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -3,7 +3,7 @@
 /// A red-black tree is a balanced binary search tree ordered by the elements.
 ///
 /// The tree data structure internally colors each of its nodes either red or black,
-/// and uses this information to balance the tree during the modifying operations.
+/// and uses this information to balance the tree during modifying operations.
 ///
 /// Performance:
 /// * Runtime: `O(log(n))` worst case cost per insertion, removal, and retrieval operation.
@@ -26,19 +26,16 @@ import Nat "../Nat";
 import Order "../Order";
 
 module {
-  /// Red-black tree of nodes with ordered set elements.
-  /// Leaves are considered implicitly black.
-  type Tree<T> = {
-    #red : (Tree<T>, T, Tree<T>);
-    #black : (Tree<T>, T, Tree<T>);
-    #leaf
-  };
 
   /// Ordered collection of unique elements of the generic type `T`.
   /// If type `T` is stable then `Set<T>` is also stable.
   /// To ensure that property the `Set<T>` does not have any methods,
   /// instead they are gathered in the functor-like class `Operations` (see example there).
-  public type Set<T> = { size : Nat; root : Tree<T> };
+  public type Set<T> = Types.Pure.Set<T>;
+
+  /// Red-black tree of nodes with ordered set elements.
+  /// Leaves are considered implicitly black.
+  type Tree<T> = Types.Pure.Set.Tree<T>;
 
   /// Create a set with the elements obtained from an iterator.
   /// Potential duplicate elements in the iterator are ignored, i.e.
@@ -679,7 +676,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<T>(set1 : Set<T>, set2 : Set<T>, compare : (T, T) -> Order.Order) : Order.Order {
-    // TODO: optimize
+    // TODO: optimize using recursion on set1?
     let iterator1 = values(set1);
     let iterator2 = values(set2);
     loop {


### PR DESCRIPTION
Remove placeholder defintion for Types.Pure.Set and rearrange Types.Pure to allow two `Tree` types (following the pattern for imperative Maps and Sets)