### PR TITLE
Make `pure/List` and `pure/Queue` stack-safe

### DIFF
--- a/bench/PureListStackSafety.bench.mo
+++ b/bench/PureListStackSafety.bench.mo
@@ -10,8 +10,8 @@ module {
   public func init() : Bench.Bench {
     let bench = Bench.Bench();
 
-    bench.name("Stack safety");
-    bench.description("Check stack-safety of the following functions.");
+    bench.name("List Stack safety");
+    bench.description("Check stack-safety of the following `pure/List`-related functions.");
 
     bench.rows([
       "pure/List.split",

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -1,9 +1,10 @@
 import Bench "mo:bench";
 
 import Nat "../src/Nat";
+import Option "../src/Option";
 import List "../src/pure/List";
 import Queue "../src/pure/Queue";
-import Option "../src/Option";
+import Runtime "../src/Runtime";
 
 module {
   public func init() : Bench.Bench {
@@ -16,7 +17,9 @@ module {
       "pure/List.split",
       "pure/List.all",
       "pure/List.any",
-      "pure/Queue"
+      // "pure/List.map",
+      // "pure/List.foldRight",
+      // "pure/Queue",
     ]);
     bench.cols([""]);
 
@@ -28,6 +31,8 @@ module {
           case "pure/List.split" ignore List.split(list, 99_999);
           case "pure/List.all" ignore List.all<Nat>(list, func x = 1 == x);
           case "pure/List.any" ignore not List.any<Nat>(list, func x = 1 != x);
+          // case "pure/List.map" ignore List.map<Nat, Nat>(list, func x = x + 1);
+          // case "pure/List.foldRight" ignore List.foldRight<Nat, Nat>(list, 0, Nat.add);
           // case "pure/Queue" {
           //   var q = Queue.empty<Nat>();
           //   let n = 100_000;
@@ -39,7 +44,7 @@ module {
           //   };
           //   assert Queue.size(q) == 0
           // };
-          case _ return ()
+          case _ Runtime.unreachable()
         }
       }
     );

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -25,13 +25,16 @@ module {
       "pure/List.flatten",
       "pure/List.take",
       "pure/List.drop",
-      // "pure/List.foldRight",
+      "pure/List.foldRight",
+      "pure/List.merge",
+      "pure/List.chunks",
       // "pure/Queue",
     ]);
     bench.cols([""]);
 
     let list = List.repeat(1, 100_000);
     let listOfLists = List.repeat(List.repeat(1, 1), 100_000);
+    let list02 = List.fromArray([0, 2]);
 
     bench.runner(
       func(row, col) {
@@ -47,7 +50,9 @@ module {
           case "pure/List.flatten" ignore List.flatten(listOfLists);
           case "pure/List.take" ignore List.take<Nat>(list, 99_999);
           case "pure/List.drop" ignore List.drop<Nat>(list, 99_999);
-          // case "pure/List.foldRight" ignore List.foldRight<Nat, Nat>(list, 0, Nat.add);
+          case "pure/List.foldRight" ignore List.foldRight<Nat, Nat>(list, 0, Nat.add);
+          case "pure/List.merge" ignore List.merge<Nat>(list, list02, Nat.compare);
+          case "pure/List.chunks" ignore List.chunks<Nat>(list, 1);
           // case "pure/Queue" {
           //   var q = Queue.empty<Nat>();
           //   let n = 100_000;

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -17,13 +17,21 @@ module {
       "pure/List.split",
       "pure/List.all",
       "pure/List.any",
-      // "pure/List.map",
+      "pure/List.map",
+      "pure/List.filter",
+      "pure/List.filterMap",
+      "pure/List.partition",
+      "pure/List.join",
+      "pure/List.flatten",
+      "pure/List.take",
+      "pure/List.drop",
       // "pure/List.foldRight",
       // "pure/Queue",
     ]);
     bench.cols([""]);
 
     let list = List.repeat(1, 100_000);
+    let listOfLists = List.repeat(List.repeat(1, 1), 100_000);
 
     bench.runner(
       func(row, col) {
@@ -31,7 +39,14 @@ module {
           case "pure/List.split" ignore List.split(list, 99_999);
           case "pure/List.all" ignore List.all<Nat>(list, func x = 1 == x);
           case "pure/List.any" ignore not List.any<Nat>(list, func x = 1 != x);
-          // case "pure/List.map" ignore List.map<Nat, Nat>(list, func x = x + 1);
+          case "pure/List.map" ignore List.map<Nat, Nat>(list, func x = x + 1);
+          case "pure/List.filter" ignore List.filter<Nat>(list, func x = x == 1);
+          case "pure/List.filterMap" ignore List.filterMap<Nat, Nat>(list, func x = if (x == 1) ?(x + 1) else null);
+          case "pure/List.partition" ignore List.partition<Nat>(list, func x = x == 1);
+          case "pure/List.join" ignore List.join(List.values listOfLists);
+          case "pure/List.flatten" ignore List.flatten(listOfLists);
+          case "pure/List.take" ignore List.take<Nat>(list, 99_999);
+          case "pure/List.drop" ignore List.drop<Nat>(list, 99_999);
           // case "pure/List.foldRight" ignore List.foldRight<Nat, Nat>(list, 0, Nat.add);
           // case "pure/Queue" {
           //   var q = Queue.empty<Nat>();

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -14,17 +14,20 @@ module {
 
     bench.rows([
       "pure/List.split",
+      "pure/List.all",
+      "pure/List.any",
       "pure/Queue"
     ]);
     bench.cols([""]);
 
+    let list = List.repeat(1, 100_000);
+
     bench.runner(
       func(row, col) {
         switch row {
-          case "pure/List.split" {
-            let list = List.repeat(1, 100_000);
-            ignore List.split(list, 99_999)
-          };
+          case "pure/List.split" ignore List.split(list, 99_999);
+          case "pure/List.all" ignore List.all<Nat>(list, func x = 1 == x);
+          case "pure/List.any" ignore not List.any<Nat>(list, func x = 1 != x);
           // case "pure/Queue" {
           //   var q = Queue.empty<Nat>();
           //   let n = 100_000;

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -28,7 +28,7 @@ module {
       "pure/List.foldRight",
       "pure/List.merge",
       "pure/List.chunks",
-      // "pure/Queue",
+      "pure/Queue"
     ]);
     bench.cols([""]);
 
@@ -53,17 +53,17 @@ module {
           case "pure/List.foldRight" ignore List.foldRight<Nat, Nat>(list, 0, Nat.add);
           case "pure/List.merge" ignore List.merge<Nat>(list, list02, Nat.compare);
           case "pure/List.chunks" ignore List.chunks<Nat>(list, 1);
-          // case "pure/Queue" {
-          //   var q = Queue.empty<Nat>();
-          //   let n = 100_000;
-          //   for (i in Nat.range(0, 2 * n)) q := Queue.pushBack(q, i);
-          //   assert Queue.size(q) == 2 * n;
-          //   for (_ in Nat.range(0, n)) {
-          //     q := Option.unwrap(Queue.popBack(q)).0;
-          //     q := Option.unwrap(Queue.popFront(q)).1
-          //   };
-          //   assert Queue.size(q) == 0
-          // };
+          case "pure/Queue" {
+            var q = Queue.empty<Nat>();
+            let n = 100_000;
+            for (i in Nat.range(0, 2 * n)) q := Queue.pushBack(q, i);
+            assert Queue.size(q) == 2 * n;
+            for (_ in Nat.range(0, n)) {
+              q := Option.unwrap(Queue.popBack(q)).0;
+              q := Option.unwrap(Queue.popFront(q)).1
+            };
+            assert Queue.size(q) == 0
+          };
           case _ Runtime.unreachable()
         }
       }

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -13,7 +13,7 @@ module {
     bench.rows([
       "List.split"
     ]);
-    bench.cols([""]);
+    bench.cols(["Should not cause a stack overflow"]);
 
     let splitN = 100_000;
     let list = List.repeat(1, splitN);

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -2,26 +2,40 @@ import Bench "mo:bench";
 
 import Nat "../src/Nat";
 import List "../src/pure/List";
+import Queue "../src/pure/Queue";
+import Option "../src/Option";
 
 module {
   public func init() : Bench.Bench {
     let bench = Bench.Bench();
 
-    bench.name("");
-    bench.description("");
+    bench.name("Stack safety");
+    bench.description("Check stack-safety of the following functions.");
 
     bench.rows([
-      "List.split"
+      "pure/List.split",
+      "pure/Queue"
     ]);
-    bench.cols(["Should not cause a stack overflow"]);
-
-    let splitN = 100_000;
-    let list = List.repeat(1, splitN);
+    bench.cols([""]);
 
     bench.runner(
       func(row, col) {
         switch row {
-          case "List.split" ignore List.split(list, splitN - 1 : Nat);
+          case "pure/List.split" {
+            let list = List.repeat(1, 100_000);
+            ignore List.split(list, 99_999)
+          };
+          // case "pure/Queue" {
+          //   var q = Queue.empty<Nat>();
+          //   let n = 100_000;
+          //   for (i in Nat.range(0, 2 * n)) q := Queue.pushBack(q, i);
+          //   assert Queue.size(q) == 2 * n;
+          //   for (_ in Nat.range(0, n)) {
+          //     q := Option.unwrap(Queue.popBack(q)).0;
+          //     q := Option.unwrap(Queue.popFront(q)).1
+          //   };
+          //   assert Queue.size(q) == 0
+          // };
           case _ return ()
         }
       }

--- a/bench/StackSafety.bench.mo
+++ b/bench/StackSafety.bench.mo
@@ -1,0 +1,32 @@
+import Bench "mo:bench";
+
+import Nat "../src/Nat";
+import List "../src/pure/List";
+
+module {
+  public func init() : Bench.Bench {
+    let bench = Bench.Bench();
+
+    bench.name("");
+    bench.description("");
+
+    bench.rows([
+      "List.split"
+    ]);
+    bench.cols([""]);
+
+    let splitN = 100_000;
+    let list = List.repeat(1, splitN);
+
+    bench.runner(
+      func(row, col) {
+        switch row {
+          case "List.split" ignore List.split(list, splitN - 1 : Nat);
+          case _ return ()
+        }
+      }
+    );
+
+    bench
+  }
+}

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -702,12 +702,12 @@ module {
   /// Runtime: O(n)
   ///
   /// Space: O(n)
-  public func split<T>(list : List<T>, n : Nat) : (List<T>, List<T>) = if (n == 0) (null, list) else switch list {
-    case null (null, null);
-    case (?(h, t)) {
-      let (l1, l2) = split(t, n - 1 : Nat);
-      (?(h, l1), l2)
-    }
+  public func split<T>(list : List<T>, n : Nat) : (List<T>, List<T>) {
+    func go(n : Nat, list : List<T>, acc : List<T>) : (List<T>, List<T>) = if (n == 0) (reverse acc, list) else switch list {
+      case (?(h, t)) go(n - 1 : Nat, t, ?(h, acc));
+      case null (reverse acc, null)
+    };
+    go(n, list, null)
   };
 
   /// Split the given list into chunks of length `n`.

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -133,24 +133,15 @@ module {
     case _ { debug assert List.isEmpty(queue.0); null }
   };
 
-  // helper to split the list evenly
-  func takeDrop<T>(list : List<T>, n : Nat) : (List<T>, List<T>) = if (n == 0) (null, list) else switch list {
-    case null (null, null);
-    case (?(h, t)) {
-      let (f, b) = takeDrop(t, n - 1 : Nat);
-      (?(h, f), b)
-    }
-  };
-
   // helper to rebalance the queue after getting lopsided
   func check<T>(q : Queue<T>) : Queue<T> {
     switch q {
       case (null, n, r) {
-        let (a, b) = takeDrop(r, n / 2);
+        let (a, b) = List.split(r, n / 2);
         (List.reverse b, n, a)
       };
       case (f, n, null) {
-        let (a, b) = takeDrop(f, n / 2);
+        let (a, b) = List.split(f, n / 2);
         (a, n, List.reverse b)
       };
       case q q

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,7 +1,6 @@
 import { run; suite; test } "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
-import Test "mo:test";
 
 import List "../../src/pure/List";
 import Nat "../../src/Nat";
@@ -1611,20 +1610,4 @@ run(
       toText
     ]
   )
-);
-
-Test.suite(
-  "Large",
-  func() {
-    Test.test(
-      "split",
-      func() {
-        // let n = 100_000;
-        // let list = List.repeat(1, n);
-        // let (left, right) = List.split(list, n - 1 : Nat);
-        // Test.expect.nat(List.size(left)).equal(n - 1);
-        // Test.expect.nat(List.size(right)).equal(1)
-      }
-    )
-  }
 )

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1613,16 +1613,12 @@ run(
   )
 );
 
-func rec(n : Nat) : Nat = if (n == 0) 0 else rec(n - 1) + 1;
-
 Test.suite(
   "Large",
   func() {
     Test.test(
       "split",
       func() {
-        let n = 1_000_000_000;
-        Test.expect.nat(rec(n)).equal(n);
         // let n = 100_000;
         // let list = List.repeat(1, n);
         // let (left, right) = List.split(list, n - 1 : Nat);

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,6 +1,7 @@
 import { run; suite; test } "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
+import Test "mo:test";
 
 import List "../../src/pure/List";
 import Nat "../../src/Nat";
@@ -8,7 +9,9 @@ import Order "../../src/Order";
 import Debug "../../src/Debug";
 import Int "../../src/Int";
 import Result "../../src/Result";
+import Iter "../../src/Iter";
 
+// TODO: Use `mo:test` for new tests, migrate legacy tests.
 /*
 
 FIXME: (CHECK these)
@@ -1610,4 +1613,34 @@ run(
       toText
     ]
   )
+);
+
+type List<T> = List.List<T>;
+
+Test.suite(
+  "join",
+  func() {
+    func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
+      let inputIter = Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x));
+      let result = List.join(inputIter);
+      Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
+    };
+    Test.test("empty", t([], []));
+    Test.test("one", t([[1, 2, 3]], [1, 2, 3]));
+    Test.test("three", t([[1, 2, 3], [4, 5, 6], [7, 8, 9]], [1, 2, 3, 4, 5, 6, 7, 8, 9]))
+  }
+);
+
+Test.suite(
+  "flatten",
+  func() {
+    func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
+      let inputList = List.fromIter(Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x)));
+      let result = List.flatten(inputList);
+      Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
+    };
+    Test.test("empty", t([], []));
+    Test.test("one", t([[1, 2, 3]], [1, 2, 3]));
+    Test.test("three", t([[1, 2, 3], [4, 5, 6], [7, 8, 9]], [1, 2, 3, 4, 5, 6, 7, 8, 9]))
+  }
 )

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1,6 +1,7 @@
 import { run; suite; test } "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
+import Test "mo:test";
 
 import List "../../src/pure/List";
 import Nat "../../src/Nat";
@@ -1610,4 +1611,24 @@ run(
       toText
     ]
   )
+);
+
+func rec(n : Nat) : Nat = if (n == 0) 0 else rec(n - 1) + 1;
+
+Test.suite(
+  "Large",
+  func() {
+    Test.test(
+      "split",
+      func() {
+        let n = 1_000_000_000;
+        Test.expect.nat(rec(n)).equal(n);
+        // let n = 100_000;
+        // let list = List.repeat(1, n);
+        // let (left, right) = List.split(list, n - 1 : Nat);
+        // Test.expect.nat(List.size(left)).equal(n - 1);
+        // Test.expect.nat(List.size(right)).equal(1)
+      }
+    )
+  }
 )

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1261,7 +1261,7 @@
       "public func fromVarArray<T>(array : [var T]) : List<T>",
       "public func get<T>(list : List<T>, n : Nat) : ?T",
       "public func isEmpty<T>(list : List<T>) : Bool",
-      "public func join<T>(list : Iter.Iter<List<T>>) : List<T>",
+      "public func join<T>(iter : Iter.Iter<List<T>>) : List<T>",
       "public func last<T>(list : List<T>) : ?T",
       "public type List<T>",
       "public func map<T1, T2>(list : List<T1>, f : T1 -> T2) : List<T2>",


### PR DESCRIPTION
- Improves the stack safety and performance of various `pure/List` operations.
  - Changed operations are `map`, `filter`, `filterMap`, `partition`, `take`, `split`, `chunks`, `join`, `flatten`, `foldRight`, `merge`, and `zipWith`.
  - These functions now use tail-recursive helper functions for improved stack safety.
  - On top of that `flatten` is no longer quadratic.
- Makes `pure/Queue` stack safe by using the improved `List.split` instead of the `takeDrop` helper.
- Adds new benchmarks and missing tests.

### Benchmarking:

* Introduced a new benchmark suite `PureListStackSafety.bench.mo` to evaluate the stack safety of various `pure/List` functions.
* The benchmark can later be used to track the performance of these operations. FYI @crusso : If we implement 'Tail Recursion Modulo Cons' we can use the benchmark to see how much we would gain.

### Testing:

* Added new tests using the `mo:test` framework for the `join` and `flatten` functions in `List.test.mo`.
