### PR TITLE
Improve `Random` module to allow persistence in stable memory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Fix bug in `Iter.step()` implementation
+* Adjust `Random` representation to allow persistence in stable memory
 
 ## 0.3.0
 

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -898,11 +898,13 @@
   {
     "name": "Random",
     "exports": [
-      "public class AsyncRandom(generator : () -> async* Blob)",
+      "public class AsyncRandom(",
       "public let blob : shared () -> async Blob",
       "public func crypto() : AsyncRandom",
       "public func fast(seed : Nat64) : Random",
-      "public class Random(generator : () -> Blob)"
+      "public func fromAsyncGenerator(generator : () -> async* Blob) : AsyncRandom",
+      "public func fromGenerator(generator : () -> Blob) : Random",
+      "public class Random("
     ]
   },
   {


### PR DESCRIPTION
Simplifies the `Random` and `AsyncRandom` classes by deferring state management to `nextBit` and `nextByte` input functions.

This makes it possible to store the state of `Random` / `AsyncRandom` instances in stable memory, which was not possible before due to bit iteration using an internally-managed state. 

The `Random(generator)` initialization prior to this PR remains available as `Random.fromGenerator(generator)`.

The performance impact of this change should be negligible or at least worth the extra flexibility. 
