### PR TITLE
Fix `Array.enumerate()` / `VarArray.enumerate()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * Add `burn : <system>Nat -> Nat` to `Cycles` (#228).
 * Fix bug in `Iter.step()` implementation
+* Fix bug in `Array.enumerate()` and `VarArray.enumerate()`
 
 ## 0.3.0
 

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -698,7 +698,7 @@ module {
     let size = array.size();
     var index = 0;
     public func next() : ?(Nat, T) {
-      if (index > size) {
+      if (index >= size) {
         return null
       };
       let i = index;

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -694,7 +694,7 @@ module {
   /// Runtime: O(1)
   ///
   /// Space: O(1)
-  public func enumerate<T>(array : [var T]) : Types.Iter<(Nat, T)> = object {
+  public func enumerate<T>(array : [T]) : Types.Iter<(Nat, T)> = object {
     let size = array.size();
     var index = 0;
     public func next() : ?(Nat, T) {

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -822,7 +822,7 @@ module {
     let size = array.size();
     var index = 0;
     public func next() : ?(Nat, T) {
-      if (index > size) {
+      if (index >= size) {
         return null
       };
       let i = index;

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -519,20 +519,20 @@ let suite = Suite.suite(
     Suite.test(
       "enumerate empty array",
       do {
-        var sum = 0;
-        for ((i, x) in Array.enumerate([var])) {
-          sum += i + x;
+        var hasItem = false;
+        for (_ in Array.enumerate([])) {
+          hasItem := true
         };
-        sum
+        hasItem
       },
-      M.equals(T.nat(0))
+      M.equals(T.bool(false))
     ),
     Suite.test(
       "enumerate non-empty array",
       do {
         var sum = 0;
-        for ((i, x) in Array.enumerate([var 10, 20, 30])) {
-          sum += i + x;
+        for ((i, x) in Array.enumerate([10, 20, 30])) {
+          sum += i + x
         };
         sum // Should be (0+10) + (1+20) + (2+30) = 63
       },
@@ -542,8 +542,8 @@ let suite = Suite.suite(
       "enumerate preserves indices",
       do {
         var indices = "";
-        for ((i, _) in Array.enumerate([var 'a', 'b', 'c'])) {
-          indices #= Nat.toText(i);
+        for ((i, _) in Array.enumerate(['a', 'b', 'c'])) {
+          indices #= Nat.toText(i)
         };
         indices
       },
@@ -553,8 +553,8 @@ let suite = Suite.suite(
       "enumerate preserves values",
       do {
         var values = "";
-        for ((_, x) in Array.enumerate([var 'a', 'b', 'c'])) {
-          values #= Char.toText(x);
+        for ((_, x) in Array.enumerate(['a', 'b', 'c'])) {
+          values #= Char.toText(x)
         };
         values
       },

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -515,6 +515,50 @@ let suite = Suite.suite(
       "Iter conversions empty",
       Array.fromIter<Nat>(Array.values([])),
       M.equals(T.array<Nat>(T.natTestable, []))
+    ),
+    Suite.test(
+      "enumerate empty array",
+      do {
+        var sum = 0;
+        for ((i, x) in Array.enumerate([var])) {
+          sum += i + x;
+        };
+        sum
+      },
+      M.equals(T.nat(0))
+    ),
+    Suite.test(
+      "enumerate non-empty array",
+      do {
+        var sum = 0;
+        for ((i, x) in Array.enumerate([var 10, 20, 30])) {
+          sum += i + x;
+        };
+        sum // Should be (0+10) + (1+20) + (2+30) = 63
+      },
+      M.equals(T.nat(63))
+    ),
+    Suite.test(
+      "enumerate preserves indices",
+      do {
+        var indices = "";
+        for ((i, _) in Array.enumerate([var 'a', 'b', 'c'])) {
+          indices #= Nat.toText(i);
+        };
+        indices
+      },
+      M.equals(T.text("012"))
+    ),
+    Suite.test(
+      "enumerate preserves values",
+      do {
+        var values = "";
+        for ((_, x) in Array.enumerate([var 'a', 'b', 'c'])) {
+          values #= Char.toText(x);
+        };
+        values
+      },
+      M.equals(T.text("abc"))
     )
   ]
 );

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -527,6 +527,50 @@ let suite = Suite.suite(
       "Iter conversions empty",
       VarArray.fromIter<Nat>(VarArray.values([var])),
       M.equals(varArray<Nat>(T.natTestable, [var]))
+    ),
+    Suite.test(
+      "enumerate empty array",
+      do {
+        var sum = 0;
+        for ((i, x) in VarArray.enumerate([var])) {
+          sum += i + x;
+        };
+        sum
+      },
+      M.equals(T.nat(0))
+    ),
+    Suite.test(
+      "enumerate non-empty array",
+      do {
+        var sum = 0;
+        for ((i, x) in VarArray.enumerate([var 10, 20, 30])) {
+          sum += i + x;
+        };
+        sum // Should be (0+10) + (1+20) + (2+30) = 63
+      },
+      M.equals(T.nat(63))
+    ),
+    Suite.test(
+      "enumerate preserves indices",
+      do {
+        var indices = "";
+        for ((i, _) in VarArray.enumerate([var 'a', 'b', 'c'])) {
+          indices #= Nat.toText(i);
+        };
+        indices
+      },
+      M.equals(T.text("012"))
+    ),
+    Suite.test(
+      "enumerate preserves values",
+      do {
+        var values = "";
+        for ((_, x) in VarArray.enumerate([var 'a', 'b', 'c'])) {
+          values #= Char.toText(x);
+        };
+        values
+      },
+      M.equals(T.text("abc"))
     )
   ]
 );

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -531,20 +531,20 @@ let suite = Suite.suite(
     Suite.test(
       "enumerate empty array",
       do {
-        var sum = 0;
-        for ((i, x) in VarArray.enumerate([var])) {
-          sum += i + x;
+        var hasItem = false;
+        for (_ in VarArray.enumerate([var])) {
+          hasItem := true
         };
-        sum
+        hasItem
       },
-      M.equals(T.nat(0))
+      M.equals(T.bool(false))
     ),
     Suite.test(
       "enumerate non-empty array",
       do {
         var sum = 0;
         for ((i, x) in VarArray.enumerate([var 10, 20, 30])) {
-          sum += i + x;
+          sum += i + x
         };
         sum // Should be (0+10) + (1+20) + (2+30) = 63
       },
@@ -555,7 +555,7 @@ let suite = Suite.suite(
       do {
         var indices = "";
         for ((i, _) in VarArray.enumerate([var 'a', 'b', 'c'])) {
-          indices #= Nat.toText(i);
+          indices #= Nat.toText(i)
         };
         indices
       },
@@ -566,7 +566,7 @@ let suite = Suite.suite(
       do {
         var values = "";
         for ((_, x) in VarArray.enumerate([var 'a', 'b', 'c'])) {
-          values #= Char.toText(x);
+          values #= Char.toText(x)
         };
         values
       },


### PR DESCRIPTION
Fixes a bug in Array / VarArray `enumerate()` (introduced in the new base library) and includes tests.