### PR TITLE
chore: make `pure/List` mostly tail-recursive

### DIFF
--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -178,10 +178,11 @@ module {
   /// Space: O(size)
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
-  public func forEach<T>(list : List<T>, f : T -> ()) = switch list {
-    case null ();
-    case (?(h, t)) { f h; forEach(t, f) }
-  };
+  public func forEach<T>(list : List<T>, f : T -> ()) =
+    switch list {
+      case (?(h, t)) { f h; forEach(t, f) };
+      case null ()
+    };
 
   /// Call the given function `f` on each list element and collect the results
   /// in a new list.
@@ -196,10 +197,11 @@ module {
   ///
   /// Space: O(size)
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
-  public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2> = switch list {
-    case null null;
-    case (?(h, t)) ?(f h, map(t, f))
-  };
+  public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2> =
+    switch list {
+      case null null;
+      case (?(h, t)) ?(f h, map(t, f))
+    };
 
   /// Create a new list with only those elements of the original list for which
   /// the given function (often called the _predicate_) returns true.

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -255,6 +255,18 @@ module {
   /// Space: O(size)
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
+
+  public func mapResult<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E> = (
+    func rev(acc : List<R>, list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E> = switch list {
+      case null #ok acc;
+      case (?(h, t)) switch (f h) {
+        case (#ok fh) rev(?(fh, acc), t, f);
+        case (#err e) #err e
+      }
+    }
+  )(null, list, f) |> Result.mapOk(_, func(l : List<R>) : List<R> = reverse l);
+
+  /*
   public func mapResult<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E> = switch list {
     case null #ok null;
     case (?(h, t)) {
@@ -263,7 +275,7 @@ module {
         case ((#err e, _) or (_, #err e)) #err e
       }
     }
-  };
+  };*/
 
   /// Create two new lists from the results of a given function (`f`).
   /// The first list only includes the elements for which the given

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -157,13 +157,12 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(size)
-  public func reverse<T>(list : List<T>) : List<T> {
-    func go(acc : List<T>, list : List<T>) : List<T> = switch list {
-      case null acc;
-      case (?(h, t)) go(?(h, acc), t)
-    };
-    go(null, list)
-  };
+  public func reverse<T>(list : List<T>) : List<T> =
+    (func go(acc : List<T>, list : List<T>) : List<T> =
+      switch list {
+        case (?(h, t)) go(?(h, acc), t);
+        case null acc
+      })(null, list);
 
   /// Call the given function for its side effect, with each list element in turn.
   ///

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -98,10 +98,11 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(1)
-  public func get<T>(list : List<T>, n : Nat) : ?T = switch list {
-    case null null;
-    case (?(h, t)) if (n == 0) ?h else get(t, n - 1)
-  };
+  public func get<T>(list : List<T>, n : Nat) : ?T =
+    switch list {
+      case (?(h, t)) if (n == 0) ?h else get(t, n - 1);
+      case null null
+    };
 
   /// Add `item` to the head of `list`, and return the new list.
   ///

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -303,10 +303,12 @@ module {
   /// Runtime: O(size(l))
   ///
   /// Space: O(size(l))
-  public func concat<T>(list1 : List<T>, list2 : List<T>) : List<T> = switch list1 {
-    case null list2;
-    case (?(h, t)) ?(h, concat(t, list2))
-  };
+  public func concat<T>(list1 : List<T>, list2 : List<T>) : List<T> = (
+    func revAppend<T>(l : List<T>, m : List<T>) : List<T> = switch l {
+      case (?(h, t)) revAppend(t, ?(h, m));
+      case null m
+    }
+  )(reverse list1, list2);
 
   public func join<T>(list : Iter.Iter<List<T>>) : List<T> {
     let ?l = list.next() else return null;

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -586,8 +586,13 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func tabulate<T>(n : Nat, f : Nat -> T) : List<T> {
-    func go(at : Nat, n : Nat) : List<T> = if (n == 0) null else ?(f at, go(at + 1, n - 1));
-    go(0, n)
+    var i = n;
+    var l : List<T> = null;
+    while (i != 0) {
+      l := ?(f i, l);
+      i -= 1
+    };
+    reverse l
   };
 
   /// Create a list with exactly one element.

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -501,7 +501,7 @@ module {
 
   /// Merge two ordered lists into a single ordered list.
   /// This function requires both list to be ordered as specified
-  /// by the given relation `lessThanOrEqual`.
+  /// by the given relation `compare`.
   ///
   /// Example:
   /// ```motoko include=initialize
@@ -509,7 +509,7 @@ module {
   /// List.merge<Nat>(
   ///   ?(1, ?(2, ?(4, null))),
   ///   ?(2, ?(4, ?(6, null))),
-  ///   func (n1, n2) = n1 <= n2
+  ///   Nat.compare
   /// ); // => ?(1, ?(2, ?(2, ?(4, ?(4, ?(6, null))))))),
   /// ```
   ///
@@ -519,14 +519,14 @@ module {
   ///
   /// *Runtime and space assumes that `lessThanOrEqual` runs in O(1) time and space.
   // TODO: replace by merge taking a compare : (T, T) -> Order.Order function?
-  public func merge<T>(list1 : List<T>, list2 : List<T>, lessThanOrEqual : (T, T) -> Bool) : List<T> = switch (list1, list2) {
+  public func merge<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : List<T> = switch (list1, list2) {
     case (?(h1, t1), ?(h2, t2)) {
-      if (lessThanOrEqual(h1, h2)) {
-        ?(h1, merge(t1, list2, lessThanOrEqual))
-      } else if (lessThanOrEqual(h2, h1)) {
-        ?(h2, merge(list1, t2, lessThanOrEqual))
+      if (compare(h1, h2) != #greater) {
+        ?(h1, merge(t1, list2, compare))
+      } else if (compare(h2, h1) != #greater) {
+        ?(h2, merge(list1, t2, compare))
       } else {
-        ?(h1, ?(h2, merge(list1, list2, lessThanOrEqual)))
+        ?(h1, ?(h2, merge(list1, list2, compare)))
       }
     };
     case (null, _) list2;

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -544,10 +544,10 @@ module {
   ///
   /// Space: O(1)
   ///
-  /// *Runtime and space assumes that `equalFunc` runs in O(1) time and space.
-  public func equal<T>(list1 : List<T>, list2 : List<T>, equalFunc : (T, T) -> Bool) : Bool = switch (list1, list2) {
+  /// *Runtime and space assumes that `equalItem` runs in O(1) time and space.
+  public func equal<T>(list1 : List<T>, list2 : List<T>, equalItem : (T, T) -> Bool) : Bool = switch (list1, list2) {
     case (null, null) true;
-    case (?(h1, t1), ?(h2, t2)) equalFunc(h1, h2) and equal(t1, t2, equalFunc);
+    case (?(h1, t1), ?(h2, t2)) equalItem(h1, h2) and equal(t1, t2, equalItem);
     case _ false
   };
 

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -833,10 +833,13 @@ module {
 
   public func toText<T>(list : List<T>, f : T -> Text) : Text {
     var text = "[";
+    var first = true;
     forEach(
       list,
       func(item : T) {
-        if (text.size() > 1) {
+        if first {
+          first := false
+        } else {
           text #= ", "
         };
         text #= f item

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -58,10 +58,13 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(1)
-  public func size<T>(list : List<T>) : Nat = switch list {
-    case null 0;
-    case (?(_, t)) 1 + size t
-  };
+  public func size<T>(list : List<T>) : Nat =
+    (func go(n : Nat, list : List<T>) : Nat =
+      switch list {
+        case (?(_, t)) go(n + 1, t);
+        case null n
+      }
+    )(0, list);
 
   /// Check whether the list contains a given value. Uses the provided equality function to compare values.
   ///

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -619,7 +619,15 @@ module {
   /// Runtime: O(n)
   ///
   /// Space: O(n)
-  public func repeat<T>(item : T, n : Nat) : List<T> = if (n == 0) null else ?(item, repeat(item, n - 1));
+  public func repeat<T>(item : T, n : Nat) : List<T> {
+    var res : List<T> = null;
+    var i : Int = n;
+    while (i != 0) {
+      i -= 1;
+      res := ?(item, res)
+    };
+    res
+  };
 
   /// Create a list of pairs from a pair of lists.
   ///

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -586,11 +586,11 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func tabulate<T>(n : Nat, f : Nat -> T) : List<T> {
-    var i = n;
+    var i = 0;
     var l : List<T> = null;
-    while (i != 0) {
+    while (i < n) {
       l := ?(f i, l);
-      i -= 1
+      i += 1
     };
     reverse l
   };

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -260,8 +260,7 @@ module {
     case (?(h, t)) {
       switch (f h, mapResult(t, f)) {
         case (#ok r, #ok l) #ok(?(r, l));
-        case (#err e, _) #err e;
-        case (_, #err e) #err e
+        case ((#err e, _) or (_, #err e)) #err e
       }
     }
   };

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -811,9 +811,13 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(size)
-  public func fromIter<T>(iter : Iter.Iter<T>) : List<T> = switch (iter.next()) {
-    case null null;
-    case (?item) ?(item, fromIter iter)
+  public func fromIter<T>(iter : Iter.Iter<T>) : List<T> {
+    var result : List<T> = null;
+    Iter.forEach<T>(
+      iter,
+      func x = result := ?(x, result)
+    );
+    reverse result
   };
 
   public func toText<T>(list : List<T>, f : T -> Text) : Text {

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -813,16 +813,13 @@ module {
 
   public func toText<T>(list : List<T>, f : T -> Text) : Text {
     var text = "[";
-    var first = false;
     forEach(
       list,
       func(item : T) {
-        if first {
+        if (text.size() > 1) {
           text #= ", "
-        } else {
-          first := true
         };
-        text #= f(item)
+        text #= f item
       }
     );
     text # "]"

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -569,18 +569,14 @@ module {
   /// Space: O(1)
   ///
   /// *Runtime and space assumes that argument `compare` runs in O(1) time and space.
-  public func compare<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order {
-    type Order = Order.Order;
-    func go(list1 : List<T>, list2 : List<T>, comp : (T, T) -> Order) : Order = switch (list1, list2) {
-      case (?(h1, t1), ?(h2, t2)) switch (comp(h1, h2)) {
-        case (#equal) go(t1, t2, comp);
-        case o o
-      };
-      case (null, null) #equal;
-      case (null, _) #less;
-      case _ #greater
+  public func compare<T>(list1 : List<T>, list2 : List<T>, compareItem : (T, T) -> Order.Order) : Order.Order = switch (list1, list2) {
+    case (?(h1, t1), ?(h2, t2)) switch (compareItem(h1, h2)) {
+      case (#equal) compare(t1, t2, compareItem);
+      case o o
     };
-    go(list1, list2, compare) // FIXME: only needed because of above shadowing
+    case (null, null) #equal;
+    case (null, _) #less;
+    case _ #greater
   };
 
   /// Generate a list based on a length and a function that maps from

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -266,17 +266,6 @@ module {
     }
   )(null, list, f) |> Result.mapOk(_, func(l : List<R>) : List<R> = reverse l);
 
-  /*
-  public func mapResult<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E> = switch list {
-    case null #ok null;
-    case (?(h, t)) {
-      switch (f h, mapResult(t, f)) {
-        case (#ok r, #ok l) #ok(?(r, l));
-        case ((#err e, _) or (_, #err e)) #err e
-      }
-    }
-  };*/
-
   /// Create two new lists from the results of a given function (`f`).
   /// The first list only includes the elements for which the given
   /// function `f` returns true and the second list only includes

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -309,6 +309,19 @@ module {
     }
   )(reverse list1, list2);
 
+  /// Flatten, or repatedly concatenate, an iterator of lists as a list.
+  ///
+  /// Example:
+  /// ```motoko include=initialize
+  /// List.join<Nat>(
+  ///   [ ?(0, ?(1, ?(2, null))),
+  ///     ?(3, ?(4, ?(5, null))) ] |> Iter.fromArray _)
+  /// ); // => ?(0, ?(1, ?(2, ?(3, ?(4, ?(5, null))))))
+  /// ```
+  ///
+  /// Runtime: O(size*size)
+  ///
+  /// Space: O(size*size)
   public func join<T>(list : Iter.Iter<List<T>>) : List<T> {
     let ?l = list.next() else return null;
     let ls = join list;

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -58,13 +58,12 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(1)
-  public func size<T>(list : List<T>) : Nat =
-    (func go(n : Nat, list : List<T>) : Nat =
-      switch list {
-        case (?(_, t)) go(n + 1, t);
-        case null n
-      }
-    )(0, list);
+  public func size<T>(list : List<T>) : Nat = (
+    func go(n : Nat, list : List<T>) : Nat = switch list {
+      case (?(_, t)) go(n + 1, t);
+      case null n
+    }
+  )(0, list);
 
   /// Check whether the list contains a given value. Uses the provided equality function to compare values.
   ///
@@ -98,11 +97,10 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(1)
-  public func get<T>(list : List<T>, n : Nat) : ?T =
-    switch list {
-      case (?(h, t)) if (n == 0) ?h else get(t, n - 1);
-      case null null
-    };
+  public func get<T>(list : List<T>, n : Nat) : ?T = switch list {
+    case (?(h, t)) if (n == 0) ?h else get(t, n - 1);
+    case null null
+  };
 
   /// Add `item` to the head of `list`, and return the new list.
   ///
@@ -157,12 +155,12 @@ module {
   /// Runtime: O(size)
   ///
   /// Space: O(size)
-  public func reverse<T>(list : List<T>) : List<T> =
-    (func go(acc : List<T>, list : List<T>) : List<T> =
-      switch list {
-        case (?(h, t)) go(?(h, acc), t);
-        case null acc
-      })(null, list);
+  public func reverse<T>(list : List<T>) : List<T> = (
+    func go(acc : List<T>, list : List<T>) : List<T> = switch list {
+      case (?(h, t)) go(?(h, acc), t);
+      case null acc
+    }
+  )(null, list);
 
   /// Call the given function for its side effect, with each list element in turn.
   ///
@@ -178,11 +176,10 @@ module {
   /// Space: O(size)
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
-  public func forEach<T>(list : List<T>, f : T -> ()) =
-    switch list {
-      case (?(h, t)) { f h; forEach(t, f) };
-      case null ()
-    };
+  public func forEach<T>(list : List<T>, f : T -> ()) = switch list {
+    case (?(h, t)) { f h; forEach(t, f) };
+    case null ()
+  };
 
   /// Call the given function `f` on each list element and collect the results
   /// in a new list.
@@ -197,11 +194,10 @@ module {
   ///
   /// Space: O(size)
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
-  public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2> =
-    switch list {
-      case null null;
-      case (?(h, t)) ?(f h, map(t, f))
-    };
+  public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2> = switch list {
+    case null null;
+    case (?(h, t)) ?(f h, map(t, f))
+  };
 
   /// Create a new list with only those elements of the original list for which
   /// the given function (often called the _predicate_) returns true.
@@ -369,7 +365,7 @@ module {
   /// Space: O(1)
   public func drop<T>(list : List<T>, n : Nat) : List<T> = if (n == 0) list else switch list {
     case null null;
-    case (?(h, t)) drop(t, n - 1)
+    case (?(_, t)) drop(t, n - 1)
   };
 
   /// Collapses the elements in `list` into a single value by starting with `base`

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -378,6 +378,8 @@ let pop = Suite.suite(
   ]
 );
 
+let hugeList = List.repeat('Y', 100_000);
+
 let size = Suite.suite(
   "size",
   [
@@ -398,7 +400,7 @@ let size = Suite.suite(
     ),
     Suite.test(
       "many",
-      do { let l = List.repeat('Y', 100_000); List.size l },
+      List.size hugeList,
       M.equals(T.nat 100_000)
     )
   ]
@@ -446,6 +448,11 @@ let get = Suite.suite(
       "threesome-4",
       List.get(?(1, ?(2, ?(3, null))), 4),
       M.equals(T.optional(T.natTestable, null : ?Nat))
+    ),
+    Suite.test(
+      "many",
+      List.get(hugeList, 99_999),
+      M.equals(T.optional(T.char 'Y', ?'Y' : ?Char))
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -523,7 +523,7 @@ let forEach = Suite.suite(
       do {
         var c = 0;
         List.forEach<Char>(hugeList, func _ = c += 1);
-        t
+        c
       },
       M.equals(T.nat 100_000)
     )

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -469,7 +469,6 @@ let reverse = Suite.suite(
       "empty list",
       List.reverse(List.empty<Nat>()),
       M.equals(T.list(T.natTestable, null : List.List<Nat>))
-
     ),
     Suite.test(
       "singleton",
@@ -480,6 +479,11 @@ let reverse = Suite.suite(
       "threesome",
       List.reverse(?(1, ?(2, ?(3, null)))),
       M.equals(T.list(T.natTestable, ?(3, ?(2, ?(1, null)))))
+    ),
+    Suite.test(
+      "many",
+      List.reverse hugeList |> List.size _,
+      M.equals(T.nat 100_000)
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -15,7 +15,6 @@ FIXME: (CHECK these)
 
 * flatten is quadratic
 * Array.mo doesn't implement `all`, `any`, `compare`
-* merge takes lte predicate of type (T,T)-> Bool, not comparison of type: (T,T) -> Ord
 * split is not tail recursive and calls redundant helpers
 
 TODO:
@@ -1049,7 +1048,7 @@ let merge = Suite.suite(
       List.merge<Nat>(
         List.tabulate<Nat>(10, func i = 2 * i),
         List.tabulate<Nat>(10, func i = 2 * i + 1),
-        func(i, j) { i <= j }
+        Nat.compare
       ),
       M.equals(
         T.list(T.natTestable, List.tabulate<Nat>(20, func i = i))
@@ -1072,7 +1071,7 @@ let merge = Suite.suite(
             { 2 * i } else { 2 * i + 1 }
           }
         ),
-        func(i, j) { i <= j }
+        Nat.compare
       ),
       M.equals(
         T.list(T.natTestable, List.tabulate<Nat>(20, func i = i))
@@ -1084,7 +1083,7 @@ let merge = Suite.suite(
       List.merge<Nat>(
         List.tabulate<Nat>(10, func i = 2 * i),
         List.tabulate<Nat>(10, func i = 2 * i),
-        func(i, j) { i <= j }
+        Nat.compare
       ),
       M.equals(
         T.list(T.natTestable, List.tabulate<Nat>(20, func i = 2 * (i / 2)))
@@ -1096,7 +1095,7 @@ let merge = Suite.suite(
       List.merge<Nat>(
         List.tabulate<Nat>(1000, func i = 2 * i),
         List.tabulate<Nat>(1000, func i = 2 * i + 1),
-        func(i, j) { i <= j }
+        Nat.compare
       ),
       M.equals(
         T.list(T.natTestable, List.tabulate<Nat>(2000, func i = i))

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,5 +1,3 @@
-// @  testXmode wasi
-
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -207,7 +207,8 @@ let mapResult = Suite.suite(
     ),
     Suite.test(
       "large",
-      List.mapResult<Char, (), ()>(hugeList, func _ = #ok),
+      List.mapResult<Char, (), ()>(hugeList, func _ = #ok)
+      |> Result.mapOk<List.List<()>, List.List<()>, ()>(_, func _ = null),
       M.equals(T.result<List.List<()>, ()>(T.listTestable<()> unit, unit, #ok null))
     )
   ]

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1567,6 +1567,19 @@ let fromIter = Suite.suite(
   ]
 );
 
+let toText = Suite.suite(
+  "toText",
+  [
+    Suite.test(
+      "small",
+      List.toText<Nat>(?(0, ?(1, null)), Nat.toText),
+      M.equals(
+        T.text "[0, 1]"
+      )
+    )
+  ]
+);
+
 Suite.run(
   Suite.suite(
     "List",
@@ -1603,7 +1616,8 @@ Suite.run(
       zip,
       split,
       chunks,
-      fromIter
+      fromIter,
+      toText
     ]
   )
 )

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,3 +1,5 @@
+// @testmode wasi
+
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
@@ -396,8 +398,8 @@ let size = Suite.suite(
     ),
     Suite.test(
       "many",
-      do { let l = List.repeat('Y', 20_000); List.size l },
-      M.equals(T.nat 20_000)
+      do { let l = List.repeat('Y', 100_000); List.size l },
+      M.equals(T.nat 100_000)
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -453,6 +453,11 @@ let get = Suite.suite(
       "many",
       List.get(hugeList, 99_999),
       M.equals(T.optional(T.char 'Y', ?'Y' : ?Char))
+    ),
+    Suite.test(
+      "past many",
+      List.get(hugeList, 100_000),
+      M.equals(T.optional(T.char 'Y', null : ?Char))
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -85,11 +85,6 @@ assert (List.size<X>(l1) == 0);
 assert (List.size<X>(l2) == 1);
 assert (List.size<X>(l3) == 2);
 
-// ## List functions
-assert (List.size<X>(l1) == 0);
-assert (List.size<X>(l2) == 1);
-assert (List.size<X>(l3) == 2);
-
 do {
   Debug.print("  flatten");
 
@@ -398,6 +393,11 @@ let size = Suite.suite(
       "threesome",
       List.size(?(1, ?(2, ?(3, null)))),
       M.equals(T.nat(3))
+    ),
+    Suite.test(
+      "many",
+      do { let l = List.repeat('Y', 20_000); List.size l },
+      M.equals(T.nat 20_000)
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -517,6 +517,15 @@ let forEach = Suite.suite(
         t
       },
       M.equals(T.text("123"))
+    ),
+    Suite.test(
+      "many",
+      do {
+        var c = 0;
+        List.forEach<Char>(hugeList, func _ = c += 1);
+        t
+      },
+      M.equals(T.nat 100_000)
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -9,7 +9,6 @@ import Nat "../../src/Nat";
 import Order "../../src/Order";
 import Debug "../../src/Debug";
 import Int "../../src/Int";
-import Iter "../../src/Iter";
 import Result "../../src/Result";
 
 /*

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -274,6 +274,11 @@ let concat = Suite.suite(
       M.equals(
         T.list(T.natTestable, List.tabulate<Nat>(20000, func i = i))
       )
+    ),
+    Suite.test(
+      "huge-list",
+      List.concat(hugeList, List.singleton 'N') |> List.last _,
+      M.equals(T.optional(T.charTestable, ?'N'))
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -992,6 +992,11 @@ let all = Suite.suite(
       "all empty",
       List.all<Nat>(null, func x = x >= 1),
       M.equals(T.bool(true))
+    ),
+    Suite.test(
+      "many",
+      List.all<Char>(hugeList, func c = c == 'Y'),
+      M.equals(T.bool true)
     )
   ]
 );
@@ -1013,6 +1018,11 @@ let any = Suite.suite(
       "empty",
       List.any<Nat>(null, func x = true),
       M.equals(T.bool(false))
+    ),
+    Suite.test(
+      "many",
+      List.any<Char>(hugeList, func c = c != 'Y'),
+      M.equals(T.bool false)
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -417,7 +417,7 @@ let get = Suite.suite(
     Suite.test(
       "singleton-0",
       List.get(?(3, null), 0),
-      M.equals(T.optional(T.natTestable, ?3 : ?Nat))
+      M.equals(T.optional(T.natTestable, ?3))
     ),
     Suite.test(
       "singleton-1",
@@ -432,12 +432,12 @@ let get = Suite.suite(
     Suite.test(
       "threesome-0",
       List.get(?(1, ?(2, ?(3, null))), 0),
-      M.equals(T.optional(T.natTestable, ?1 : ?Nat))
+      M.equals(T.optional(T.natTestable, ?1))
     ),
     Suite.test(
       "threesome-1",
       List.get(?(1, ?(2, ?(3, null))), 1),
-      M.equals(T.optional(T.natTestable, ?2 : ?Nat))
+      M.equals(T.optional(T.natTestable, ?2))
     ),
     Suite.test(
       "threesome-3",
@@ -452,12 +452,12 @@ let get = Suite.suite(
     Suite.test(
       "many",
       List.get(hugeList, 99_999),
-      M.equals(T.optional(T.char 'Y', ?'Y' : ?Char))
+      M.equals(T.optional(T.charTestable, ?'Y'))
     ),
     Suite.test(
       "past many",
       List.get(hugeList, 100_000),
-      M.equals(T.optional(T.char 'Y', null : ?Char))
+      M.equals(T.optional(T.charTestable, null : ?Char))
     )
   ]
 );

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -223,6 +223,8 @@ let repeat = Suite.suite(
   ]
 );
 
+let hugeList = List.repeat('Y', 100_000);
+
 let tabulate = Suite.suite(
   "tabulate",
   [
@@ -242,9 +244,9 @@ let tabulate = Suite.suite(
     ),
     Suite.test(
       "large-list",
-      List.tabulate<Nat>(10000, func i = 0),
+      List.tabulate<Char>(100_000, func _ = 'Y'),
       M.equals(
-        T.list<Nat>(T.natTestable, List.repeat(0, 10000))
+        T.list<Char>(T.charTestable, hugeList)
       )
     )
   ]
@@ -377,8 +379,6 @@ let pop = Suite.suite(
     )
   ]
 );
-
-let hugeList = List.repeat('Y', 100_000);
 
 let size = Suite.suite(
   "size",

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1530,6 +1530,17 @@ let chunks = Suite.suite(
   ]
 );
 
+let fromIter = Suite.suite(
+  "fromIter",
+  [
+    Suite.test(
+      "large",
+      List.fromIter<Nat>(Nat.range(0, 100_000)) |> List.size _,
+      M.equals(T.nat 100_000)
+    )
+  ]
+);
+
 Suite.run(
   Suite.suite(
     "List",
@@ -1565,7 +1576,8 @@ Suite.run(
       zipWith,
       zip,
       split,
-      chunks
+      chunks,
+      fromIter
     ]
   )
 )

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -174,6 +174,14 @@ func listRes(itm : Result.Result<List.List<Nat>, Text>) : T.TestableItem<Result.
   { display = resT.display; equals = resT.equals; item = itm }
 };
 
+object unit : T.TestableItem<()> {
+  public let item = ();
+  public func display(()) : Text = "()";
+  public func equals((), ()) : Bool = true
+};
+
+let hugeList = List.repeat('Y', 100_000);
+
 let mapResult = Suite.suite(
   "mapResult",
   [
@@ -196,6 +204,11 @@ let mapResult = Suite.suite(
       "fail last",
       List.mapResult<Int, Nat, Text>(?(1, ?(2, ?(-3, null))), makeNatural),
       M.equals(listRes(#err("-3 is not a natural number.")))
+    ),
+    Suite.test(
+      "large",
+      List.mapResult<Char, (), ()>(hugeList, func _ = #ok),
+      M.equals(T.result<List.List<()>, ()>(T.listTestable<()> unit, unit, #ok null))
     )
   ]
 );
@@ -221,8 +234,6 @@ let repeat = Suite.suite(
     )
   ]
 );
-
-let hugeList = List.repeat('Y', 100_000);
 
 let tabulate = Suite.suite(
   "tabulate",

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,4 +1,4 @@
-// @testmode wasi
+// @  testXmode wasi
 
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1534,6 +1534,16 @@ let fromIter = Suite.suite(
   "fromIter",
   [
     Suite.test(
+      "small",
+      List.fromIter<Nat>(Nat.range(0, 100)),
+      M.equals(
+        T.list(
+          T.natTestable,
+          List.tabulate<Nat>(100, func i = i)
+        )
+      )
+    ),
+    Suite.test(
       "large",
       List.fromIter<Nat>(Nat.range(0, 100_000)) |> List.size _,
       M.equals(T.nat 100_000)

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1222,7 +1222,7 @@
       "public func contains<T>(list : List<T>, equal : (T, T) -> Bool, item : T) : Bool",
       "public func drop<T>(list : List<T>, n : Nat) : List<T>",
       "public func empty<T>() : List<T>",
-      "public func equal<T>(list1 : List<T>, list2 : List<T>, equalFunc : (T, T) -> Bool) : Bool",
+      "public func equal<T>(list1 : List<T>, list2 : List<T>, equalItem : (T, T) -> Bool) : Bool",
       "public func filter<T>(list : List<T>, f : T -> Bool) : List<T>",
       "public func filterMap<T, R>(list : List<T>, f : T -> ?R) : List<R>",
       "public func find<T>(list : List<T>, f : T -> Bool) : ?T",

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1234,7 +1234,7 @@
       "public type List<T>",
       "public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2>",
       "public func mapResult<T, R, E>(list : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E>",
-      "public func merge<T>(list1 : List<T>, list2 : List<T>, lessThanOrEqual : (T, T) -> Bool) : List<T>",
+      "public func merge<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : List<T>",
       "public func partition<T>(list : List<T>, f : T -> Bool) : (List<T>, List<T>)",
       "public func pop<T>(list : List<T>) : (?T, List<T>)",
       "public func push<T>(list : List<T>, item : T) : List<T>",

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1217,7 +1217,7 @@
       "public func all<T>(list : List<T>, f : T -> Bool) : Bool",
       "public func any<T>(list : List<T>, f : T -> Bool) : Bool",
       "public func chunks<T>(list : List<T>, n : Nat) : List<List<T>>",
-      "public func compare<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order",
+      "public func compare<T>(list1 : List<T>, list2 : List<T>, compareItem : (T, T) -> Order.Order) : Order.Order",
       "public func concat<T>(list1 : List<T>, list2 : List<T>) : List<T>",
       "public func contains<T>(list : List<T>, equal : (T, T) -> Bool, item : T) : Bool",
       "public func drop<T>(list : List<T>, n : Nat) : List<T>",


### PR DESCRIPTION
TODO:
- [ ] `size` could be more efficient with a loop
- [x] `repeat` ditto
- [x] `tabulate` is not tail-recursive (but constructor tailed)
- [x] `concat` is not tail-recursive (but constructor tailed)
- [ ] `merge` is not tail-recursive (but constructor tailed)
- [x] `fromIter` is not tail-recursive (but constructor tailed)
- [ ] `reverse` looks tail recursive (could be more efficient with a loop)
- [x] `mapResult` needs another look (somewhat convoluted in legacy `base`)