### PR TITLE
Update to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It's also possible to start using both versions in parallel:
 
 ```toml
 base = "0.14.2"
-new-base = "0.1.0"
+new-base = "0.1.2"
 ```
 
 Since this is a preview release for community feedback, expect breaking changes.

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "new-base"
-version = "0.1.1"
+version = "0.1.2"
 description = "The new Motoko base library (preview)"
 repository = "https://github.com/dfinity/new-motoko-base"
 keywords = [ "base" ]

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -2044,7 +2044,7 @@ module {
 
   func containsInInternal<T>(internalNode : Internal<T>, compare : (T, T) -> Order.Order, element : T) : Bool {
     switch (NodeUtil.getElementIndex<T>(internalNode.data, compare, element)) {
-      case (#elementFound(index)) {
+      case (#elementFound(_index)) {
         true
       };
       case (#notFound(index)) {


### PR DESCRIPTION
Releases https://github.com/dfinity/new-motoko-base/pull/203, fixes a compiler warning, and updates the readme. 