### PR TITLE
Release 2.4.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Next
+
+## 2.4.0
 * Fix `Float32.rem` to use native `%` operator instead of round-tripping through `Float` (#482).
 * Flip x/y arg names in `arctan2` functions (#481).
 * Add `Float32` module for single-precision (32-bit) floating-point arithmetic (#477).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This adds the following dependency to your `mops.toml` config file:
 
 ```toml
 [dependencies]
-core = "2.3.1"
+core = "2.4.0"
 ```
 
 ## Contributing

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core"
-version = "2.3.1"
+version = "2.4.0"
 description = "The Motoko standard library"
 repository = "https://github.com/caffeinelabs/motoko-core"
 keywords = [


### PR DESCRIPTION
## Summary

Prepares the `core` 2.4.0 release per Releasing.md:

- `mops.toml`: version 2.4.0
- `README.md`: quick-start snippet updated to match
- `Changelog.md`: `## Next` → `## 2.4.0`, new empty `## Next`

## After merge

- Tag `v2.4.0` and push (triggers Mops publish)
- Confirm [mops.one/core](https://mops.one/core) shows 2.4.0

Made with [Cursor](https://cursor.com)