### PR TITLE
Carlo/Exposing Char.toLower and Char.toUpper to Char Interface

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* Expose `Char.toUpper` and `Char.toLower` to public interface (#339).
 * **Breaking:** Enable persistence of `Random` and `AsyncRandom` state in stable memory (#329).
 * Fix a bug in `List.last<T>` (#336). 
 * Fix a typo in the `VarArray` documentation (#338).

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -74,7 +74,7 @@ module {
   /// Returns the char argument in uppercase. Unicode compliant.
   ///
   /// ```motoko include=import
-  /// let char = Char.toUpper("A");
+  /// let char = Char.toLower("A");
   /// assert char == "a";
   /// ```
   public let toLower : (char : Char) -> Char = Prim.charToLower;

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -71,7 +71,7 @@ module {
   /// ```
   public let toUpper : (char : Char) -> Char = Prim.charToUpper;
 
-  /// Returns the char argument in uppercase. Unicode compliant.
+  /// Returns the char argument in lowercase. Unicode compliant.
   ///
   /// ```motoko include=import
   /// let char = Char.toLower("A");

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -63,8 +63,20 @@ module {
   /// ```
   public let toText : (char : Char) -> Text = Prim.charToText;
 
+  /// Returns the char argument in uppercase. Unicode compliant.
+  ///
+  /// ```motoko include=import
+  /// let char = Char.toUpper("a");
+  /// assert char == "A";
+  /// ```
   public let toUpper : (char : Char) -> Char = Prim.charToUpper;
 
+  /// Returns the char argument in uppercase. Unicode compliant.
+  ///
+  /// ```motoko include=import
+  /// let char = Char.toUpper("A");
+  /// assert char == "a";
+  /// ```
   public let toLower : (char : Char) -> Char = Prim.charToLower;
 
   /// Returns `true` when `char` is a decimal digit between `0` and `9`, otherwise `false`.

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -64,10 +64,10 @@ module {
   public let toText : (char : Char) -> Text = Prim.charToText;
 
   // Not exposed pending multi-char implementation.
-  private let _toUpper : (char : Char) -> Char = Prim.charToUpper;
+  public let toUpper : (char : Char) -> Char = Prim.charToUpper;
 
   // Not exposed pending multi-char implementation.
-  private let _toLower : (char : Char) -> Char = Prim.charToLower;
+  public let toLower : (char : Char) -> Char = Prim.charToLower;
 
   /// Returns `true` when `char` is a decimal digit between `0` and `9`, otherwise `false`.
   ///

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -66,16 +66,16 @@ module {
   /// Returns the char argument in uppercase. Unicode compliant.
   ///
   /// ```motoko include=import
-  /// let char = Char.toUpper("a");
-  /// assert char == "A";
+  /// let char = Char.toUpper('a');
+  /// assert char == 'A';
   /// ```
   public let toUpper : (char : Char) -> Char = Prim.charToUpper;
 
   /// Returns the char argument in lowercase. Unicode compliant.
   ///
   /// ```motoko include=import
-  /// let char = Char.toLower("A");
-  /// assert char == "a";
+  /// let char = Char.toLower('A');
+  /// assert char == 'a';
   /// ```
   public let toLower : (char : Char) -> Char = Prim.charToLower;
 

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -63,10 +63,8 @@ module {
   /// ```
   public let toText : (char : Char) -> Text = Prim.charToText;
 
-  // Not exposed pending multi-char implementation.
   public let toUpper : (char : Char) -> Char = Prim.charToUpper;
 
-  // Not exposed pending multi-char implementation.
   public let toLower : (char : Char) -> Char = Prim.charToLower;
 
   /// Returns `true` when `char` is a decimal digit between `0` and `9`, otherwise `false`.

--- a/test/Char.test.mo
+++ b/test/Char.test.mo
@@ -10,14 +10,14 @@ suite(
       func() {
         expect.char(Char.toUpper('a')).equal('A');
         expect.char(Char.toUpper('ö')).equal('Ö');
-        expect.char(Char.toUpper('σ')).equal('Σ');
+        expect.char(Char.toUpper('σ')).equal('Σ')
       }
     );
 
     test(
       "preserves non-letter chars",
       func() {
-        expect.char(Char.toUpper('💩')).equal('💩');
+        expect.char(Char.toUpper('💩')).equal('💩')
       }
     )
   }
@@ -31,14 +31,14 @@ suite(
       func() {
         expect.char(Char.toLower('A')).equal('a');
         expect.char(Char.toLower('Ö')).equal('ö');
-        expect.char(Char.toLower('Σ')).equal('σ');
+        expect.char(Char.toLower('Σ')).equal('σ')
       }
     );
 
     test(
       "preserves non-letter chars",
       func() {
-        expect.char(Char.toLower('💩')).equal('💩');
+        expect.char(Char.toLower('💩')).equal('💩')
       }
     )
   }

--- a/test/Char.test.mo
+++ b/test/Char.test.mo
@@ -10,7 +10,8 @@ suite(
       func() {
         expect.char(Char.toUpper('a')).equal('A');
         expect.char(Char.toUpper('ö')).equal('Ö');
-        expect.char(Char.toUpper('σ')).equal('Σ')
+        expect.char(Char.toUpper('ë')).equal('Ë');
+        expect.char(Char.toUpper('σ')).equal('Σ');
       }
     );
 
@@ -18,7 +19,8 @@ suite(
       "preserves non-letter chars",
       func() {
         expect.char(Char.toUpper('💩')).equal('💩');
-        expect.char(Char.toLower('1')).equal('1')
+        expect.char(Char.toLower('1')).equal('1');
+        expect.char(Char.toUpper('ख़')).equal('ख़');
       }
     )
   }
@@ -32,7 +34,8 @@ suite(
       func() {
         expect.char(Char.toLower('A')).equal('a');
         expect.char(Char.toLower('Ö')).equal('ö');
-        expect.char(Char.toLower('Σ')).equal('σ')
+        expect.char(Char.toLower('Ë')).equal('ë');
+        expect.char(Char.toLower('Σ')).equal('σ');
       }
     );
 
@@ -40,7 +43,8 @@ suite(
       "preserves non-letter chars",
       func() {
         expect.char(Char.toLower('💩')).equal('💩');
-        expect.char(Char.toLower('1')).equal('1')
+        expect.char(Char.toLower('1')).equal('1');
+        expect.char(Char.toUpper('ख़')).equal('ख़');
       }
     )
   }

--- a/test/Char.test.mo
+++ b/test/Char.test.mo
@@ -2,45 +2,47 @@ import Char "../src/Char";
 import Prim "mo:⛔";
 import { suite; test; expect } "mo:test";
 
-// suite(
-//   "toUpper",
-//   func() {
-//     test(
-//       "converts lowercase special chars to uppercase",
-//       func() {
-//         expect.char(Char.toUpper('ö')).equal('Ö');
-//         expect.char(Char.toUpper('σ')).equal('Σ');
-//       }
-//     );
+suite(
+  "toUpper",
+  func() {
+    test(
+      "converts lowercase special chars to uppercase",
+      func() {
+        expect.char(Char.toUpper('a')).equal('A');
+        expect.char(Char.toUpper('ö')).equal('Ö');
+        expect.char(Char.toUpper('σ')).equal('Σ');
+      }
+    );
 
-//     test(
-//       "preserves non-letter chars",
-//       func() {
-//         expect.char(Char.toUpper('💩')).equal('💩');
-//       }
-//     )
-//   }
-// );
+    test(
+      "preserves non-letter chars",
+      func() {
+        expect.char(Char.toUpper('💩')).equal('💩');
+      }
+    )
+  }
+);
 
-// suite(
-//   "toLower",
-//   func() {
-//     test(
-//       "converts uppercase special chars to lowercase",
-//       func() {
-//         expect.char(Char.toLower('Ö')).equal('ö');
-//         expect.char(Char.toLower('Σ')).equal('σ');
-//       }
-//     );
+suite(
+  "toLower",
+  func() {
+    test(
+      "converts uppercase special chars to lowercase",
+      func() {
+        expect.char(Char.toLower('A')).equal('a');
+        expect.char(Char.toLower('Ö')).equal('ö');
+        expect.char(Char.toLower('Σ')).equal('σ');
+      }
+    );
 
-//     test(
-//       "preserves non-letter chars",
-//       func() {
-//         expect.char(Char.toLower('💩')).equal('💩');
-//       }
-//     )
-//   }
-// );
+    test(
+      "preserves non-letter chars",
+      func() {
+        expect.char(Char.toLower('💩')).equal('💩');
+      }
+    )
+  }
+);
 
 suite(
   "conversion",

--- a/test/Char.test.mo
+++ b/test/Char.test.mo
@@ -17,7 +17,8 @@ suite(
     test(
       "preserves non-letter chars",
       func() {
-        expect.char(Char.toUpper('💩')).equal('💩')
+        expect.char(Char.toUpper('💩')).equal('💩');
+        expect.char(Char.toLower('1')).equal('1')
       }
     )
   }
@@ -38,7 +39,8 @@ suite(
     test(
       "preserves non-letter chars",
       func() {
-        expect.char(Char.toLower('💩')).equal('💩')
+        expect.char(Char.toLower('💩')).equal('💩');
+        expect.char(Char.toLower('1')).equal('1')
       }
     )
   }

--- a/test/Char.test.mo
+++ b/test/Char.test.mo
@@ -11,7 +11,7 @@ suite(
         expect.char(Char.toUpper('a')).equal('A');
         expect.char(Char.toUpper('ö')).equal('Ö');
         expect.char(Char.toUpper('ë')).equal('Ë');
-        expect.char(Char.toUpper('σ')).equal('Σ');
+        expect.char(Char.toUpper('σ')).equal('Σ')
       }
     );
 
@@ -20,7 +20,7 @@ suite(
       func() {
         expect.char(Char.toUpper('💩')).equal('💩');
         expect.char(Char.toLower('1')).equal('1');
-        expect.char(Char.toUpper('ख़')).equal('ख़');
+        expect.char(Char.toUpper('ख़')).equal('ख़')
       }
     )
   }
@@ -35,7 +35,7 @@ suite(
         expect.char(Char.toLower('A')).equal('a');
         expect.char(Char.toLower('Ö')).equal('ö');
         expect.char(Char.toLower('Ë')).equal('ë');
-        expect.char(Char.toLower('Σ')).equal('σ');
+        expect.char(Char.toLower('Σ')).equal('σ')
       }
     );
 
@@ -44,7 +44,7 @@ suite(
       func() {
         expect.char(Char.toLower('💩')).equal('💩');
         expect.char(Char.toLower('1')).equal('1');
-        expect.char(Char.toUpper('ख़')).equal('ख़');
+        expect.char(Char.toUpper('ख़')).equal('ख़')
       }
     )
   }

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -102,8 +102,10 @@
       "public func less(a : Char, b : Char) : Bool",
       "public func lessOrEqual(a : Char, b : Char) : Bool",
       "public func notEqual(a : Char, b : Char) : Bool",
+      "public let toLower : (char : Char) -> Char",
       "public let toNat32 : (char : Char) -> Nat32",
-      "public let toText : (char : Char) -> Text"
+      "public let toText : (char : Char) -> Text",
+      "public let toUpper : (char : Char) -> Char"
     ]
   },
   {


### PR DESCRIPTION
Resolves [#339](https://github.com/dfinity/motoko-core/issues/339)

- Changed Char.toLower and Char.toUpper from private to public
- Removed underscore from function name
- Uncommented previously existing Tests from Char.test.mo
- Added one new base case test for Char.toLower and Char.toUpper: 'A' -> 'a' and 'a' -> 'A'
- Updated Changelog regarding new exposure