### PR TITLE
Setup `next-moc` branch

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,17 @@
+name: Sync main and next-moc
+on:
+  push:
+    branches:
+      - main
+jobs:
+  sync-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Merge main -> next-moc
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: main
+          target_branch: next-moc
+          github_token: ${{ github.token }}

--- a/Release.md
+++ b/Release.md
@@ -1,0 +1,23 @@
+# Release process
+
+Please refer to the [release instructions](https://github.com/dfinity/motoko/blob/master/Building.md#making-releases) in the Motoko repository.
+
+## The `next-moc` branch
+
+The `next-moc` branch contains changes that make base compatible with the
+in-development version of `moc`. This repository's public CI does _not_ run
+on that branch.
+
+External contributions are best made against `master`.
+
+- `master` branch is meant for the newest **released** version of `moc`
+  - The CI runs on this branch
+- `next-moc` branch is meant for the **in-development** version of `moc`
+  - This branch is used by the [`motoko` repository](https://github.com/dfinity/motoko)'s CI
+
+Both branches are kept in sync with each other by mutual, circular merges:
+- `next-moc` is updated automatically on each push to `master` via the [sync.yml](.github/workflows/sync.yml) workflow
+- `master` is updated **manually** on each release of `moc` as part of the `motoko` release process
+
+Only *normal* merges are allowed between `master` and `next-moc`, because development is permitted on both branches.
+This policy makes every PR (to either branch) visible in the history of both branches.

--- a/Release.md
+++ b/Release.md
@@ -8,16 +8,16 @@ The `next-moc` branch contains changes that make base compatible with the
 in-development version of `moc`. This repository's public CI does _not_ run
 on that branch.
 
-External contributions are best made against `master`.
+External contributions are best made against `main`.
 
-- `master` branch is meant for the newest **released** version of `moc`
+- `main` branch is meant for the newest **released** version of `moc`
   - The CI runs on this branch
 - `next-moc` branch is meant for the **in-development** version of `moc`
   - This branch is used by the [`motoko` repository](https://github.com/dfinity/motoko)'s CI
 
 Both branches are kept in sync with each other by mutual, circular merges:
-- `next-moc` is updated automatically on each push to `master` via the [sync.yml](.github/workflows/sync.yml) workflow
-- `master` is updated **manually** on each release of `moc` as part of the `motoko` release process
+- `next-moc` is updated automatically on each push to `main` via the [sync.yml](.github/workflows/sync.yml) workflow
+- `main` is updated **manually** on each release of `moc` as part of the `motoko` release process
 
-Only *normal* merges are allowed between `master` and `next-moc`, because development is permitted on both branches.
+Only *normal* merges are allowed between `main` and `next-moc`, because development is permitted on both branches.
 This policy makes every PR (to either branch) visible in the history of both branches.


### PR DESCRIPTION
Adds CI workflows to set up the `next-moc` branch in the same way as the previous base library repository.

Progress:
* [x] Documentation
* [x] `sync` CI workflow

Splitting into a future PR:
* Run tests using master branch of `motoko` repository for `next-moc`