### PR TITLE
Workflow: Make `validate-changelog` and skipping tests work again

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,13 +9,17 @@ on:
       - main
 
 jobs:
+  check-motoko-changes:
+    uses: ./.github/workflows/check-motoko-changes.yml
+
   benchmark:
+    needs: check-motoko-changes
+    if: needs.check-motoko-changes.outputs.has_mo_changes == 'true'
     runs-on: ubuntu-24.04
     name: Run Benchmarks and Comment on PR or Upload on push
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/setup
         with:
           setup-dfx: true

--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -6,12 +6,20 @@ on:
       has_mo_changes:
         description: "Whether there are any Motoko file changes"
         value: ${{ jobs.check.outputs.has_mo_changes }}
+      has_src_mo_changes:
+        description: "Whether there are any Motoko file changes in src directory"
+        value: ${{ jobs.check.outputs.has_src_mo_changes }}
+      has_changelog_changes:
+        description: "Whether Changelog.md was modified"
+        value: ${{ jobs.check.outputs.has_changelog_changes }}
 
 jobs:
   check:
     runs-on: ubuntu-24.04
     outputs:
       has_mo_changes: ${{ steps.check_mo_changes.outputs.has_mo_changes }}
+      has_src_mo_changes: ${{ steps.check_mo_changes.outputs.has_src_mo_changes }}
+      has_changelog_changes: ${{ steps.check_mo_changes.outputs.has_changelog_changes }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,9 +31,26 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha || '$(git rev-parse HEAD~1)' }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
+          # Check for any .mo changes
           if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
             echo "has_mo_changes=false" >> $GITHUB_OUTPUT
             echo "No Motoko file changes detected"
           else
             echo "has_mo_changes=true" >> $GITHUB_OUTPUT
-          fi 
+          fi
+
+          # Check for src/*.mo changes
+          if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^src/.*\.mo$'; then
+            echo "has_src_mo_changes=false" >> $GITHUB_OUTPUT
+            echo "No Motoko file changes in src directory detected"
+          else
+            echo "has_src_mo_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for Changelog.md changes
+          if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^Changelog\.md$'; then
+            echo "has_changelog_changes=false" >> $GITHUB_OUTPUT
+            echo "No Changelog.md changes detected"
+          else
+            echo "has_changelog_changes=true" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -1,0 +1,31 @@
+name: Check Motoko Changes
+
+on:
+  workflow_call:
+    outputs:
+      has_mo_changes:
+        description: "Whether there are any Motoko file changes"
+        value: ${{ jobs.check.outputs.has_mo_changes }}
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    outputs:
+      has_mo_changes: ${{ steps.check_mo_changes.outputs.has_mo_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check for Motoko file changes
+        id: check_mo_changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || '$(git rev-parse HEAD~1)' }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
+            echo "has_mo_changes=false" >> $GITHUB_OUTPUT
+            echo "No Motoko file changes detected"
+          else
+            echo "has_mo_changes=true" >> $GITHUB_OUTPUT
+          fi 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
 
 jobs:
+  check-motoko-changes:
+    uses: ./.github/workflows/check-motoko-changes.yml
+
   validate-changelog:
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
@@ -67,24 +70,10 @@ jobs:
       - run: npm run format:check
 
   test:
+    needs: check-motoko-changes
+    if: needs.check-motoko-changes.outputs.has_mo_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
-      - name: Check for Motoko file changes
-        id: check_mo_changes
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha || '$(git rev-parse HEAD~1)' }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-
-          if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
-            echo "has_mo_changes=false" >> $GITHUB_OUTPUT
-            echo "No Motoko file changes detected, skipping tests"
-          else
-            echo "has_mo_changes=true" >> $GITHUB_OUTPUT
-          fi
       - uses: ./.github/actions/setup
-        if: steps.check_mo_changes.outputs.has_mo_changes == 'true'
       - run: npm test
-        if: steps.check_mo_changes.outputs.has_mo_changes == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,18 +7,26 @@ on:
 
 jobs:
   validate-changelog:
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
       - uses: ./.github/actions/setup
         with:
           setup-mops: false
       - run: npm run validate:changelog
       - name: Check for Motoko file changes
         run: |
