### PR TITLE
Optimize `Iter.reverse`

### DIFF
--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -2,9 +2,10 @@ import Bench "mo:bench";
 import Fuzz "mo:fuzz";
 
 import Array "../src/Array";
+import Iter "../src/Iter";
+import Nat "../src/Nat";
 import List "../src/pure/List";
 import Runtime "../src/Runtime";
-import Nat "../src/Nat";
 
 module {
   public func init() : Bench.Bench {
@@ -15,7 +16,8 @@ module {
 
     bench.rows([
       "Array.fromIter",
-      "List.fromIter"
+      "List.fromIter",
+      "List.fromIter . Iter.reverse"
     ]);
     bench.cols([
       "100",
@@ -41,8 +43,9 @@ module {
         };
         switch (row) {
           case "List.fromIter" ignore List.fromIter(array.vals());
+          case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.vals()));
           case "Array.fromIter" ignore Array.fromIter(array.vals());
-          case _ return ()
+          case _ Runtime.unreachable()
         }
       }
     );

--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -41,7 +41,7 @@ module {
           case "100_000" array3;
           case _ Runtime.unreachable()
         };
-        switch (row) {
+        switch row {
           case "List.fromIter" ignore List.fromIter(array.vals());
           case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.vals()));
           case "Array.fromIter" ignore Array.fromIter(array.vals());

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -819,7 +819,21 @@ module {
   ///
   /// Space: O(n) where n is the number of elements in the iterator
   public func reverse<T>(iter : Iter<T>) : Iter<T> {
-    fromArray(Array.reverse(toArray(iter))) // TODO: optimize
+    var acc : Types.Pure.List<T> = null;
+    for (x in iter) {
+      acc := ?(x, acc)
+    };
+    object {
+      public func next() : ?T {
+        switch (acc) {
+          case null null;
+          case (?(h, t)) {
+            acc := t;
+            ?h
+          }
+        }
+      }
+    }
   };
 
 }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -825,7 +825,7 @@ module {
     };
     object {
       public func next() : ?T {
-        switch (acc) {
+        switch acc {
           case null null;
           case (?(h, t)) {
             acc := t;

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -824,10 +824,9 @@ module {
   /// Space: O(size)
   public func fromIter<T>(iter : Iter.Iter<T>) : List<T> {
     var result : List<T> = null;
-    Iter.forEach<T>(
-      iter,
-      func x = result := ?(x, result)
-    );
+    for (x in iter) {
+      result := ?(x, result)
+    };
     reverse result
   };
 


### PR DESCRIPTION
- Replace `Iter.reverse` implementation by using the `pure/List`
- Use `for` instead of `Iter.forEach` for `List.fromIter`
- Add relevant benchmarks

Remarks:
- The new `Iter.reverse` gets a **speed up of 50%** in terms of instructions, see the [manual benchmark comment](https://github.com/dfinity/new-motoko-base/pull/266#issuecomment-2769037480)