### PR TITLE
CI: validate all docs on version change

### DIFF
--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -18,6 +18,9 @@ on:
       has_mops_dependency_changes:
         description: "Whether mops dependency versions were changed"
         value: ${{ jobs.check.outputs.has_mops_dependency_changes }}
+      has_mops_package_version_changes:
+        description: "Whether the version field in mops.toml was changed"
+        value: ${{ jobs.check.outputs.has_mops_package_version_changes }}
 
 jobs:
   check:
@@ -28,6 +31,7 @@ jobs:
       src_mo_changed_files: ${{ steps.check_mo_changes.outputs.src_mo_changed_files }}
       has_changelog_changes: ${{ steps.check_mo_changes.outputs.has_changelog_changes }}
       has_mops_dependency_changes: ${{ steps.check_mo_changes.outputs.has_mops_dependency_changes }}
+      has_mops_package_version_changes: ${{ steps.check_mo_changes.outputs.has_mops_package_version_changes }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,3 +78,12 @@ jobs:
           else
             echo "has_mops_dependency_changes=true" >> $GITHUB_OUTPUT
           fi
+
+          # Check for mops package version changes
+          if [ -z "$(git diff $BASE_SHA $HEAD_SHA -- mops.toml | grep '^[+-]\s*version\s*=')" ]; then
+            echo "has_mops_package_version_changes=false" >> $GITHUB_OUTPUT
+            echo "No mops package version changes detected"
+          else
+            echo "has_mops_package_version_changes=true" >> $GITHUB_OUTPUT
+          fi
+          

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,16 +58,22 @@ jobs:
 
   validate-docs:
     needs: check-motoko-changes
-    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true'
+    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Validate docs for changed src/*.mo files
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false'
         run: |
           echo "${{ needs.check-motoko-changes.outputs.src_mo_changed_files }}" | while read -r file; do
             npm run validate:docs "$file"
           done
+        env:
+          FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
+      - name: Validate all docs on version change
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true'
+        run: npm run validate:docs
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
 

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "new-base"
-version = "0.4.0"
+version = "0.4.1"
 description = "The new Motoko base library (preview)"
 repository = "https://github.com/dfinity/new-motoko-base"
 keywords = [ "base" ]

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "new-base"
-version = "0.4.1"
+version = "0.4.0"
 description = "The new Motoko base library (preview)"
 repository = "https://github.com/dfinity/new-motoko-base"
 keywords = [ "base" ]


### PR DESCRIPTION
Adds full `validation:docs` on version change in `mops.toml`.
Continuation after #303 FYI @rvanasa .

Manual test: version change triggered the [workflow](https://github.com/dfinity/new-motoko-base/actions/runs/14790146639/job/41525569513?pr=305), it took almost 24mins!