### PR TITLE
optimization: Implement imperative stack using tuple, not record, based lists.

### DIFF
--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -39,7 +39,7 @@ import Types "Types";
 import PureList "pure/List";
 
 module {
-  type Node<T> = Types.Stack.Node<T>;
+  type List<T> = Types.Pure.List<T>;
   public type Stack<T> = Types.Stack<T>;
 
   /// Convert a mutable stack to an immutable, purely functional list.
@@ -439,7 +439,7 @@ module {
   /// Space: O(n)
   /// where `n` denotes the number of elements stored on the stack.
   public func reverse<T>(stack : Stack<T>) {
-    var last : Node<T> = null;
+    var last : List<T> = null;
     for (element in values(stack)) {
       last := ?(element, last)
     };

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -34,6 +34,8 @@
 /// * Space: `O(n)`.
 /// `n` denotes the number of elements stored on the stack.
 
+// TODO: optimize or re-use pure/List operations (e.g. for `any` etc)
+
 import Order "Order";
 import Types "Types";
 import PureList "pure/List";
@@ -99,17 +101,16 @@ module {
     var cur = list;
     loop {
       switch cur {
-	case (?(_, next)) {
-	  size += 1;
-	  cur := next
-	};
+        case (?(_, next)) {
+          size += 1;
+          cur := next
+        };
         case null {
-	  return { var top = list; var size }
+          return { var top = list; var size }
         }
       }
     }
   };
-
 
   /// Create a new empty mutable stack.
   ///

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -60,11 +60,11 @@ module {
   /// }
   /// ```
   ///
-  /// Runtime: `O(n)`.
-  /// Space: `O(n)`.
+  /// Runtime: `O(1)`.
+  /// Space: `O(1)`.
   /// where `n` denotes the number of elements stored in the stack.
   public func toPure<T>(stack : Stack<T>) : PureList.List<T> {
-    PureList.fromIter(values(stack))
+    stack.top
   };
 
   /// Convert an immutable, purely functional list to a mutable stack.
@@ -95,8 +95,22 @@ module {
   /// Space: `O(n)`.
   /// where `n` denotes the number of elements stored in the queue.
   public func fromPure<T>(list : PureList.List<T>) : Stack<T> {
-    fromIter(PureList.values(list))
+    var size = 0;
+    var cur = list;
+    label size loop {
+      switch cur {
+	case (?(_, next)) {
+	  size += 1;
+	  cur := next
+	};
+        case null { break size }
+      }
+    };
+    { var top = list;
+      var size;
+    }
   };
+
 
   /// Create a new empty mutable stack.
   ///
@@ -301,11 +315,7 @@ module {
   /// Runtime: O(1)
   /// Space: O(1)
   public func push<T>(stack : Stack<T>, value : T) {
-    let node = {
-      value;
-      next = stack.top
-    };
-    stack.top := ?node;
+    stack.top := ?(value, stack.top);
     stack.size += 1
   };
 
@@ -330,7 +340,7 @@ module {
   public func peek<T>(stack : Stack<T>) : ?T {
     switch (stack.top) {
       case null null;
-      case (?node) ?node.value
+      case (?(value, _)) ?value
     }
   };
 
@@ -358,10 +368,10 @@ module {
   public func pop<T>(stack : Stack<T>) : ?T {
     switch (stack.top) {
       case null null;
-      case (?node) {
-        stack.top := node.next;
+      case (?(value, next)) {
+        stack.top := next;
         stack.size -= 1;
-        ?node.value
+        ?value
       }
     }
   };
@@ -395,15 +405,15 @@ module {
     while (index < position) {
       switch (current) {
         case null return null;
-        case (?node) {
-          current := node.next
+        case (?(_, next)) {
+          current := next
         }
       };
       index += 1
     };
     switch (current) {
       case null null;
-      case (?node) ?node.value
+      case (?(value, _)) ?value
     }
   };
 
@@ -430,12 +440,9 @@ module {
   /// Space: O(n)
   /// where `n` denotes the number of elements stored on the stack.
   public func reverse<T>(stack : Stack<T>) {
-    var last : ?Node<T> = null;
+    var last : Node<T> = null;
     for (element in values(stack)) {
-      last := ?{
-        value = element;
-        next = last
-      }
+      last := ?(element, last)
     };
     stack.top := last
   };
@@ -473,9 +480,9 @@ module {
       public func next() : ?T {
         switch (current) {
           case null null;
-          case (?node) {
-            current := node.next;
-            ?node.value
+          case (?(value, next)) {
+            current := next;
+            ?value
           }
         }
       }

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -97,17 +97,16 @@ module {
   public func fromPure<T>(list : PureList.List<T>) : Stack<T> {
     var size = 0;
     var cur = list;
-    label size loop {
+    loop {
       switch cur {
 	case (?(_, next)) {
 	  size += 1;
 	  cur := next
 	};
-        case null { break size }
+        case null {
+	  return { var top = list; var size }
+        }
       }
-    };
-    { var top = list;
-      var size;
     }
   };
 

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -118,10 +118,8 @@ module {
   public type Map<K, V> = Map.Map<K, V>;
 
   public module Stack {
-    public type Node<T> = ?(T, Node<T>); // a.k. Pure.List<T>
-
     public type Stack<T> = {
-      var top : Node<T>;
+      var top : Pure.List<T>;
       var size : Nat
     }
   };

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -118,13 +118,10 @@ module {
   public type Map<K, V> = Map.Map<K, V>;
 
   public module Stack {
-    public type Node<T> = {
-      value : T;
-      next : ?Node<T>
-    };
+    public type Node<T> = ?(T, Node<T>); // a.k. Pure.List<T>
 
     public type Stack<T> = {
-      var top : ?Node<T>;
+      var top : Node<T>;
       var size : Nat
     }
   };


### PR DESCRIPTION
(As discussed offline with Luc)*

Should be cheaper, allows constant time conversion to pure List and not really that much less readable.

In future, we could probably reimplement most operations using the underlying List functions.

*well, online, but different line.

If approved, I'll merge into #172 and then merge #172 into master.