### PR TITLE
Experiment: Try Motoko Debugger

### DIFF
--- a/src/SimpleDebuggerTest.mo
+++ b/src/SimpleDebuggerTest.mo
@@ -1,0 +1,28 @@
+/// Setup motoko debugger:
+/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
+/// - cd ~/ic-sdk && cargo build
+///
+/// Run:
+/// moc $(mops sources) -o MoDe.wasm -g src/SimpleDebuggerTest.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
+///
+/// Commands:
+/// bp set -n main
+/// run
+/// bt
+/// list
+/// thread step-in  Note: wrong line?
+/// thread step-over  Note: correct line!
+/// thread step-over
+/// thread step-out
+/// local read  Output: 1  . list      : "HeapAddress: 2133695, tagged: Object, I32"
+import List "List";
+import Debug "Debug";
+
+func main() {
+
+  let list = List.fromArray<Nat>([1, 2, 3]);
+  List.addAll(list, [4, 5, 6].vals());
+  Debug.print(debug_show (List.toArray(list)))
+};
+
+main()

--- a/src/SimpleDebuggerTest.mo
+++ b/src/SimpleDebuggerTest.mo
@@ -1,10 +1,3 @@
-/// Setup motoko debugger:
-/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
-/// - cd ~/ic-sdk && cargo build
-///
-/// Run:
-/// moc $(mops sources) -o MoDe.wasm -g src/SimpleDebuggerTest.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
-///
 /// Commands:
 /// bp set -n main
 /// run

--- a/src/SimpleDebuggerTestWithBase.mo
+++ b/src/SimpleDebuggerTestWithBase.mo
@@ -1,0 +1,28 @@
+/// Setup motoko debugger:
+/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
+/// - cd ~/ic-sdk && cargo build
+///
+/// Run:
+/// moc $(mops sources) -o MoDe.wasm -g src/SimpleDebuggerTestWithBase.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
+///
+/// Commands:
+/// bp set -n main
+/// run
+/// bt
+/// list  Output: File not found: "./internals"
+/// thread step-in  Note: wrong line?
+/// thread step-over  Output: File not found: "./internals"
+/// thread step-over  Output: File not found: "./internals"
+/// list  Output: File not found: "./internals"
+import List "List";
+import Debug "Debug";
+import BaseArray "mo:base/Array";
+
+func main() {
+  let baseArray = BaseArray.tabulate<Nat>(3, func i = i);
+  let list = List.fromArray<Nat>(baseArray);
+  List.addAll(list, [4, 5, 6].vals());
+  Debug.print(debug_show (List.toArray(list)))
+};
+
+main()

--- a/src/SimpleDebuggerTestWithBase.mo
+++ b/src/SimpleDebuggerTestWithBase.mo
@@ -1,19 +1,18 @@
-/// Setup motoko debugger:
-/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
-/// - cd ~/ic-sdk && cargo build
-///
-/// Run:
-/// moc $(mops sources) -o MoDe.wasm -g src/SimpleDebuggerTestWithBase.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
-///
 /// Commands:
 /// bp set -n main
 /// run
 /// bt
-/// list  Output: File not found: "./internals"
-/// thread step-in  Note: wrong line?
-/// thread step-over  Output: File not found: "./internals"
-/// thread step-over  Output: File not found: "./internals"
-/// list  Output: File not found: "./internals"
+/// list
+/// thread step-in
+/// thread step-in
+/// thread step-in
+/// thread step-out
+/// thread step-out
+/// thread step-out
+/// thread step-in  Note: Wrong line
+/// thread step-in  Note: Correct line
+/// thread step-over
+/// thread step-out
 import List "List";
 import Debug "Debug";
 import BaseArray "mo:base/Array";

--- a/test/SmallBlob.test.mo
+++ b/test/SmallBlob.test.mo
@@ -9,6 +9,7 @@
 /// bp set -n breakpoint
 /// run
 /// bt
+/// list  Output: File not found: "<moc-asset>/prelude"
 /// thread step-in  Note: output seems to be wrong, points to a wrong line
 /// bt
 /// thread step-out

