### PR TITLE
Replace `Set.toText` by `Iter.toArray(Set.toIter ...)` in examples

### DIFF
--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -63,7 +63,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert Set.toText(set, Nat.toText) == "{1, 2, 3}";
+  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -90,16 +90,17 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set0 = Set.empty<Nat>();
   ///   let set1 = Set.add(set0, Nat.compare, 2);
   ///   let set2 = Set.add(set1, Nat.compare, 1);
   ///   let set3 = Set.add(set2, Nat.compare, 2);
-  ///   assert Set.toText(set0, Nat.toText) == "{}";
-  ///   assert Set.toText(set1, Nat.toText) == "{2}";
-  ///   assert Set.toText(set2, Nat.toText) == "{1, 2}";
-  ///   assert Set.toText(set3, Nat.toText) == "{1, 2}";
+  ///   assert Iter.toArray(Set.values(set0)) == [];
+  ///   assert Iter.toArray(Set.values(set1)) == [2];
+  ///   assert Iter.toArray(Set.values(set2)) == [1, 2];
+  ///   assert Iter.toArray(Set.values(set3)) == [1, 2];
   /// }
   /// ```
   ///
@@ -121,15 +122,19 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
-  ///   let r1 = Set.insert(Set.empty<Nat>(), Nat.compare, 2);
-  ///   assert r1.1;
-  ///   let r2 = Set.insert(r1.0, Nat.compare, 1);
-  ///   assert r2.1;
-  ///   let r3 = Set.insert(r2.0, Nat.compare, 2);
-  ///   assert not r3.1;
-  ///   assert Set.toText(r3.0, Nat.toText) == "{1, 2}"
+  ///   let set0 = Set.empty();
+  ///   do {
+  ///     let (set1, new1) = Set.insert(set0, Nat.compare, 2);
+  ///     assert new1;
+  ///     let (set2, new2) = Set.insert(set1, Nat.compare, 1);
+  ///     assert new2;
+  ///     let (set3, new3) = Set.insert(set2, Nat.compare, 2);
+  ///     assert not new3;
+  ///     assert Iter.toArray(Set.values(set3)) == [1, 2]
+  ///   }
   /// }
   /// ```
   ///
@@ -149,13 +154,14 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
-  ///   assert Set.toText(set2, Nat.toText) == "{1, 3}"
+  ///   assert Iter.toArray(Set.values(set2)) == [1, 3];
   /// }
   /// ```
   ///
@@ -177,16 +183,18 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///
-  ///   let r1 = Set.delete(set, Nat.compare, 2);
-  ///   assert r1.1;
-  ///   assert Set.toText(r1.0, Nat.toText) == "{1, 3}";
-  ///   let r2 = Set.delete(r1.0, Nat.compare, 4);
-  ///   assert not r2.1;
-  ///   assert Set.toText(r2.0, Nat.toText) == "{1, 3}";
+  ///   do {
+  ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
+  ///     assert contained1;
+  ///     assert Iter.toArray(Set.values(set1)) == [1, 3];
+  ///     let (set2, contained2) = Set.delete(set1, Nat.compare, 4);
+  ///     assert not contained2;
+  ///     assert Iter.toArray(Set.values(set2)) == [1, 3];
+  ///   }
   /// }
   /// ```
   ///
@@ -273,12 +281,13 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert Set.toText(union, Nat.toText) == "{1, 2, 3, 4, 5}";
+  ///   assert Iter.toArray(Set.values(union)) == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -303,12 +312,13 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert Set.toText(intersection, Nat.toText) == "{1, 2}";
+  ///   assert Iter.toArray(Set.values(intersection)) == [1, 2];
   /// }
   /// ```
   ///
@@ -349,12 +359,13 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert Set.toText(difference, Nat.toText) == "{1, 2}";
+  ///   assert Iter.toArray(Set.values(difference)) == [1, 2];
   /// }
   /// ```
   ///
@@ -398,14 +409,14 @@ module {
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
   /// import Text "mo:base/Text";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert Set.toText<Text>(textNumbers, func t { "`" # t # "`" }) ==
-  ///     "{`1`, `2`, `3`}";
+  ///   assert Iter.toArray(Set.values(textNumbers)) == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -428,11 +439,11 @@ module {
   /// persistent actor {
   ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   var tmp = "";
+  ///   var text = "";
   ///   Set.forEach<Nat>(numbers, func (element) {
-  ///     tmp #= " " # Nat.toText(element)
+  ///     text #= " " # Nat.toText(element)
   ///   });
-  ///   assert tmp == " 0 1 2 3";
+  ///   assert text == " 0 1 2 3";
   /// }
   /// ```
   ///
@@ -452,6 +463,7 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
@@ -459,7 +471,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert Set.toText(evenNumbers, Nat.toText) == "{0, 2}";
+  ///   assert Iter.toArray(Set.values(evenNumbers)) == [0, 2];
   /// }
   /// ```
   ///
@@ -487,6 +499,7 @@ module {
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
   /// import Text "mo:base/Text";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
@@ -498,8 +511,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert Set.toText<Text>(evenTextNumbers, func t { "`" # t # "`"}) ==
-  ///     "{`0`, `2`}";
+  ///   assert Iter.toArray(Set.values(evenTextNumbers)) == ["0", "2"];
   /// }
   /// ```
   ///
@@ -666,11 +678,11 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
-  ///   var tmp = "";
+  ///   var text = "";
   ///   for (number in Set.values(set)) {
-  ///      tmp #= " " # Nat.toText(number);
+  ///      text #= " " # Nat.toText(number);
   ///   };
-  ///   assert tmp == " 0 1 2 3";
+  ///   assert text == " 0 1 2 3";
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -713,10 +725,11 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set = Set.empty<Nat>();
-  ///   assert Set.toText(set, Nat.toText) == "{}"
+  ///   assert Iter.toArray(Set.values(set)) == [];
   /// }
   /// ```
   ///
@@ -730,10 +743,11 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set = Set.singleton(0);
-  ///   assert Set.toText(set, Nat.toText) == "{0}"
+  ///   assert Iter.toArray(Set.values(set)) == [0];
   /// }
   /// ```
   ///
@@ -912,11 +926,12 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   assert Set.toText(set, Nat.toText) == "{0, 1, 2, 3}"
+  ///   assert Set.toText(set, Nat.toText) == "{0, 1, 2, 3}";
   /// }
   /// ```
   ///
@@ -948,6 +963,7 @@ module {
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
   /// import Order "mo:base/Order";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   func setCompare(first: Set.Set<Nat>, second: Set.Set<Nat>) : Order.Order {
@@ -959,7 +975,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert Set.toText(flatSet, Nat.toText) == "{1, 2, 3, 4, 5, 6, 7}";
+  ///   assert Iter.toArray(Set.values(flatSet)) == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -986,13 +1002,14 @@ module {
   /// ```motoko
   /// import Set "mo:base/pure/Set";
   /// import Nat "mo:base/Nat";
+  /// import Iter "mo:base/Iter";
   ///
   /// persistent actor {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert Set.toText(combined, Nat.toText) == "{1, 2, 3, 4, 5, 6, 7}";
+  ///   assert Iter.toArray(Set.values(combined)) == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///


### PR DESCRIPTION
Extracts changes from https://github.com/dfinity/new-motoko-base/pull/294 which seem to be lost in the noise from merging #237 and #224.