### PR TITLE
Add additional keywords to `mops.toml` for improved discoverability

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -3,7 +3,12 @@ name = "new-base"
 version = "0.4.0"
 description = "The new Motoko base library (preview)"
 repository = "https://github.com/dfinity/new-motoko-base"
-keywords = [ "base" ]
+keywords = [
+  "base",
+  "data-structure",
+  "stable-memory",
+  "persistent",
+]
 license = "Apache-2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Adds mops keywords so that `new-base` would appear in the 'Data Structures' and 'Stable Memory' categories on https://mops.one/