--- a/test/SmallBlob.test.mo
+++ b/test/SmallBlob.test.mo
@@ -1,0 +1,58 @@
+/// Setup motoko debugger:
+/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
+/// - cd ~/ic-sdk && cargo build
+///
+/// Run:
+/// moc $(mops sources) -o MoDe.wasm -g test/SmallBlob.test.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
+///
+/// Commands:
+/// bp set -n breakpoint
+/// run
+/// bt
+/// thread step-in  Note: output seems to be wrong, points to a wrong line
+/// bt
+/// thread step-out
+/// list  Note: no output?
+/// bt
+/// thread step-out  Output: File not found: "<moc-asset>/prelude"
+/// thread step-over Output: File not found: "./internals"
+import Blob "../src/Blob";
+import { suite; test; expect } "mo:test";
+import Debug "../src/Debug";
+
+// placeholder for debugger breakpoint
+func breakpoint() {
+  Debug.print("breakpoint"); // must be non-empty otherwise the debugger seems to skip it
+};
+
+suite(
+  "basic operations",
+  func() {
+    test(
+      "empty creates an empty blob",
+      func() {
+        let emptyBlob = Blob.empty();
+        breakpoint();
+        expect.nat(emptyBlob.size()).equal(0)
+      }
+    );
+
+    test(
+      "isEmpty identifies empty blobs",
+      func() {
+        breakpoint();
+        expect.bool(Blob.isEmpty(Blob.empty())).equal(true);
+        expect.bool(Blob.isEmpty("\FF\00" : Blob)).equal(false)
+      }
+    );
+
+    test(
+      "size returns correct byte count",
+      func() {
+        breakpoint();
+        expect.nat(Blob.size("\FF\00\AA" : Blob)).equal(3);
+        expect.nat(Blob.size(Blob.empty())).equal(0)
+      }
+    )
+  }
+)

--- a/test/SmallBlob.test.mo
+++ b/test/SmallBlob.test.mo
@@ -1,22 +1,20 @@
-/// Setup motoko debugger:
-/// - git clone https://github.com/scalebit/ic-sdk to ~/ic-sdk
-/// - cd ~/ic-sdk && cargo build
-///
-/// Run:
-/// moc $(mops sources) -o MoDe.wasm -g test/SmallBlob.test.mo && ~/ic-sdk/target/debug/dfx debug MoDe.wasm
-///
 /// Commands:
 /// bp set -n breakpoint
 /// run
 /// bt
-/// list  Output: File not found: "<moc-asset>/prelude"
-/// thread step-in  Note: output seems to be wrong, points to a wrong line
+/// list
+/// thread step-in
 /// bt
 /// thread step-out
-/// list  Note: no output?
+/// thread step-in
+/// thread step-out
+/// thread step-in
+/// thread step-out
 /// bt
-/// thread step-out  Output: File not found: "<moc-asset>/prelude"
-/// thread step-over Output: File not found: "./internals"
+/// thread step-out
+/// thread step-out
+/// thread step-out
+/// thread step-out
 import Blob "../src/Blob";
 import { suite; test; expect } "mo:test";
 import Debug "../src/Debug";


### PR DESCRIPTION
Do not merge: Just an experiment of using the [motoko_debugger](https://github.com/scalebit/motoko_debugger) in the new-base

Cases I wanted to test:
- Simple main-program with mops sources
- Debugging tests

Check out this branch locally and try one of the [changed files](https://github.com/dfinity/new-motoko-base/pull/327/files). See the instructions below.

**Update:**
I've tried the debugger with this [`moc` fix to the debug section](https://github.com/dfinity/motoko/pull/5281) and I can say that it works pretty well on these 3 files in this PR and it runs on the `List.test.mo` as well

Current limitations that I've found:
- ~Most test files e.g. `test/List.test.mo` do not work and fail with `index out of bounds: the len is 27 but the index is 30`, seems like bigger wasms are problematic~
- The `list` command (and transitively other commands e.g. thread step-in with similar output): sometimes produces wrong output. The code line shown might not correspond to the actual one. See the changed files.
  - This is probably due to wrong debug section encoding on the `moc` side
- ~Use of mops packages break the `list` output, frequent `File not found: "./internals"`~
- `read local` works great for primitives but complex types like objects are just memory addresses.
- No vscode integration yet

## How to run
Setup motoko debugger:
- `git clone https://github.com/scalebit/motoko_debugger to ~/motoko_debugger`
- `cd ~/motoko_debugger && cargo build --release`

Run, e.g. `src/SimpleDebuggerTest.mo`:
- `moc $(mops sources) -o MoDe.wasm -g src/SimpleDebuggerTest.mo && ~/motoko_debugger/target/release/debugger MoDe.wasm`
- Or using custom-built `moc`:
  - `cd ~/motoko && nix develop`
  - `cd ~/motoko-core`
  - `make -C ../motoko/src moc && moc $(mops sources) -o MoDe.wasm -g --legacy-persistence src/SimpleDebuggerTest.mo && ~/motoko_debugger/target/release/debugger MoDe.wasm`