### PR TITLE
chore: bump `mops` to 1.5.1

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -53,6 +53,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ${{ steps.benchmarks.outputs.result }}
+            
             **Note**: Renamed benchmarks cannot be compared. Refer to the [current baseline](https://github.com/dfinity/new-motoko-base/tree/benchmark-results) for manual comparison.
           edit-mode: replace
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "execa": "^4.1.0",
         "fast-glob": "^3.3.2",
-        "ic-mops": "^1.4.0",
+        "ic-mops": "^1.5.1",
         "mo-dev": "^0.13.0",
         "npm-run-all": "^4.1.5",
         "prettier": "2",
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/ic-mops": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-1.4.0.tgz",
-      "integrity": "sha512-EPuhzUVFFMBcZcbrFkiA27GXWUDTNo5ptoWKdM0oWXKl9TqfAGQ44ZpSTdYG7kagomW4j+zpGz2xhsMuDLMI6Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ic-mops/-/ic-mops-1.5.1.tgz",
+      "integrity": "sha512-sgcRsZAi6mb0vfK2KWwD9pyQmW1GPlpeq8gco2HPyZ7HET7RHQLw4lGLunafvmqIUy8B2t+Tn+nG6Y5O9oim2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "execa": "^4.1.0",
     "fast-glob": "^3.3.2",
-    "ic-mops": "^1.4.0",
+    "ic-mops": "^1.5.1",
     "mo-dev": "^0.13.0",
     "npm-run-all": "^4.1.5",
     "prettier": "2",


### PR DESCRIPTION
- bump `mops` to `^1.5.1`
- fix formatting of the benchmark PR comment note