### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,14 +26,14 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           setup-dfx: true
 
       - name: Checkout baseline benchmark-results from upstream
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: dfinity/motoko-core
           ref: benchmark-results
@@ -53,7 +53,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Find Comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -61,7 +61,7 @@ jobs:
           body-includes: Benchmark Results
       - name: Create or update comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -84,7 +84,7 @@ jobs:
           mv bench-results.md .bench-br/README.md
       - name: Upload benchmark results
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: benchmark-results

--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -33,7 +33,7 @@ jobs:
       has_mops_dependency_changes: ${{ steps.check_mo_changes.outputs.has_mops_dependency_changes }}
       has_mops_package_version_changes: ${{ steps.check_mo_changes.outputs.has_mops_package_version_changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       PR_PATH: pull/${{github.event.number}}
     steps:
       - name: Checkout website repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup
         with:
@@ -28,14 +28,14 @@ jobs:
         run: npm run docs
 
       - name: Deploy if main branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
 
       - name: Deploy to PR preview
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         if: github.ref != 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
           destination_dir: ${{ env.PR_PATH }}
 
       - name: Update comment
-        uses: hasura/comment-progress@v2.2.0
+        uses: hasura/comment-progress@1d904b435730dd3d43ffa8a45522b8d06ebfbb43 # v2.2.0
         if: github.ref != 'refs/heads/main'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dfinity/setup-dfx@main # Currently required for `mops publish`
-      - uses: ZenVoich/setup-mops@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
+      - uses: ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           # Make sure you set the MOPS_IDENTITY_PEM secret in your repository settings https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
           identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -11,20 +11,20 @@ jobs:
       PR_PATH: pull/${{github.event.number}}
     steps:
       - name: Checkout website repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Make empty dir
         run: mkdir docs
 
       - name: Delete folder
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
           destination_dir: ${{ env.PR_PATH }}
 
       - name: Comment on PR
-        uses: hasura/comment-progress@v2.2.0
+        uses: hasura/comment-progress@1d904b435730dd3d43ffa8a45522b8d06ebfbb43 # v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           setup-mops: false
@@ -32,7 +32,7 @@ jobs:
   validate-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           setup-mops: false
@@ -41,7 +41,7 @@ jobs:
   validate-api:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: npm run validate:api
       - name: Check for API changes
@@ -61,7 +61,7 @@ jobs:
     if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: Validate docs for changed src/*.mo files
         if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false'
@@ -80,7 +80,7 @@ jobs:
   format:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: npm run format:check
 
@@ -89,7 +89,7 @@ jobs:
     if: needs.check-motoko-changes.outputs.has_mo_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
       - name: Check for Motoko file changes in 'src' directory


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Version: v6.0.2 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

- `peter-evans/find-comment@v3` -> `peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0`
  - Version: v3.1.0 | Latest: v4.0.0 | Release age: 190d
  - Commit: https://github.com/peter-evans/find-comment/commit/3eae4d37986fb5a8592848f6a574fdf654e61f9e

- `peter-evans/create-or-update-comment@v4` -> `peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4`
  - Version: v4 | Latest: v5.0.0 | Release age: 189d
  - Commit: https://github.com/peter-evans/create-or-update-comment/commit/71345be0265236311c031f5c7866368bd1eff043

- `JamesIves/github-pages-deploy-action@v4` -> `JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0`
  - Version: v4.8.0 | Latest: v4.8.0 | Release age: 90d
  - Commit: https://github.com/JamesIves/github-pages-deploy-action/commit/d92aa235d04922e8f08b40ce78cc5442fcfbfa2f

- `peaceiris/actions-gh-pages@v3` -> `peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3`
  - Version: v3.9.3 | Latest: v4.0.0 | Release age: 731d
  - Commit: https://github.com/peaceiris/actions-gh-pages/commit/373f7f263a76c20808c831209c920827a82a2847

- `hasura/comment-progress@v2.2.0` -> `hasura/comment-progress@1d904b435730dd3d43ffa8a45522b8d06ebfbb43 # v2.2.0`
  - Version: v2.2.0 | Latest: v2.3.0 | Release age: 993d
  - Commit: https://github.com/hasura/comment-progress/commit/1d904b435730dd3d43ffa8a45522b8d06ebfbb43

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `ZenVoich/setup-mops@v1` -> `ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1`
  - Version: v1.4.1 | Latest: v1.4.1 | Release age: 569d
  - Commit: https://github.com/ZenVoich/setup-mops/commit/3e94e453352269b34137b5ce49f09a8df81bed7d


### Files modified

- `.github/workflows/benchmarks.yml`
- `.github/workflows/check-motoko-changes.yml`
- `.github/workflows/gh-pages.yml`
- `.github/workflows/mops-publish.yml`
- `.github/workflows/pr-close.yml`
- `.github/workflows/tests.yml`