### PR TITLE
Add range functions to `Random.crypto()`

### DIFF
--- a/src/Random.mo
+++ b/src/Random.mo
@@ -129,7 +129,15 @@ module {
     };
 
     public func nat64() : Nat64 {
-      (Nat64.fromNat(Nat8.toNat(nat8())) << 56) | (Nat64.fromNat(Nat8.toNat(nat8())) << 48) | (Nat64.fromNat(Nat8.toNat(nat8())) << 40) | (Nat64.fromNat(Nat8.toNat(nat8())) << 32) | (Nat64.fromNat(Nat8.toNat(nat8())) << 24) | (Nat64.fromNat(Nat8.toNat(nat8())) << 16) | (Nat64.fromNat(Nat8.toNat(nat8())) << 8) | Nat64.fromNat(Nat8.toNat(nat8()))
+      // prettier-ignore
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 56) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 48) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 40) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 32) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 24) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 16) |
+      (Nat64.fromNat(Nat8.toNat(nat8())) << 8) |
+      (Nat64.fromNat(Nat8.toNat(nat8())))
     };
 
     public func nat64Range(fromInclusive : Nat64, toExclusive : Nat64) : Nat64 {
@@ -206,6 +214,67 @@ module {
           }
         }
       }
+    };
+
+    // Helper function which returns a uniformly sampled `Nat64` in the range `[0, max]`.
+    // Uses rejection sampling to ensure uniform distribution even when the range
+    // doesn't divide evenly into 2^64. This avoids modulo bias that would occur
+    // from simply taking the modulo of a random 64-bit number.
+    func uniform64(max : Nat64) : async* Nat64 {
+      if (max == 0) {
+        return 0
+      };
+      if (max == Nat64.maxValue) {
+        return await* nat64()
+      };
+      let toExclusive = max + 1;
+      // 2^64 - (2^64 % toExclusive) = (2^64-1) - (2^64-1 % toExclusive):
+      let cutoff = Nat64.maxValue - (Nat64.maxValue % toExclusive);
+      // 2^64 / toExclusive, with toExclusive > 1:
+      let multiple = Nat64.fromNat(/* 2^64 */ 0x10000000000000000 / Nat64.toNat(toExclusive));
+      loop {
+        // Build up a random Nat64 from bytes
+        var number = await* nat64();
+        // If number is below cutoff, we can use it
+        if (number < cutoff) {
+          // Scale down to desired range
+          return number / multiple
+        };
+        // Otherwise reject and try again
+      }
+    };
+
+    public func nat64() : async* Nat64 {
+      // prettier-ignore
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 56) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 48) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 40) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 32) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 24) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 16) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 8) |
+      (Nat64.fromNat(Nat8.toNat(await* nat8())))
+    };
+
+    public func nat64Range(fromInclusive : Nat64, toExclusive : Nat64) : async* Nat64 {
+      if (fromInclusive >= toExclusive) {
+        Runtime.trap("Random.nat64Range(): fromInclusive >= toExclusive")
+      };
+      (await* uniform64(toExclusive - fromInclusive - 1)) + fromInclusive
+    };
+
+    public func natRange(fromInclusive : Nat, toExclusive : Nat) : async* Nat {
+      if (fromInclusive >= toExclusive) {
+        Runtime.trap("Random.natRange(): fromInclusive >= toExclusive")
+      };
+      Nat64.toNat(await* uniform64(Nat64.fromNat(toExclusive - fromInclusive - 1))) + fromInclusive
+    };
+
+    public func intRange(fromInclusive : Int, toExclusive : Int) : async* Int {
+      if (fromInclusive >= toExclusive) {
+        Runtime.trap("Random.intRange(): fromInclusive >= toExclusive")
+      };
+      Nat64.toNat(await* uniform64(Nat64.fromNat(Nat.fromInt(toExclusive - fromInclusive - 1)))) + fromInclusive
     };
 
   };

--- a/test/Random.test.mo
+++ b/test/Random.test.mo
@@ -6,30 +6,30 @@ import Nat64 "../src/Nat64";
 import Float "../src/Float";
 import Bool "../src/Bool";
 import Array "../src/Array";
-import { suite; test; expect } = "mo:test";
+import { suite; test; expect } = "mo:test/async";
 
