### PR TITLE
feat: make `replyDeadline` an optional return type

### DIFF
--- a/src/InternetComputer.mo
+++ b/src/InternetComputer.mo
@@ -82,7 +82,11 @@ module {
 
   /// Returns the time (in nanoseconds from the epoch start) by when the update message should
   /// reply to the best effort message so that it can be received by the requesting canister.
-  /// Queries and non-best-effort update messages return zero.
-  public func replyDeadline() : Nat = Prim.nat64ToNat(Prim.replyDeadline());
+  /// Queries and unbounded-time update messages return null.
+  public func replyDeadline() : ?Nat {
+    let raw = Prim.replyDeadline();
+    if (raw == 0) null
+    else ?Prim.nat64ToNat(raw)
+  };
 
 }

--- a/src/InternetComputer.mo
+++ b/src/InternetComputer.mo
@@ -85,8 +85,7 @@ module {
   /// Queries and unbounded-time update messages return null.
   public func replyDeadline() : ?Nat {
     let raw = Prim.replyDeadline();
-    if (raw == 0) null
-    else ?Prim.nat64ToNat(raw)
+    if (raw == 0) null else ?Prim.nat64ToNat(raw)
   };
 
 }

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -446,7 +446,7 @@
       "public let call : (canister : Principal, name : Text, data : Blob) -> async (reply : Blob)",
       "public func countInstructions(comp : () -> ()) : Nat64",
       "public let performanceCounter : (counter : Nat32) -> (value : Nat64)",
-      "public func replyDeadline() : Nat"
+      "public func replyDeadline() : ?Nat"
     ]
   },
   {


### PR DESCRIPTION
It occurred to me that we shouldn't force the user to check against some arbitrary `0`. Returning an option seems like the right way to model possible deadlines.

_Note_: this should be backported to the legacy base