### PR TITLE
Add `List.at()` with the original behavior of `List.get()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 * Fix corner case in `sliceToArray()` (#364).
 * **Breaking:** Adjust `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
 * **Breaking:** Change `List.get()` to return `?T` instead of `T` for consistency (#367).
-* Add `List.at()` with the original behavior of `List.get()`.
+* Add `List.at()` with the original behavior of `List.get()` (#373).
 
 ## 0.6.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 * Fix corner case in `sliceToArray()` (#364).
 * **Breaking:** Adjust `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
 * **Breaking:** Change `List.get()` to return `?T` instead of `T` for consistency (#367).
+* Add `List.at()` with the original behavior of `List.get()`.
 
 ## 0.6.0
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -523,6 +523,33 @@ module {
     }
   };
 
+  /// Returns the element at index `index`.
+  /// Traps if `index >= size`. Indexing is zero-based.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let list = List.empty<Nat>();
+  /// List.add(list, 10);
+  /// List.add(list, 11);
+  /// assert List.at(list, 0) == 10;
+  /// // List.at(list, 2); // traps
+  /// ```
+  ///
+  /// Runtime: `O(1)`
+  ///
+  /// Space: `O(1)`
+  public func at<T>(list : List<T>, index : Nat) : T {
+    let (a, b) = locate(index);
+    if (a < list.blockIndex or list.elementIndex != 0 and a == list.blockIndex) {
+      switch (list.blocks[a][b]) {
+        case (?value) value;
+        case (null) Prim.trap "List.at(): internal error"
+      }
+    } else {
+      Prim.trap "List.at(): index out of bounds"
+    }
+  };
+
   /// Returns the element at index `index` as an option.
   /// Returns `null` when `index >= size`. Indexing is zero-based.
   ///
@@ -1186,7 +1213,7 @@ module {
   public func toVarArray<T>(list : List<T>) : [var T] {
     let s = size(list);
     if (s == 0) return [var];
-    let arr = VarArray.repeat<T>(Option.unwrap(first(list)), s);
+    let arr = VarArray.repeat<T>(at(list, 0), s);
     var i = 0;
     let next = values_(list).unsafe_next;
     while (i < s) {
@@ -1523,7 +1550,7 @@ module {
   public func max<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T {
     if (isEmpty(list)) return null;
 
-    var maxSoFar = Option.unwrap(get(list, 0));
+    var maxSoFar = at(list, 0);
     forEach<T>(
       list,
       func(x) = switch (compare(x, maxSoFar)) {
@@ -1558,7 +1585,7 @@ module {
   public func min<T>(list : List<T>, compare : (T, T) -> Order.Order) : ?T {
     if (isEmpty(list)) return null;
 
-    var minSoFar = Option.unwrap(get(list, 0));
+    var minSoFar = at(list, 0);
     forEach<T>(
       list,
       func(x) = switch (compare(x, minSoFar)) {
@@ -1676,7 +1703,7 @@ module {
     };
     if (vsize > 0) {
       // avoid the trailing comma
-      text := text # f(Option.unwrap(get<T>(list, i)))
+      text := text # f(at(list, i))
     };
 
     "List[" # text # "]"
@@ -1762,10 +1789,10 @@ module {
 
     var i = 0;
     var j = vsize - 1 : Nat;
-    var temp = Option.unwrap(get(list, 0));
+    var temp = at(list, 0);
     while (i < vsize / 2) {
-      temp := Option.unwrap(get(list, j));
-      put(list, j, Option.unwrap(get(list, i)));
+      temp := at(list, j);
+      put(list, j, at(list, i));
       put(list, i, temp);
       i += 1;
       j -= 1

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -39,7 +39,6 @@ import Iter "../Iter";
 import Types "../Types";
 import Nat "../Nat";
 import Order "../Order";
-import Option "../Option";
 
 module {
 
@@ -1127,9 +1126,9 @@ module {
       func buildFromSortedHelper(l : Nat, r : Nat, depth : Nat) : Tree<V> {
         if (l + 1 == r) {
           if (depth == maxDepth) {
-            return #red(#leaf, Option.unwrap(List.get(buf, l)), #leaf)
+            return #red(#leaf, List.at(buf, l), #leaf)
           } else {
-            return #black(#leaf, Option.unwrap(List.get(buf, l)), #leaf)
+            return #black(#leaf, List.at(buf, l), #leaf)
           }
         };
         if (l >= r) {
@@ -1138,7 +1137,7 @@ module {
         let m = (l + r) / 2;
         return #black(
           buildFromSortedHelper(l, m, depth + 1),
-          Option.unwrap(List.get(buf, m)),
+          List.at(buf, m),
           buildFromSortedHelper(m + 1, r, depth + 1)
         )
       };

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1292,16 +1292,8 @@ Test.suite(
         let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
         for (i in Nat.range(0, 4)) {
           let getResult = List.get(list, i);
-          switch (getResult) {
-            case (?value) {
-              let atResult = List.at(list, i);
-              Test.expect.nat(atResult).equal(value)
-            };
-            case (null) {
-              // This shouldn't happen for valid indices
-              Test.expect.bool(false).equal(true)
-            }
-          }
+          let atResult = List.at(list, i);
+          Test.expect.option(getResult, Nat.toText, Nat.equal).equal(?atResult)
         }
       }
     )

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1061,6 +1061,19 @@ func testGetOpt(n : Nat) : Bool {
   true
 };
 
+func testAt(n : Nat) : Bool {
+  let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i + 1));
+
+  for (i in Nat.range(1, n + 1)) {
+    let value = List.at(vec, i - 1 : Nat);
+    if (value != i) {
+      Debug.print("at: Mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(i) # ", got " # Nat.toText(value));
+      return false
+    }
+  };
+  true
+};
+
 func testPut(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
   if (n == 0) {
@@ -1240,6 +1253,7 @@ func runAllTests() {
   runTest("testRemoveLast", testRemoveLast);
   runTest("testGet", testGet);
   runTest("testGetOpt", testGetOpt);
+  runTest("testAt", testAt);
   runTest("testPut", testPut);
   runTest("testClear", testClear);
   runTest("testClone", testClone);
@@ -1259,6 +1273,40 @@ func runAllTests() {
 
 // Run all tests
 runAllTests();
+
+Test.suite(
+  "at() function tests",
+  func() {
+    Test.test(
+      "at() returns correct values",
+      func() {
+        let list = List.fromArray<Nat>([10, 11, 12]);
+        Test.expect.nat(List.at(list, 0)).equal(10);
+        Test.expect.nat(List.at(list, 1)).equal(11);
+        Test.expect.nat(List.at(list, 2)).equal(12)
+      }
+    );
+    Test.test(
+      "at() vs get() consistency",
+      func() {
+        let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
+        for (i in Nat.range(0, 4)) {
+          let getResult = List.get(list, i);
+          switch (getResult) {
+            case (?value) {
+              let atResult = List.at(list, i);
+              Test.expect.nat(atResult).equal(value)
+            };
+            case (null) {
+              // This shouldn't happen for valid indices
+              Test.expect.bool(false).equal(true)
+            }
+          }
+        }
+      }
+    )
+  }
+);
 
 Test.suite(
   "Regression tests",

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -512,6 +512,7 @@
       "public func addRepeat<T>(list : List<T>, initValue : T, count : Nat)",
       "public func all<T>(list : List<T>, predicate : T -> Bool) : Bool",
       "public func any<T>(list : List<T>, predicate : T -> Bool) : Bool",
+      "public func at<T>(list : List<T>, index : Nat) : T",
       "public func clear<T>(list : List<T>)",
       "public func clone<T>(list : List<T>) : List<T>",
       "public func compare<T>(list1 : List<T>, list2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order",


### PR DESCRIPTION
See #367.

Naming precedent is the [`at()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) method on JavaScript arrays.

In the future, we could expand this function to take `Int` values for indices relative to the end of the array (commonly used in Python and JS).