-suite(
+await suite(
   "Random.fast()",
-  func() {
-    test(
+  func() : async () {
+    await test(
       "bool(), seed = 0",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let expected = [false, false, false, true, true, false, true, true, false, false];
         expect.array(Array.tabulate<Bool>(10, func _ = random.bool()), Bool.toText, Bool.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "bool(), seed = 123456789",
-      func() {
+      func() : async () {
         let random = Random.fast(123456789);
         let expected = [false, false, true, false, true, false, false, true, true, false];
         expect.array(Array.tabulate<Bool>(10, func _ = random.bool()), Bool.toText, Bool.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "bool() has approximately uniform distribution",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         var trueCount = 0;
         let trials = 10000;
@@ -40,25 +40,25 @@ suite(
         assert ratio > 0.49 and ratio < 0.51
       }
     );
-    test(
+    await test(
       "nat8(), seed = 0",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let expected : [Nat8] = [27, 58, 135, 48, 175, 107, 232, 146, 65, 96];
         expect.array(Array.tabulate<Nat8>(10, func _ = random.nat8()), Nat8.toText, Nat8.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "nat8(), seed = 123456789",
-      func() {
+      func() : async () {
         let random = Random.fast(123456789);
         let expected : [Nat8] = [41, 152, 30, 100, 244, 79, 22, 249, 53, 2];
         expect.array(Array.tabulate<Nat8>(10, func _ = random.nat8()), Nat8.toText, Nat8.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "nat64(), seed = 0",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let expected : [Nat64] = [
           1962029230844536978,
@@ -70,9 +70,9 @@ suite(
         expect.array(Array.tabulate<Nat64>(5, func _ = random.nat64()), Nat64.toText, Nat64.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "nat64(), seed = 123456789",
-      func() {
+      func() : async () {
         let random = Random.fast(123456789);
         let expected : [Nat64] = [
           2997178970959451897,
@@ -84,9 +84,9 @@ suite(
         expect.array(Array.tabulate<Nat64>(5, func _ = random.nat64()), Nat64.toText, Nat64.equal).equal(expected)
       }
     );
-    test(
+    await test(
       "nat64() has approximately uniform distribution",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let trials = 10000;
         var sum = 0;
@@ -98,9 +98,9 @@ suite(
         assert Int.abs(avg - expectedAvg : Int) < expectedAvg / 100
       }
     );
-    test(
+    await test(
       "nat64Range() returns values within range",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let from : Nat64 = 10;
         let toExclusive : Nat64 = 20;
@@ -110,9 +110,9 @@ suite(
         }
       }
     );
-    test(
+    await test(
       "natRange() has approximately uniform distribution",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let from = 1000;
         let toExclusive = 2000;
@@ -126,9 +126,9 @@ suite(
         assert Int.abs(avg - expectedAvg : Int) < (toExclusive - from : Nat) / 100
       }
     );
-    test(
+    await test(
       "natRange() returns values within range",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let from = 10;
         let toExclusive = 20;
@@ -138,9 +138,9 @@ suite(
         }
       }
     );
-    test(
+    await test(
       "intRange() has approximately uniform distribution",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let from = -1000;
         let toExclusive = +1000;
@@ -154,9 +154,9 @@ suite(
         assert Int.abs(avg - expectedAvg) < (toExclusive - from) / 100
       }
     );
-    test(
+    await test(
       "intRange() returns values within range",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
         let from = -10;
         let toExclusive = 10;
@@ -166,9 +166,9 @@ suite(
         }
       }
     );
-    test(
+    await test(
       "*range()",
-      func() {
+      func() : async () {
         let random = Random.fast(0);
 
         let rangeFunctions : [(Nat, Nat) -> Int] = [
@@ -217,6 +217,48 @@ suite(
           assert count0 > 0;
           assert count1 > 0;
           assert count2 > 0
+        }
+      }
+    )
+  }
+);
+
+await suite(
+  "Random.crypto()",
+  func() : async () {
+    await test(
+      "nat64Range() returns values within range",
+      func() : async () {
+        let random = Random.fast(0);
+        let from : Nat64 = 10;
+        let toExclusive : Nat64 = 20;
+        for (_ in Nat.range(0, 1000)) {
+          let val = random.nat64Range(from, toExclusive);
+          assert val >= from and val < toExclusive
+        }
+      }
+    );
+    await test(
+      "natRange() returns values within range",
+      func() : async () {
+        let random = Random.fast(0);
+        let from = 10;
+        let toExclusive = 20;
+        for (_ in Nat.range(0, 1000)) {
+          let val = random.natRange(from, toExclusive);
+          assert val >= from and val < toExclusive
+        }
+      }
+    );
+    await test(
+      "intRange() returns values within range",
+      func() : async () {
+        let random = Random.fast(0);
+        let from = -10;
+        let toExclusive = 10;
+        for (_ in Nat.range(0, 1000)) {
+          let val = random.intRange(from, toExclusive);
+          assert val >= from and val < toExclusive
         }
       }
     )


### PR DESCRIPTION
Fills in missing implementations from `Random.fast()` for `Random.crypto()`.

Continuation of #52.