### PR TITLE
chore: benchmarks should fail when `mops bench` fails

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: benchmarks
         run: |  # Make sure to use the same flags as in the `mops bench` command below!
+          set -o pipefail
           npx mops bench --compare 2>&1 | tee benchmark_results.txt
           echo "result<<EOF" >> $GITHUB_OUTPUT
           cat benchmark_results.txt >> $GITHUB_OUTPUT
@@ -64,6 +65,7 @@ jobs:
       - name: Generate Benchmark Results
         if: github.event_name != 'pull_request'
         run: | # Make sure to use the same flags as in the `mops bench` command above!
+          set -o pipefail
           npx mops bench --save 2>&1 | tee bench-results.md 
       - name: Move Generated Results
         if: github.event_name != 'pull_request'

--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -1,6 +1,7 @@
 import Bench "mo:bench";
 import Fuzz "mo:fuzz";
 
+import Array "../src/Array";
 import Iter "../src/Iter";
 import Nat "../src/Nat";
 import List "../src/pure/List";

--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -1,7 +1,6 @@
 import Bench "mo:bench";
 import Fuzz "mo:fuzz";
 
-import Array "../src/Array";
 import Iter "../src/Iter";
 import Nat "../src/Nat";
 import List "../src/pure/List";


### PR DESCRIPTION
Modifies the benchmark workflow to fail when the `mops bench` command fails.