### PR TITLE
Carlo/implicits additions

### DIFF
--- a/src/Int.mo
+++ b/src/Int.mo
@@ -119,7 +119,9 @@ module {
   /// ```motoko include=import
   /// assert Int.toFloat(-123) == -123.0;
   /// ```
-  public let toFloat : Int -> Float = Prim.intToFloat;
+  public func toFloat(self : Int) : Float {
+    Prim.intToFloat(self)
+  };
 
   /// Converts an integer to a natural number. Traps if the integer is negative.
   ///

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -109,6 +109,18 @@ module {
     ?(if (isNegative) { -n } else { n })
   };
 
+  /// Conversion to Float. May result in `Inf`.
+  ///
+  /// Note: The floating point number may be imprecise for large or small Int values.
+  /// Returns `inf` if the integer is greater than the maximum floating point number.
+  /// Returns `-inf` if the integer is less than the minimum floating point number.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// assert Int.toFloat(-123) == -123.0;
+  /// ```
+  public let toFloat : Int -> Float = Prim.intToFloat;
+
   /// Converts an integer to a natural number. Traps if the integer is negative.
   ///
   /// Example:

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -78,8 +78,8 @@ module {
   /// ```motoko include=import
   /// assert Nat.toFloat(123) == 123.0;
   /// ```
-  public func toFloat(nat : Nat) : Float {
-    Int.toFloat(nat : Int)
+  public func toFloat(self : Nat) : Float {
+    Int.toFloat(self : Int)
   };
 
   /// Converts a natural number to an integer.

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -79,7 +79,7 @@ module {
   /// assert Nat.toFloat(123) == 123.0;
   /// ```
   public func toFloat(self : Nat) : Float {
-    Int.toFloat(self : Int)
+    Prim.intToFloat(self)
   };
 
   /// Converts a natural number to an integer.

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -69,6 +69,19 @@ module {
     }
   };
 
+  /// Conversion to Float. May result in `Inf`.
+  ///
+  /// Note: The floating point number may be imprecise for large or small Nat values.
+  /// Returns `inf` if the nat is greater than the maximum floating point number.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// assert Nat.toFloat(123) == 123.0;
+  /// ```
+  public func toFloat(nat : Nat) : Float {
+    Int.toFloat(nat : Int);
+  };
+
   /// Converts a natural number to an integer.
   ///
   /// Example:

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -79,7 +79,7 @@ module {
   /// assert Nat.toFloat(123) == 123.0;
   /// ```
   public func toFloat(nat : Nat) : Float {
-    Int.toFloat(nat : Int);
+    Int.toFloat(nat : Int)
   };
 
   /// Converts a natural number to an integer.

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -115,7 +115,9 @@ module {
   /// let unicode = Nat32.toChar(65);
   /// assert unicode == 'A';
   /// ```
-  public let toChar : (self : Nat32) -> Char = Prim.nat32ToChar;
+  public func toChar(self : Nat32) : Char { 
+    Prim.nat32ToChar(self);
+  };
 
   /// Returns the minimum of `x` and `y`.
   ///

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -108,6 +108,13 @@ module {
     Nat.toText(toNat(x))
   };
 
+  /// Convert a Nat32 `char` to a Char in its Unicode representation.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let unicode = Nat32.toChar(65);
+  /// assert unicode == 'A';
+  /// ```
   public let toChar : (self : Nat32) -> Char = Prim.nat32ToChar;
 
   /// Returns the minimum of `x` and `y`.

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -108,6 +108,8 @@ module {
     Nat.toText(toNat(x))
   };
 
+  public let toChar : (self : Nat32) -> Char = Prim.nat32ToChar;
+
   /// Returns the minimum of `x` and `y`.
   ///
   /// Example:

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -966,12 +966,12 @@ module {
   /// ```motoko include=import
   /// assert Text.toNat("1234") == ?1234;
   /// ```
-  public func toNat(text : Text) : ?Nat {
-    if (text == "") {
+  public func toNat(self : Text) : ?Nat {
+    if (self == "") {
       return null
     };
     var n = 0;
-    for (c in text.chars()) {
+    for (c in self.chars()) {
       if (Char.isDigit(c)) {
         let charAsNat = Prim.nat32ToNat(Prim.charToNat32(c) -% Prim.charToNat32('0'));
         n := n * 10 + charAsNat
@@ -992,15 +992,15 @@ module {
   /// ```motoko include=import
   /// assert Text.toInt("-1234") == ?-1234;
   /// ```
-  public func toInt(text : Text) : ?Int {
-    if (text == "") {
+  public func toInt(self : Text) : ?Int {
+    if (self == "") {
       return null
     };
     var n = 0;
     var isFirst = true;
     var isNegative = false;
     var hasDigits = false;
-    for (c in text.chars()) {
+    for (c in self.chars()) {
       if (isFirst and c == '+') {
         // Skip character
       } else if (isFirst and c == '-') {

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -957,6 +957,69 @@ module {
   /// ```
   public let toUpper : Text -> Text = Prim.textUppercase;
 
+  /// Creates a natural number from its textual representation. Returns `null`
+  /// if the input is not a valid natural number.
+  ///
+  /// The textual representation _must not_ contain underscores.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// assert Text.toNat("1234") == ?1234;
+  /// ```
+  public func toNat(text : Text) : ?Nat {
+    if (text == "") {
+      return null
+    };
+    var n = 0;
+    for (c in text.chars()) {
+      if (Char.isDigit(c)) {
+        let charAsNat = Prim.nat32ToNat(Prim.charToNat32(c) -% Prim.charToNat32('0'));
+        n := n * 10 + charAsNat
+      } else {
+        return null
+      }
+    };
+    ?n
+  };
+
+  /// Creates a integer from its textual representation. Returns `null`
+  /// if the input is not a valid integer.
+  ///
+  /// The textual representation _must not_ contain underscores but may
+  /// begin with a '+' or '-' character.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// assert Text.toInt("-1234") == ?-1234;
+  /// ```
+  public func toInt(text : Text) : ?Int {
+    if (text == "") {
+      return null
+    };
+    var n = 0;
+    var isFirst = true;
+    var isNegative = false;
+    var hasDigits = false;
+    for (c in text.chars()) {
+      if (isFirst and c == '+') {
+        // Skip character
+      } else if (isFirst and c == '-') {
+        isNegative := true
+      } else if (Char.isDigit(c)) {
+        hasDigits := true;
+        let charAsNat = Prim.nat32ToNat(Prim.charToNat32(c) -% Prim.charToNat32('0'));
+        n := n * 10 + charAsNat
+      } else {
+        return null
+      };
+      isFirst := false
+    };
+    if (not hasDigits) {
+      return null
+    };
+    ?(if (isNegative) { -n } else { n })
+  };
+
   /// Returns the given text value unchanged.
   /// This function is provided for consistency with other modules.
   ///

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -660,7 +660,7 @@
       "public func rem(x : Nat, y : Nat) : Nat",
       "public type Self",
       "public func sub(x : Nat, y : Nat) : Nat",
-      "public func toFloat(nat : Nat) : Float",
+      "public func toFloat(self : Nat) : Float",
       "public func toInt(nat : Nat) : Int",
       "public let toText : Nat -> Text"
     ]
@@ -1189,11 +1189,11 @@
       "public func stripStart(t : Text, p : Pattern) : ?Text",
       "public type Text",
       "public func toArray(t : Text) : [Char]",
-      "public func toInt(text : Text) : ?Int",
+      "public func toInt(self : Text) : ?Int",
       "public func toIter(t : Text) : Iter.Iter<Char>",
       "public func tokens(t : Text, p : Pattern) : Iter.Iter<Text>",
       "public let toLower : Text -> Text",
-      "public func toNat(text : Text) : ?Nat",
+      "public func toNat(self : Text) : ?Nat",
       "public func toText(t : Text) : Text",
       "public let toUpper : Text -> Text",
       "public func toVarArray(t : Text) : [var Char]",

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -226,6 +226,7 @@
       "public func rem(x : Int, y : Int) : Int",
       "public type Self",
       "public func sub(x : Int, y : Int) : Int",
+      "public let toFloat : Int -> Float",
       "public func toNat(int : Int) : Nat",
       "public func toText(x : Int) : Text"
     ]
@@ -659,6 +660,7 @@
       "public func rem(x : Nat, y : Nat) : Nat",
       "public type Self",
       "public func sub(x : Nat, y : Nat) : Nat",
+      "public func toFloat(nat : Nat) : Float",
       "public func toInt(nat : Nat) : Int",
       "public let toText : Nat -> Text"
     ]
@@ -765,6 +767,7 @@
       "public type Self",
       "public func sub(x : Nat32, y : Nat32) : Nat32",
       "public func subWrap(x : Nat32, y : Nat32) : Nat32",
+      "public let toChar : (self : Nat32) -> Char",
       "public let toNat : Nat32 -> Nat",
       "public func toNat16(x : Nat32) : Nat16",
       "public func toNat64(x : Nat32) : Nat64",
@@ -1186,9 +1189,11 @@
       "public func stripStart(t : Text, p : Pattern) : ?Text",
       "public type Text",
       "public func toArray(t : Text) : [Char]",
+      "public func toInt(text : Text) : ?Int",
       "public func toIter(t : Text) : Iter.Iter<Char>",
       "public func tokens(t : Text, p : Pattern) : Iter.Iter<Text>",
       "public let toLower : Text -> Text",
+      "public func toNat(text : Text) : ?Nat",
       "public func toText(t : Text) : Text",
       "public let toUpper : Text -> Text",
       "public func toVarArray(t : Text) : [var Char]",


### PR DESCRIPTION
adds the following functions enabling context.dot syntax for these functions you can use those instead of the according .fromType() function:

- Nat.toFloat
- Text.toNat
- Text.toInt
- Nat32.toChar
- Int.toFloat