### PR TITLE
Set toolchain version to 0.13.7

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -11,5 +11,5 @@ matchers = "https://github.com/kritzcreek/motoko-matchers#v1.3.1@5ba5f52bd9a5649
 test = "2.1.0"
 
 [toolchain]
-moc = "0.14.2"
+moc = "0.13.7"
 wasmtime = "17.0.0"

--- a/test/Random.test.mo
+++ b/test/Random.test.mo
@@ -176,7 +176,7 @@ suite(
           func(a, b) = Nat.toInt(random.natRange(a, b)),
           random.intRange
         ];
-        for (f in rangeFunctions.values()) {
+        for (f in rangeFunctions.vals()) {
           // (i, i + 1)
           for (i in Nat.range(0, 10)) {
             assert f(i, i + 1) == i

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -408,7 +408,7 @@ suite(
   }
 );
 
-queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].values()), func n = n < 3);
+queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].vals()), func n = n < 3);
 
 suite(
   "filter invariants",


### PR DESCRIPTION
Reconfigures the test runner to use `moc` from the latest dfx version. Since the priority is collecting user feedback, we want to make sure that developers can easily use the new base library without having to use a custom `moc` installation.