### PR TITLE
chore: add tag triggered mops release action

### DIFF
--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -1,0 +1,20 @@
+name: publish on mops
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - moc-*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ZenVoich/setup-mops@v1
+        with:
+          # Make sure you set the MOPS_IDENTITY_PEM secret in your repository settings https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
+          identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}
+      - run: mops install
+      - run: mops publish

--- a/mops.toml
+++ b/mops.toml
@@ -1,5 +1,5 @@
 [package]
-name = "core"
+name = "new-base"
 version = "0.0.0"
 description = "The Motoko new-base library (replaces `base`)"
 repository = "https://github.com/dfinity/new-motoko-base"

--- a/mops.toml
+++ b/mops.toml
@@ -1,9 +1,9 @@
 [package]
 name = "core"
 version = "0.0.0"
-description = "The Motoko core library (replaces `base`)"
+description = "The Motoko new-base library (replaces `base`)"
 repository = "https://github.com/dfinity/new-motoko-base"
-keywords = [ "core", "base" ]
+keywords = [ "new-base", "base" ]
 license = "Apache-2.0"
 
 [dev-dependencies]

--- a/mops.toml
+++ b/mops.toml
@@ -1,9 +1,9 @@
 [package]
-name = "base"
-version = "1.0.0"
-description = "The Motoko base library"
-repository = "https://github.com/dfinity/motoko-base"
-keywords = [ "base" ]
+name = "core"
+version = "0.0.0"
+description = "The Motoko core library (replaces `base`)"
+repository = "https://github.com/dfinity/new-motoko-base"
+keywords = [ "core", "base" ]
 license = "Apache-2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Published new motoko base libary under name ~core~ `new-base`

* need a  new identity to be stored in GH secret.

cargo-culted from motoko-base.