-          if git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} HEAD | grep -q '^src/.*\.mo$'; then
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^src/.*\.mo$'; then
             echo "Found modified Motoko files, checking for Changelog.md update..."
-            if ! git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} HEAD | grep -q '^Changelog\.md$'; then
+            if git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^Changelog\.md$'; then
+              echo "Changelog.md was updated"
+            else
               echo "Error: Motoko files were modified but Changelog.md was not updated"
               exit 1
             fi
@@ -62,11 +70,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
       - uses: ./.github/actions/setup
       - name: Check for Motoko file changes in 'src' directory
         id: check_mo_changes
         run: |
-          if ! git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} HEAD | grep -q '\.mo$'; then
+          BASE_SHA="${{ github.event.pull_request.base.sha || '$(git rev-parse HEAD~1)' }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
             echo "No Motoko file changes in src directory detected, skipping tests"
             exit 0
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           setup-mops: false
       - run: npm run validate:changelog
-      - name: Validate Changelog for Motoko changes
+      - name: Verify Changelog updated when Motoko source files changed
         if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true'
         run: |
           if [ "${{ needs.check-motoko-changes.outputs.has_changelog_changes }}" != "true" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for all branches and tags
-      - uses: ./.github/actions/setup
       - name: Check for Motoko file changes in 'src' directory
         id: check_mo_changes
         run: |
@@ -85,5 +84,7 @@ jobs:
           else
             echo "has_mo_changes=true" >> $GITHUB_OUTPUT
           fi
+      - uses: ./.github/actions/setup
+        if: steps.check_mo_changes.outputs.has_mo_changes == 'true'
       - run: npm test
         if: steps.check_mo_changes.outputs.has_mo_changes == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for all branches and tags
-      - name: Check for Motoko file changes in 'src' directory
+      - name: Check for Motoko file changes
         id: check_mo_changes
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha || '$(git rev-parse HEAD~1)' }}"
@@ -80,7 +80,7 @@ jobs:
 
           if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
             echo "has_mo_changes=false" >> $GITHUB_OUTPUT
-            echo "No Motoko file changes in src directory detected, skipping tests"
+            echo "No Motoko file changes detected, skipping tests"
           else
             echo "has_mo_changes=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,10 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           if ! git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '\.mo$'; then
+            echo "has_mo_changes=false" >> $GITHUB_OUTPUT
             echo "No Motoko file changes in src directory detected, skipping tests"
-            exit 0
+          else
+            echo "has_mo_changes=true" >> $GITHUB_OUTPUT
           fi
       - run: npm test
+        if: steps.check_mo_changes.outputs.has_mo_changes == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,30 +10,23 @@ jobs:
     uses: ./.github/workflows/check-motoko-changes.yml
 
   validate-changelog:
+    needs: check-motoko-changes
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
       - uses: ./.github/actions/setup
         with:
           setup-mops: false
       - run: npm run validate:changelog
-      - name: Check for Motoko file changes
+      - name: Validate Changelog for Motoko changes
+        if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true'
         run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-
-          if git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^src/.*\.mo$'; then
-            echo "Found modified Motoko files, checking for Changelog.md update..."
-            if git diff --name-only $BASE_SHA $HEAD_SHA | grep -q '^Changelog\.md$'; then
-              echo "Changelog.md was updated"
-            else
-              echo "Error: Motoko files were modified but Changelog.md was not updated"
-              exit 1
-            fi
+          if [ "${{ needs.check-motoko-changes.outputs.has_changelog_changes }}" != "true" ]; then
+            echo "Error: Motoko files were modified but Changelog.md was not updated"
+            exit 1
           fi
+          echo "Changelog.md was updated"
 
   validate-version:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Workflow changes:
1. `validate-changelog` now correctly fails when there are no `Changelog.md` changes but there are `src/*.mo` changes -- no changes in logic, just fixing the existing one
2. Similar fix applied to skipping tests when there are no *.mo changes
3. Added skipping benchmarks as well

Details:
- Fixes how to get the correct `HEAD` commit reference in a workflow
- Corrects the skipping tests step to actually prevent the next step from executing
- Fetches the full git history where it is necessary