### PR TITLE
refactor: use contextual-dot throughout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Bump the `motoko` npm package used for doc-snippet checks, fix iterator call patterns (`entries`/`values`), and correct a few documentation examples (#489).
+
 ## 2.2.0
 * Make `compare`, `equal`, and `toText` parameters implicit in `Tuples` module (#470).
 * Add `fromIter`, `values`, and `clone` to `PriorityQueue` (#467).

--- a/bench/FromIters.bench.mo
+++ b/bench/FromIters.bench.mo
@@ -42,9 +42,9 @@ module {
           case _ Runtime.unreachable()
         };
         switch row {
-          case "List.fromIter" ignore List.fromIter(array.vals());
-          case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.vals()));
-          case "Array.fromIter" ignore Array.fromIter(array.vals());
+          case "List.fromIter" ignore List.fromIter(array.values());
+          case "List.fromIter . Iter.reverse" ignore List.fromIter(Iter.reverse(array.values()));
+          case "Array.fromIter" ignore Array.fromIter(array.values());
           case _ Runtime.unreachable()
         }
       }

--- a/bench/Queues.bench.mo
+++ b/bench/Queues.bench.mo
@@ -45,21 +45,21 @@ module {
 
     bench.runner(
       func(row, col) = switch (col, row) {
-        case ("pure/RealTimeQueue", "Initialize with 2 elements") newQ := NewQueue.fromIter<Nat>(init.vals());
-        case ("pure/Queue", "Initialize with 2 elements") oldQ := OldQueue.fromIter<Nat>(init.vals());
-        case ("mutable Queue", "Initialize with 2 elements") mutQ := MutQueue.fromIter<Nat>(init.vals());
+        case ("pure/RealTimeQueue", "Initialize with 2 elements") newQ := NewQueue.fromIter<Nat>(init.values());
+        case ("pure/Queue", "Initialize with 2 elements") oldQ := OldQueue.fromIter<Nat>(init.values());
+        case ("mutable Queue", "Initialize with 2 elements") mutQ := MutQueue.fromIter<Nat>(init.values());
         case ("pure/RealTimeQueue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             newQ := NewQueue.pushBack<Nat>(newQ, i)
           }
         };
         case ("pure/Queue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             oldQ := OldQueue.pushBack<Nat>(oldQ, i)
           }
         };
         case ("mutable Queue", "Push 500 elements") {
-          for (i in toPush.vals()) {
+          for (i in toPush.values()) {
             MutQueue.pushBack<Nat>(mutQ, i)
           }
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "devDependencies": {
         "@dfinity/pic": "^0.13.1",
         "execa": "^4.1.0",
-        "fast-check": "^4.6.0",
         "fast-glob": "^3.3.2",
         "ic-mops": "^1.11.1",
         "mo-dev": "^0.13.0",
@@ -3892,29 +3891,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-check": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
-      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.17.0"
-      }
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -7810,23 +7786,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@dfinity/pic": "^0.13.1",
         "execa": "^4.1.0",
+        "fast-check": "^4.6.0",
         "fast-glob": "^3.3.2",
         "ic-mops": "^1.11.1",
         "mo-dev": "^0.13.0",
@@ -3892,6 +3893,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -7745,6 +7769,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "fast-glob": "^3.3.2",
         "ic-mops": "^1.11.1",
         "mo-dev": "^0.13.0",
-        "motoko": "^3.16.0",
+        "motoko": "^4.4.0",
         "npm-run-all": "^4.1.5",
         "prettier": "2",
         "prettier-plugin-motoko": "^0.11.2",
@@ -6772,6 +6772,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/mo-dev/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mo-dev/node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6817,6 +6835,36 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/mo-dev/node_modules/motoko": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.20.0.tgz",
+      "integrity": "sha512-9L9iDe5kdiT8GquwUCmyermnLuJCifHJZ+WBz6iMbv4omt+layBMNgesDMevD1p33oChw+FzUXEBhschmU3Glw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "parse-github-url": "1.0.3",
+        "sanitize-filename": "1.6.3"
+      }
+    },
+    "node_modules/mo-dev/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mo-dev/node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/morgan": {
@@ -6867,26 +6915,26 @@
       }
     },
     "node_modules/motoko": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-3.16.0.tgz",
-      "integrity": "sha512-6LQiRYp5LsakznOewQKqppF76pn818ynhhU1cy9emCu7e8VMI1OroCDD0Ya8j7TSug1Q7DsrkfrGi2jbgxaJDw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/motoko/-/motoko-4.4.0.tgz",
+      "integrity": "sha512-5ATxFb6gtTcwQNNxffCB3Kb6mXLUJIGXqNKF/Q5KB15q9+rXupWkTY+asy6B8t63PWUNwP+ChteIec55GwDYmw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
+        "debug": "^4.4.3",
         "parse-github-url": "1.0.3",
-        "sanitize-filename": "1.6.3"
+        "sanitize-filename": "^1.6.4"
       }
     },
     "node_modules/motoko/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6896,13 +6944,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/motoko/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8220,9 +8261,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@dfinity/pic": "^0.13.1",
     "execa": "^4.1.0",
+    "fast-check": "^4.6.0",
     "fast-glob": "^3.3.2",
     "ic-mops": "^1.11.1",
     "mo-dev": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@dfinity/pic": "^0.13.1",
     "execa": "^4.1.0",
-    "fast-check": "^4.6.0",
     "fast-glob": "^3.3.2",
     "ic-mops": "^1.11.1",
     "mo-dev": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fast-glob": "^3.3.2",
     "ic-mops": "^1.11.1",
     "mo-dev": "^0.13.0",
-    "motoko": "^3.16.0",
+    "motoko": "^4.4.0",
     "npm-run-all": "^4.1.5",
     "prettier": "2",
     "prettier-plugin-motoko": "^0.11.2",

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -151,7 +151,7 @@ module {
   ///
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func find<T>(self : [T], predicate : T -> Bool) : ?T {
-    for (element in self.vals()) {
+    for (element in self.values()) {
       if (predicate(element)) {
         return ?element
       }
@@ -262,7 +262,7 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func forEach<T>(self : [T], f : T -> ()) {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       f(item)
     }
   };
@@ -598,7 +598,7 @@ module {
   /// Space: O(number of elements in array)
   public func flatten<T>(self : [[T]]) : [T] {
     var flatSize = 0;
-    for (subArray in self.vals()) {
+    for (subArray in self.values()) {
       flatSize += subArray.size()
     };
 
@@ -891,7 +891,7 @@ module {
   ///
   /// Space: O(1)
   public func contains<T>(self : [T], equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       if (equal(item, element)) {
         return true
       }

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -124,7 +124,7 @@ module {
   /// ```motoko include=import
   /// let iter = Iter.fromArray(["A", "B", "C"]);
   /// let enumerated = Iter.enumerate(iter);
-  /// let result = Iter.toArray(enumerated);
+  /// let result = enumerated.toArray();
   /// assert result == [(0, "A"), (1, "B"), (2, "C")];
   /// ```
   public func enumerate<T>(self : Iter<T>) : Iter<(Nat, T)> {
@@ -191,7 +191,7 @@ module {
   /// ```motoko include=import
   /// let iter = [1, 2, 3].values();
   /// let mappedIter = Iter.map<Nat, Nat>(iter, func (x) = x * 2);
-  /// let result = Iter.toArray(mappedIter);
+  /// let result = mappedIter.toArray();
   /// assert result == [2, 4, 6];
   /// ```
   public func map<T, R>(self : Iter<T>, f : T -> R) : Iter<R> = object {
@@ -213,7 +213,7 @@ module {
   /// ```motoko include=import
   /// let iter = [1, 2, 3, 4, 5].values();
   /// let evenNumbers = Iter.filter<Nat>(iter, func (x) = x % 2 == 0);
-  /// let result = Iter.toArray(evenNumbers);
+  /// let result = evenNumbers.toArray();
   /// assert result == [2, 4];
   /// ```
   public func filter<T>(self : Iter<T>, f : T -> Bool) : Iter<T> = object {
@@ -233,7 +233,7 @@ module {
   /// ```motoko include=import
   /// let iter = [1, 2, 3].values();
   /// let evenNumbers = Iter.filterMap<Nat, Nat>(iter, func (x) = if (x % 2 == 0) ?x else null);
-  /// let result = Iter.toArray(evenNumbers);
+  /// let result = evenNumbers.toArray();
   /// assert result == [2];
   /// ```
   public func filterMap<T, R>(self : Iter<T>, f : T -> ?R) : Iter<R> = object {
@@ -253,7 +253,7 @@ module {
   /// Possible optimization: Use `flatMap` when you need to transform elements before calling `flatten`. Example: use `flatMap(...)` instead of `flatten(map(...))`.
   /// ```motoko include=import
   /// let iter = Iter.flatten([[1, 2].values(), [3].values(), [4, 5, 6].values()].values());
-  /// let result = Iter.toArray(iter);
+  /// let result = iter.toArray();
   /// assert result == [1, 2, 3, 4, 5, 6];
   /// ```
   public func flatten<T>(self : Iter<Iter<T>>) : Iter<T> = object {
@@ -274,7 +274,7 @@ module {
   /// Transforms every element of an iterator into an iterator and concatenates the results.
   /// ```motoko include=import
   /// let iter = Iter.flatMap<Nat, Nat>([1, 3, 5].values(), func (x) = [x, x + 1].values());
-  /// let result = Iter.toArray(iter);
+  /// let result = iter.toArray();
   /// assert result == [1, 2, 3, 4, 5, 6];
   /// ```
   public func flatMap<T, R>(self : Iter<T>, f : T -> Iter<R>) : Iter<R> = object {
@@ -299,14 +299,14 @@ module {
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5]);
   /// let first3 = Iter.take(iter, 3);
-  /// let result = Iter.toArray(first3);
+  /// let result = first3.toArray();
   /// assert result == [1, 2, 3];
   /// ```
   ///
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3]);
   /// let first5 = Iter.take(iter, 5);
-  /// let result = Iter.toArray(first5);
+  /// let result = first5.toArray();
   /// assert result == [1, 2, 3]; // only 3 elements in the original iterator
   /// ```
   public func take<T>(self : Iter<T>, n : Nat) : Iter<T> = object {
@@ -324,7 +324,7 @@ module {
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5, 4, 3, 2, 1]);
   /// let result = Iter.takeWhile<Nat>(iter, func (x) = x < 4);
-  /// let array = Iter.toArray(result);
+  /// let array = result.toArray();
   /// assert array == [1, 2, 3]; // note the difference between `takeWhile` and `filter`
   /// ```
   public func takeWhile<T>(self : Iter<T>, f : T -> Bool) : Iter<T> = object {
@@ -344,7 +344,7 @@ module {
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5]);
   /// let skipped = Iter.drop(iter, 3);
-  /// let result = Iter.toArray(skipped);
+  /// let result = skipped.toArray();
   /// assert result == [4, 5];
   /// ```
   public func drop<T>(self : Iter<T>, n : Nat) : Iter<T> = object {
@@ -364,7 +364,7 @@ module {
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5, 4, 3, 2, 1]);
   /// let result = Iter.dropWhile<Nat>(iter, func (x) = x < 4);
-  /// let array = Iter.toArray(result);
+  /// let array = result.toArray();
   /// assert array == [4, 5, 4, 3, 2, 1]; // notice that `takeWhile` and `dropWhile` are complementary
   /// ```
   public func dropWhile<T>(self : Iter<T>, f : T -> Bool) : Iter<T> = object {
@@ -388,7 +388,7 @@ module {
   /// let iter1 = [1, 2, 3].values();
   /// let iter2 = ["A", "B"].values();
   /// let zipped = Iter.zip(iter1, iter2);
-  /// let result = Iter.toArray(zipped);
+  /// let result = zipped.toArray();
   /// assert result == [(1, "A"), (2, "B")]; // note that the third element from iter1 is not included, because iter2 is exhausted
   /// ```
   public func zip<A, B>(self : Iter<A>, other : Iter<B>) : Iter<(A, B)> = object {
@@ -407,7 +407,7 @@ module {
   /// let iter2 = ["1", "2", "3"].values();
   /// let iter3 = ["x", "y", "z", "xd"].values();
   /// let zipped = Iter.zip3(iter1, iter2, iter3);
-  /// let result = Iter.toArray(zipped);
+  /// let result = zipped.toArray();
   /// assert result == [("A", "1", "x"), ("B", "2", "y")]; // note that the unmatched elements from iter2 and iter3 are not included
   /// ```
   public func zip3<A, B, C>(self : Iter<A>, other1 : Iter<B>, other2 : Iter<C>) : Iter<(A, B, C)> = object {
@@ -426,7 +426,7 @@ module {
   /// let iter1 = ["A", "B"].values();
   /// let iter2 = ["1", "2", "3"].values();
   /// let zipped = Iter.zipWith<Text, Text, Text>(iter1, iter2, func (a, b) = a # b);
-  /// let result = Iter.toArray(zipped);
+  /// let result = zipped.toArray();
   /// assert result == ["A1", "B2"]; // note that the third element from iter2 is not included, because iter1 is exhausted
   /// ```
   public func zipWith<A, B, R>(self : Iter<A>, other : Iter<B>, f : (A, B) -> R) : Iter<R> = object {
@@ -445,7 +445,7 @@ module {
   /// let iter2 = ["1", "2", "3"].values();
   /// let iter3 = ["x", "y", "z", "xd"].values();
   /// let zipped = Iter.zipWith3<Text, Text, Text, Text>(iter1, iter2, iter3, func (a, b, c) = a # b # c);
-  /// let result = Iter.toArray(zipped);
+  /// let result = zipped.toArray();
   /// assert result == ["A1x", "B2y"]; // note that the unmatched elements from iter2 and iter3 are not included
   /// ```
   public func zipWith3<A, B, C, R>(self : Iter<A>, other1 : Iter<B>, other2 : Iter<C>, f : (A, B, C) -> R) : Iter<R> = object {
@@ -594,7 +594,7 @@ module {
   ///
   /// let iter = [1, 2, 3].values();
   /// let scanned = Iter.scanLeft<Nat, Nat>(iter, 0, Nat.add);
-  /// let result = Iter.toArray(scanned);
+  /// let result = scanned.toArray();
   /// assert result == [0, 1, 3, 6];
   /// ```
   public func scanLeft<T, R>(self : Iter<T>, initial : R, combine : (R, T) -> R) : Iter<R> = object {
@@ -626,7 +626,7 @@ module {
   ///
   /// let iter = [1, 2, 3].values();
   /// let scanned = Iter.scanRight<Nat, Nat>(iter, 0, Nat.add);
-  /// let result = Iter.toArray(scanned);
+  /// let result = scanned.toArray();
   /// assert result == [0, 3, 5, 6];
   /// ```
   public func scanRight<T, R>(self : Iter<T>, initial : R, combine : (T, R) -> R) : Iter<R> {
@@ -638,7 +638,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = Iter.unfold<Nat, Nat>(1, func (x) = if (x <= 3) ?(x, x + 1) else null);
-  /// let result = Iter.toArray(iter);
+  /// let result = iter.toArray();
   /// assert result == [1, 2, 3];
   /// ```
   public func unfold<T, S>(initial : S, step : S -> ?(T, S)) : Iter<T> = object {
@@ -714,7 +714,7 @@ module {
   /// let iter1 = [1, 2].values();
   /// let iter2 = [5, 6, 7].values();
   /// let concatenatedIter = Iter.concat(iter1, iter2);
-  /// let result = Iter.toArray(concatenatedIter);
+  /// let result = concatenatedIter.toArray();
   /// assert result == [1, 2, 5, 6, 7];
   /// ```
   public func concat<T>(self : Iter<T>, other : Iter<T>) : Iter<T> {
@@ -755,7 +755,7 @@ module {
   /// Consumes an iterator and collects its produced elements in an Array.
   /// ```motoko include=import
   /// let iter = [1, 2, 3].values();
-  /// assert [1, 2, 3] == Iter.toArray(iter);
+  /// assert [1, 2, 3] == iter.toArray();
   /// ```
   public func toArray<T>(self : Iter<T>) : [T] {
     // TODO: Replace implementation. This is just temporay.
@@ -789,7 +789,7 @@ module {
       count,
       func(_) {
         switch (current) {
-          case null Runtime.trap("Iter.toArray(): node must not be null");
+          case null Runtime.trap("toArray(): node must not be null");
           case (?node) {
             current := node.next;
             node.value

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -744,13 +744,13 @@ module {
   /// assert null == iter.next();
   /// ```
   /// @deprecated M0235
-  public func fromArray<T>(array : [T]) : Iter<T> = array.vals();
+  public func fromArray<T>(array : [T]) : Iter<T> = array.values();
 
   /// Like `fromArray` but for Arrays with mutable elements. Captures
   /// the elements of the Array at the time the iterator is created, so
   /// further modifications won't be reflected in the iterator.
   /// @deprecated M0235
-  public func fromVarArray<T>(array : [var T]) : Iter<T> = array.vals();
+  public func fromVarArray<T>(array : [var T]) : Iter<T> = array.values();
 
   /// Consumes an iterator and collects its produced elements in an Array.
   /// ```motoko include=import

--- a/src/List.mo
+++ b/src/List.mo
@@ -439,7 +439,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let lists = [List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])];
-  /// let joinedList = List.join<Nat>(lists.vals());
+  /// let joinedList = List.join<Nat>(lists.values());
   /// assert List.equal<Nat>(joinedList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
@@ -816,7 +816,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let newList = List.flatMap<Nat, Int>(list, func x = [x, -x].vals());
+  /// let newList = List.flatMap<Nat, Int>(list, func x = [x, -x].values());
   /// assert List.equal(newList, List.fromArray<Int>([1, -1, 2, -2, 3, -3, 4, -4]), Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -1929,7 +1929,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   ///
   /// let list = List.fromIter<Nat>(iter);
   /// assert (List.values(list)).toArray() == [1, 1, 1];
@@ -1951,7 +1951,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   ///
   /// let list = iter.toList<Nat>();
   /// assert (List.values(list)).toArray() == [1, 1, 1];
@@ -2007,7 +2007,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [1, 1, 1];
-  /// let iter = array.vals();
+  /// let iter = array.values();
   /// let list = List.repeat<Nat>(2, 1);
   ///
   /// List.addAll<Nat>(list, iter);

--- a/src/List.mo
+++ b/src/List.mo
@@ -1932,7 +1932,7 @@ module {
   /// let iter = array.values();
   ///
   /// let list = List.fromIter<Nat>(iter);
-  /// assert list.values().toArray() == [1, 1, 1];
+  /// assert list.toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1954,7 +1954,7 @@ module {
   /// let iter = array.values();
   ///
   /// let list = iter.toList<Nat>();
-  /// assert list.values().toArray() == [1, 1, 1];
+  /// assert list.toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2011,7 +2011,7 @@ module {
   /// let list = List.repeat<Nat>(2, 1);
   ///
   /// list.addAll<Nat>(iter);
-  /// assert list.values().toArray() == [2, 1, 1, 1];
+  /// assert list.toArray() == [2, 1, 1, 1];
   /// ```
   ///
   /// The maximum number of elements in a `List` is 2^32.
@@ -2066,7 +2066,7 @@ module {
   ///
   /// let array = [2, 3];
   /// let list = List.fromArray<Nat>(array);
-  /// assert list.values().toArray() == [2, 3];
+  /// assert list.toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2153,7 +2153,7 @@ module {
   ///
   /// let array = [var 2, 3];
   /// let list = List.fromVarArray<Nat>(array);
-  /// assert list.values().toArray() == [2, 3];
+  /// assert list.toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2976,7 +2976,7 @@ module {
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
   /// list.reverseInPlace<Nat>();
-  /// assert list.values().toArray() == [3, 2, 1];
+  /// assert list.toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -3033,7 +3033,7 @@ module {
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
   /// let rlist = list.reverse<Nat>();
-  /// assert rlist.values().toArray() == [3, 2, 1];
+  /// assert rlist.toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`

--- a/src/List.mo
+++ b/src/List.mo
@@ -55,7 +55,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.singleton<Nat>(1);
-  /// assert List.toText<Nat>(list, Nat.toText) == "List[1]";
+  /// assert list.toText<Nat>(Nat.toText) == "List[1]";
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -99,7 +99,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.repeat<Nat>(2, 4);
-  /// assert List.toArray(list) == [2, 2, 2, 2];
+  /// assert list.toArray() == [2, 2, 2, 2];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -112,8 +112,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3]);
-  /// List.fill(list, 0); // fills the list with 0
-  /// assert List.toArray(list) == [0, 0, 0];
+  /// list.fill(0); // fills the list with 0
+  /// assert list.toArray() == [0, 0, 0];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -145,7 +145,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3]);
-  /// let pureList = List.toPure<Nat>(list); // converts to immutable PureList
+  /// let pureList = list.toPure<Nat>(); // converts to immutable PureList
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -274,7 +274,7 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.repeat<Nat>(2, 4); // [2, 2, 2, 2]
-  /// List.addRepeat(list, 2, 1); // [2, 2, 2, 2, 1, 1]
+  /// list.addRepeat(2, 1); // [2, 2, 2, 2, 1, 1]
   /// ```
   ///
   /// The maximum number of elements in a `List` is 2^32.
@@ -289,8 +289,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
-  /// List.truncate(list, 3); // list is now [1, 2, 3]
-  /// assert List.toArray(list) == [1, 2, 3];
+  /// list.truncate(3); // list is now [1, 2, 3]
+  /// assert list.toArray() == [1, 2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -332,11 +332,11 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// List.add(list, 12);
-  /// List.clear(list); // list is now empty
-  /// assert List.toArray(list) == [];
+  /// list.add(10);
+  /// list.add(11);
+  /// list.add(12);
+  /// list.clear(); // list is now empty
+  /// assert list.toArray() == [];
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -353,7 +353,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.tabulate<Nat>(4, func i = i * 2);
-  /// assert List.toArray(list) == [0, 2, 4, 6];
+  /// assert list.toArray() == [0, 2, 4, 6];
   /// ```
   ///
   /// Runtime: O(size)
@@ -393,7 +393,7 @@ module {
   /// Combines a list of lists into a single list. Retains the original
   /// ordering of the elements.
   ///
-  /// This has better performance compared to `List.join()`.
+  /// This has better performance compared to `join()` on an iterator of lists.
   ///
   /// ```motoko include=import
   /// import Nat "mo:core/Nat";
@@ -401,8 +401,8 @@ module {
   /// let lists = List.fromArray<List.List<Nat>>([
   ///   List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])
   /// ]);
-  /// let flatList = List.flatten<Nat>(lists);
-  /// assert List.equal<Nat>(flatList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
+  /// let flatList = lists.flatten<Nat>();
+  /// assert flatList.equal(List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
   /// Runtime: O(number of elements in list)
@@ -433,14 +433,14 @@ module {
   /// Combines an iterator of lists into a single list.
   /// Retains the original ordering of the elements.
   ///
-  /// Consider using `List.flatten()` for better performance.
+  /// Consider using `flatten()` on a list of lists for better performance.
   ///
   /// ```motoko include=import
   /// import Nat "mo:core/Nat";
   ///
   /// let lists = [List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])];
-  /// let joinedList = List.join<Nat>(lists.values());
-  /// assert List.equal<Nat>(joinedList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
+  /// let joinedList = lists.values().join<Nat>();
+  /// assert joinedList.equal(List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
   /// Runtime: O(number of elements in list)
@@ -460,10 +460,10 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
+  /// list.add(1);
   ///
-  /// let clone = List.clone(list);
-  /// assert List.toArray(clone) == [1];
+  /// let clone = list.clone();
+  /// assert clone.toArray() == [1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -487,8 +487,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.singleton<Nat>(123);
-  /// let textList = List.map<Nat, Text>(list, Nat.toText);
-  /// assert List.toArray(textList) == ["123"];
+  /// let textList = list.map<Nat, Text>(Nat.toText);
+  /// assert textList.toArray() == ["123"];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -532,8 +532,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([0, 1, 2, 3]);
-  /// List.mapInPlace<Nat>(list, func x = x * 3);
-  /// assert List.equal(list, List.fromArray<Nat>([0, 3, 6, 9]), Nat.equal);
+  /// list.mapInPlace<Nat>(func x = x * 3);
+  /// assert list.equal(List.fromArray<Nat>([0, 3, 6, 9]), Nat.equal);
   /// ```
   ///
   /// Runtime: O(size)
@@ -570,8 +570,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([10, 10, 10, 10]);
-  /// let newList = List.mapEntries<Nat, Nat>(list, func (x, i) = i * x);
-  /// assert List.equal(newList, List.fromArray<Nat>([0, 10, 20, 30]), Nat.equal);
+  /// let newList = list.mapEntries<Nat, Nat>(func (x, i) = i * x);
+  /// assert newList.equal(List.fromArray<Nat>([0, 10, 20, 30]), Nat.equal);
   /// ```
   ///
   /// Runtime: O(size)
@@ -620,7 +620,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([4, 3, 2, 1, 0]);
   /// // divide 100 by every element in the list
-  /// let result = List.mapResult<Nat, Nat, Text>(list, func x {
+  /// let result = list.mapResult<Nat, Nat, Text>(func x {
   ///   if (x > 0) {
   ///     #ok(100 / x)
   ///   } else {
@@ -690,8 +690,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let evenNumbers = List.filter<Nat>(list, func x = x % 2 == 0);
-  /// assert List.toArray(evenNumbers) == [2, 4];
+  /// let evenNumbers = list.filter<Nat>(func x = x % 2 == 0);
+  /// assert evenNumbers.toArray() == [2, 4];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -731,8 +731,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// List.retain<Nat>(list, func x = x % 2 == 0);
-  /// assert List.toArray(list) == [2, 4];
+  /// list.retain<Nat>(func x = x % 2 == 0);
+  /// assert list.toArray() == [2, 4];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -771,8 +771,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let doubled = List.filterMap<Nat, Nat>(list, func x = if (x % 2 == 0) ?(x * 2) else null);
-  /// assert List.toArray(doubled) == [4, 8];
+  /// let doubled = list.filterMap<Nat, Nat>(func x = if (x % 2 == 0) ?(x * 2) else null);
+  /// assert doubled.toArray() == [4, 8];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -816,8 +816,8 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let newList = List.flatMap<Nat, Int>(list, func x = [x, -x].values());
-  /// assert List.equal(newList, List.fromArray<Int>([1, -1, 2, -2, 3, -3, 4, -4]), Int.equal);
+  /// let newList = list.flatMap<Nat, Int>(func x = [x, -x].values());
+  /// assert newList.equal(List.fromArray<Int>([1, -1, 2, -2, 3, -3, 4, -4]), Int.equal);
   /// ```
   /// Runtime: O(size)
   ///
@@ -880,7 +880,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// assert List.size(list) == 0
+  /// assert list.size() == 0
   /// ```
   ///
   /// Runtime: `O(1)` (with some internal calculations)
@@ -942,11 +942,11 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 0); // add 0 to list
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// assert List.toArray(list) == [0, 1, 2, 3];
+  /// list.add(0); // add 0 to list
+  /// list.add(1);
+  /// list.add(2);
+  /// list.add(3);
+  /// assert list.toArray() == [0, 1, 2, 3];
   /// ```
   ///
   /// The maximum number of elements in a `List` is 2^32.
@@ -999,11 +999,11 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// assert List.removeLast(list) == ?11;
-  /// assert List.removeLast(list) == ?10;
-  /// assert List.removeLast(list) == null;
+  /// list.add(10);
+  /// list.add(11);
+  /// assert list.removeLast() == ?11;
+  /// assert list.removeLast() == ?10;
+  /// assert list.removeLast() == null;
   /// ```
   ///
   /// Amortized Runtime: `O(1)`, Worst Case Runtime: `O(sqrt(n))`
@@ -1056,9 +1056,9 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// assert List.at(list, 0) == 10;
+  /// list.add(10);
+  /// list.add(11);
+  /// assert list.at(0) == 10;
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -1090,10 +1090,10 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// assert List.get(list, 0) == ?10;
-  /// assert List.get(list, 2) == null;
+  /// list.add(10);
+  /// list.add(11);
+  /// assert list.get(0) == ?10;
+  /// assert list.get(2) == null;
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -1123,9 +1123,9 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.put(list, 0, 20); // overwrites 10 at index 0 with 20
-  /// assert List.toArray(list) == [20];
+  /// list.add(10);
+  /// list.put(0, 20); // overwrites 10 at index 0 with 20
+  /// assert list.toArray() == [20];
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -1153,11 +1153,11 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 3);
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// List.sortInPlace(list, Nat.compare);
-  /// assert List.toArray(list) == [1, 2, 3];
+  /// list.add(3);
+  /// list.add(1);
+  /// list.add(2);
+  /// list.sortInPlace(Nat.compare);
+  /// assert list.toArray() == [1, 2, 3];
   /// ```
   ///
   /// Runtime: O(size * log(size))
@@ -1202,11 +1202,11 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 3);
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// let sorted = List.sort(list, Nat.compare);
-  /// assert List.toArray(sorted) == [1, 2, 3];
+  /// list.add(3);
+  /// list.add(1);
+  /// list.add(2);
+  /// let sorted = list.sort(Nat.compare);
+  /// assert sorted.toArray() == [1, 2, 3];
   /// ```
   ///
   /// Runtime: O(size * log(size))
@@ -1226,7 +1226,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
-  /// assert List.isSorted(list, Nat.compare);
+  /// assert list.isSorted(Nat.compare);
   /// ```
   ///
   /// Runtime: O(size)
@@ -1271,8 +1271,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([1, 1, 2, 2, 3]);
-  /// List.deduplicate(list, Nat.equal);
-  /// assert List.equal(list, List.fromArray<Nat>([1, 2, 3]), Nat.equal);
+  /// list.deduplicate(Nat.equal);
+  /// assert list.equal(List.fromArray<Nat>([1, 2, 3]), Nat.equal);
   /// ```
   ///
   /// Runtime: O(size)
@@ -1323,13 +1323,13 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// List.add(list, 4);
+  /// list.add(1);
+  /// list.add(2);
+  /// list.add(3);
+  /// list.add(4);
   ///
-  /// assert List.indexOf<Nat>(list, Nat.equal, 3) == ?2;
-  /// assert List.indexOf<Nat>(list, Nat.equal, 5) == null;
+  /// assert list.indexOf<Nat>(Nat.equal, 3) == ?2;
+  /// assert list.indexOf<Nat>(Nat.equal, 5) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1345,11 +1345,11 @@ module {
   /// ```motoko include=import
   /// import Char "mo:core/Char";
   /// let list = List.fromArray<Char>(['c', 'o', 'f', 'f', 'e', 'e']);
-  /// assert List.nextIndexOf<Char>(list, Char.equal, 'c', 0) == ?0;
-  /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 0) == ?2;
-  /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 2) == ?2;
-  /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 3) == ?3;
-  /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 4) == null;
+  /// assert list.nextIndexOf<Char>(Char.equal, 'c', 0) == ?0;
+  /// assert list.nextIndexOf<Char>(Char.equal, 'f', 0) == ?2;
+  /// assert list.nextIndexOf<Char>(Char.equal, 'f', 2) == ?2;
+  /// assert list.nextIndexOf<Char>(Char.equal, 'f', 3) == ?3;
+  /// assert list.nextIndexOf<Char>(Char.equal, 'f', 4) == null;
   /// ```
   ///
   /// Runtime: O(size)
@@ -1393,8 +1393,8 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 2, 2]);
   ///
-  /// assert List.lastIndexOf<Nat>(list, Nat.equal, 2) == ?5;
-  /// assert List.lastIndexOf<Nat>(list, Nat.equal, 5) == null;
+  /// assert list.lastIndexOf<Nat>(Nat.equal, 2) == ?5;
+  /// assert list.lastIndexOf<Nat>(Nat.equal, 5) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1412,10 +1412,10 @@ module {
   /// ```motoko include=import
   /// import Char "mo:core/Char";
   /// let list = List.fromArray<Char>(['c', 'o', 'f', 'f', 'e', 'e']);
-  /// assert List.prevIndexOf<Char>(list, Char.equal, 'c', List.size(list)) == ?0;
-  /// assert List.prevIndexOf<Char>(list, Char.equal, 'e', List.size(list)) == ?5;
-  /// assert List.prevIndexOf<Char>(list, Char.equal, 'e', 5) == ?4;
-  /// assert List.prevIndexOf<Char>(list, Char.equal, 'e', 4) == null;
+  /// assert list.prevIndexOf<Char>(Char.equal, 'c', list.size()) == ?0;
+  /// assert list.prevIndexOf<Char>(Char.equal, 'e', list.size()) == ?5;
+  /// assert list.prevIndexOf<Char>(Char.equal, 'e', 5) == ?4;
+  /// assert list.prevIndexOf<Char>(Char.equal, 'e', 4) == null;
   /// ```
   ///
   /// Runtime: O(size)
@@ -1452,7 +1452,7 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 9, 4, 8]);
-  /// let found = List.find<Nat>(list, func(x) { x > 8 });
+  /// let found = list.find<Nat>(func(x) { x > 8 });
   /// assert found == ?9;
   /// ```
   /// Runtime: O(size)
@@ -1470,13 +1470,13 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// List.add(list, 4);
+  /// list.add(1);
+  /// list.add(2);
+  /// list.add(3);
+  /// list.add(4);
   ///
-  /// assert List.findIndex<Nat>(list, func(i) { i % 2 == 0 }) == ?1;
-  /// assert List.findIndex<Nat>(list, func(i) { i > 5 }) == null;
+  /// assert list.findIndex<Nat>(func(i) { i % 2 == 0 }) == ?1;
+  /// assert list.findIndex<Nat>(func(i) { i > 5 }) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1511,13 +1511,13 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// List.add(list, 4);
+  /// list.add(1);
+  /// list.add(2);
+  /// list.add(3);
+  /// list.add(4);
   ///
-  /// assert List.findLastIndex<Nat>(list, func(i) { i % 2 == 0 }) == ?3;
-  /// assert List.findLastIndex<Nat>(list, func(i) { i > 5 }) == null;
+  /// assert list.findLastIndex<Nat>(func(i) { i % 2 == 0 }) == ?3;
+  /// assert list.findLastIndex<Nat>(func(i) { i > 5 }) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1560,8 +1560,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-  /// assert List.binarySearch<Nat>(list, Nat.compare, 5) == #found(2);
-  /// assert List.binarySearch<Nat>(list, Nat.compare, 6) == #insertionIndex(3);
+  /// assert list.binarySearch<Nat>(Nat.compare, 5) == #found(2);
+  /// assert list.binarySearch<Nat>(Nat.compare, 6) == #insertionIndex(3);
   /// ```
   ///
   /// Runtime: `O(log(size))`
@@ -1655,11 +1655,11 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// List.add(list, 4);
+  /// list.add(2);
+  /// list.add(3);
+  /// list.add(4);
   ///
-  /// assert List.all<Nat>(list, func x { x > 1 });
+  /// assert list.all<Nat>(func x { x > 1 });
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1696,11 +1696,11 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 2);
-  /// List.add(list, 3);
-  /// List.add(list, 4);
+  /// list.add(2);
+  /// list.add(3);
+  /// list.add(4);
   ///
-  /// assert List.any<Nat>(list, func x { x > 3 });
+  /// assert list.any<Nat>(func x { x > 3 });
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1716,12 +1716,12 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// List.add(list, 12);
+  /// list.add(10);
+  /// list.add(11);
+  /// list.add(12);
   ///
   /// var sum = 0;
-  /// for (element in List.values(list)) {
+  /// for (element in list.values()) {
   ///   sum += element;
   /// };
   /// assert sum == 33;
@@ -1766,10 +1766,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// List.add(list, 12);
-  /// assert (List.enumerate(list)).toArray() == [(0, 10), (1, 11), (2, 12)];
+  /// list.add(10);
+  /// list.add(11);
+  /// list.add(12);
+  /// assert list.enumerate().toArray() == [(0, 10), (1, 11), (2, 12)];
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1814,12 +1814,12 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// List.add(list, 12);
+  /// list.add(10);
+  /// list.add(11);
+  /// list.add(12);
   ///
   /// var sum = 0;
-  /// for (element in List.reverseValues(list)) {
+  /// for (element in list.reverseValues()) {
   ///   sum += element;
   /// };
   /// assert sum == 33;
@@ -1859,10 +1859,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 10);
-  /// List.add(list, 11);
-  /// List.add(list, 12);
-  /// assert (List.reverseEnumerate(list)).toArray() == [(2, 12), (1, 11), (0, 10)];
+  /// list.add(10);
+  /// list.add(11);
+  /// list.add(12);
+  /// assert list.reverseEnumerate().toArray() == [(2, 12), (1, 11), (0, 10)];
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1907,10 +1907,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let list = List.empty<Text>();
-  /// List.add(list, "A");
-  /// List.add(list, "B");
-  /// List.add(list, "C");
-  /// (List.keys(list)).toArray() // [0, 1, 2]
+  /// list.add("A");
+  /// list.add("B");
+  /// list.add("C");
+  /// list.keys().toArray() // [0, 1, 2]
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1932,7 +1932,7 @@ module {
   /// let iter = array.values();
   ///
   /// let list = List.fromIter<Nat>(iter);
-  /// assert (List.values(list)).toArray() == [1, 1, 1];
+  /// assert list.values().toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1954,7 +1954,7 @@ module {
   /// let iter = array.values();
   ///
   /// let list = iter.toList<Nat>();
-  /// assert (List.values(list)).toArray() == [1, 1, 1];
+  /// assert list.values().toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1967,8 +1967,8 @@ module {
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2]);
   /// let added = List.fromArray<Nat>([3, 4]);
-  /// List.append<Nat>(list, added);
-  /// assert List.toArray(list) == [1, 2, 3, 4];
+  /// list.append<Nat>(added);
+  /// assert list.toArray() == [1, 2, 3, 4];
   /// ```
   ///
   /// Runtime: `O(size(added))`
@@ -2010,8 +2010,8 @@ module {
   /// let iter = array.values();
   /// let list = List.repeat<Nat>(2, 1);
   ///
-  /// List.addAll<Nat>(list, iter);
-  /// assert (List.values(list)).toArray() == [2, 1, 1, 1];
+  /// list.addAll<Nat>(iter);
+  /// assert list.values().toArray() == [2, 1, 1, 1];
   /// ```
   ///
   /// The maximum number of elements in a `List` is 2^32.
@@ -2028,7 +2028,7 @@ module {
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// assert List.toArray<Nat>(list) == [1, 2, 3];
+  /// assert list.toArray<Nat>() == [1, 2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2066,7 +2066,7 @@ module {
   ///
   /// let array = [2, 3];
   /// let list = List.fromArray<Nat>(array);
-  /// assert (List.values(list)).toArray() == [2, 3];
+  /// assert list.values().toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2108,7 +2108,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// let varArray = List.toVarArray<Nat>(list);
+  /// let varArray = list.toVarArray<Nat>();
   /// assert Array.fromVarArray(varArray) == [1, 2, 3];
   /// ```
   ///
@@ -2153,7 +2153,7 @@ module {
   ///
   /// let array = [var 2, 3];
   /// let list = List.fromVarArray<Nat>(array);
-  /// assert (List.values(list)).toArray() == [2, 3];
+  /// assert list.values().toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2199,8 +2199,8 @@ module {
   ///
   /// Example:
   /// ```motoko include=import
-  /// assert List.first(List.fromArray<Nat>([1, 2, 3])) == ?1;
-  /// assert List.first(List.empty<Nat>()) == null;
+  /// assert List.fromArray<Nat>([1, 2, 3]).first() == ?1;
+  /// assert List.empty<Nat>().first() == null;
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -2214,8 +2214,8 @@ module {
   ///
   /// Example:
   /// ```motoko include=import
-  /// assert List.last(List.fromArray<Nat>([1, 2, 3])) == ?3;
-  /// assert List.last(List.empty<Nat>()) == null;
+  /// assert List.fromArray<Nat>([1, 2, 3]).last() == ?3;
+  /// assert List.empty<Nat>().last() == null;
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -2241,7 +2241,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// List.forEach<Nat>(list, func(x) {
+  /// list.forEach<Nat>(func(x) {
   ///   Debug.print(Nat.toText(x)); // prints each element in list
   /// });
   /// ```
@@ -2283,7 +2283,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// List.forEachEntry<Nat>(list, func (i,x) {
+  /// list.forEachEntry<Nat>(func (i,x) {
   ///   // prints each item (i,x) in list
   ///   Debug.print(Nat.toText(i) # Nat.toText(x));
   /// });
@@ -2343,16 +2343,16 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
-  /// let iter1 = List.range<Nat>(list, 3, List.size(list));
+  /// let iter1 = list.range<Nat>(3, list.size());
   /// assert iter1.next() == ?4;
   /// assert iter1.next() == ?5;
   /// assert iter1.next() == null;
   ///
-  /// let iter2 = List.range<Nat>(list, 3, -1);
+  /// let iter2 = list.range<Nat>(3, -1);
   /// assert iter2.next() == ?4;
   /// assert iter2.next() == null;
   ///
-  /// let iter3 = List.range<Nat>(list, 0, 0);
+  /// let iter3 = list.range<Nat>(0, 0);
   /// assert iter3.next() == null;
   /// ```
   ///
@@ -2427,10 +2427,10 @@ module {
   /// ```motoko include=import
   /// let array = List.fromArray<Nat>([1, 2, 3, 4, 5]);
   ///
-  /// let slice1 = List.sliceToArray<Nat>(array, 1, 4);
+  /// let slice1 = array.sliceToArray<Nat>(1, 4);
   /// assert slice1 == [2, 3, 4];
   ///
-  /// let slice2 = List.sliceToArray<Nat>(array, 1, -1);
+  /// let slice2 = array.sliceToArray<Nat>(1, -1);
   /// assert slice2 == [2, 3, 4];
   /// ```
   ///
@@ -2451,10 +2451,10 @@ module {
   ///
   /// let array = List.fromArray<Nat>([1, 2, 3, 4, 5]);
   ///
-  /// let slice1 = List.sliceToVarArray<Nat>(array, 1, 4);
+  /// let slice1 = array.sliceToVarArray<Nat>(1, 4);
   /// assert VarArray.equal(slice1, [var 2, 3, 4], Nat.equal);
   ///
-  /// let slice2 = List.sliceToVarArray<Nat>(array, 1, -1);
+  /// let slice2 = array.sliceToVarArray<Nat>(1, -1);
   /// assert VarArray.equal(slice2, [var 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -2476,7 +2476,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// List.reverseForEachEntry<Nat>(list, func (i,x) {
+  /// list.reverseForEachEntry<Nat>(func (i,x) {
   ///   // prints each item (i,x) in list
   ///   Debug.print(Nat.toText(i) # Nat.toText(x));
   /// });
@@ -2522,7 +2522,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// List.reverseForEach<Nat>(list, func (x) {
+  /// list.reverseForEach<Nat>(func (x) {
   ///   Debug.print(Nat.toText(x)); // prints each element in list in reverse order
   /// });
   /// ```
@@ -2562,7 +2562,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
-  /// List.forEachInRange<Nat>(list, func x = Debug.print(Nat.toText(x)), 1, 2); // prints 2 and 3
+  /// list.forEachInRange<Nat>(func x = Debug.print(Nat.toText(x)), 1, 2); // prints 2 and 3
   /// ```
   ///
   /// Runtime: `O(toExclusive - fromExclusive)`
@@ -2613,11 +2613,11 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 2);
-  /// List.add(list, 0);
-  /// List.add(list, 3);
+  /// list.add(2);
+  /// list.add(0);
+  /// list.add(3);
   ///
-  /// assert List.contains<Nat>(list, Nat.equal, 2);
+  /// assert list.contains<Nat>(Nat.equal, 2);
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2637,11 +2637,11 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
-  /// List.add(list, 2);
+  /// list.add(1);
+  /// list.add(2);
   ///
-  /// assert List.max<Nat>(list, Nat.compare) == ?2;
-  /// assert List.max<Nat>(List.empty<Nat>(), Nat.compare) == null;
+  /// assert list.max<Nat>(Nat.compare) == ?2;
+  /// assert List.empty<Nat>().max<Nat>(Nat.compare) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2689,11 +2689,11 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.empty<Nat>();
-  /// List.add(list, 1);
-  /// List.add(list, 2);
+  /// list.add(1);
+  /// list.add(2);
   ///
-  /// assert List.min<Nat>(list, Nat.compare) == ?1;
-  /// assert List.min<Nat>(List.empty<Nat>(), Nat.compare) == null;
+  /// assert list.min<Nat>(Nat.compare) == ?1;
+  /// assert List.empty<Nat>().min<Nat>(Nat.compare) == null;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2743,10 +2743,10 @@ module {
   ///
   /// let list1 = List.fromArray<Nat>([1,2]);
   /// let list2 = List.empty<Nat>();
-  /// List.add(list2, 1);
-  /// List.add(list2, 2);
+  /// list2.add(1);
+  /// list2.add(2);
   ///
-  /// assert List.equal<Nat>(list1, list2, Nat.equal);
+  /// assert list1.equal<Nat>(list2, Nat.equal);
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2793,9 +2793,9 @@ module {
   /// let list2 = List.fromArray<Nat>([2]);
   /// let list3 = List.fromArray<Nat>([0, 1, 2]);
   ///
-  /// assert List.compare<Nat>(list1, list2, Nat.compare) == #less;
-  /// assert List.compare<Nat>(list1, list3, Nat.compare) == #less;
-  /// assert List.compare<Nat>(list2, list3, Nat.compare) == #greater;
+  /// assert list1.compare<Nat>(list2, Nat.compare) == #less;
+  /// assert list1.compare<Nat>(list3, Nat.compare) == #less;
+  /// assert list2.compare<Nat>(list3, Nat.compare) == #greater;
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2841,7 +2841,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3,4]);
   ///
-  /// assert List.toText<Nat>(list, Nat.toText) == "List[1, 2, 3, 4]";
+  /// assert list.toText<Nat>(Nat.toText) == "List[1, 2, 3, 4]";
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2888,7 +2888,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
-  /// assert List.foldLeft<Text, Nat>(list, "", func (acc, x) { acc # Nat.toText(x)}) == "123";
+  /// assert list.foldLeft<Text, Nat>("", func (acc, x) { acc # Nat.toText(x)}) == "123";
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2931,7 +2931,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
-  /// assert List.foldRight<Nat, Text>(list, "", func (x, acc) { Nat.toText(x) # acc }) == "123";
+  /// assert list.foldRight<Nat, Text>("", func (x, acc) { Nat.toText(x) # acc }) == "123";
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2975,8 +2975,8 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
-  /// List.reverseInPlace<Nat>(list);
-  /// assert (List.values(list)).toArray() == [3, 2, 1];
+  /// list.reverseInPlace<Nat>();
+  /// assert list.values().toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -3032,8 +3032,8 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
-  /// let rlist = List.reverse<Nat>(list);
-  /// assert (List.values(rlist)).toArray() == [3, 2, 1];
+  /// let rlist = list.reverse<Nat>();
+  /// assert rlist.values().toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -3081,8 +3081,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([2,0,3]);
-  /// assert not List.isEmpty<Nat>(list);
-  /// assert List.isEmpty<Nat>(List.empty<Nat>());
+  /// assert not list.isEmpty<Nat>();
+  /// assert List.empty<Nat>().isEmpty<Nat>();
   /// ```
   ///
   /// Runtime: `O(1)`
@@ -3097,7 +3097,7 @@ module {
   /// Example:
   /// ```
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
-  /// let reader = List.reader<Nat>(list, 2);
+  /// let reader = list.reader<Nat>(2);
   /// assert reader() == 3;
   /// assert reader() == 4;
   /// assert reader() == 5;

--- a/src/List.mo
+++ b/src/List.mo
@@ -64,7 +64,7 @@ module {
   public func singleton<T>(element : T) : List<T> = {
     var blockIndex = 2;
     var blocks = [var [var], [var ?element]];
-    var elementIndex = 0;
+    var elementIndex = 0
   };
 
   func repeatInternal<T>(initValue : ?T, size : Nat) : List<T> {
@@ -90,7 +90,7 @@ module {
     {
       var blocks = dataBlocks;
       var blockIndex = blockIndex;
-      var elementIndex = elementIndex;
+      var elementIndex = elementIndex
     }
   };
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -1769,7 +1769,7 @@ module {
   /// List.add(list, 10);
   /// List.add(list, 11);
   /// List.add(list, 12);
-  /// assert Iter.toArray(List.enumerate(list)) == [(0, 10), (1, 11), (2, 12)];
+  /// assert (List.enumerate(list)).toArray() == [(0, 10), (1, 11), (2, 12)];
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1862,7 +1862,7 @@ module {
   /// List.add(list, 10);
   /// List.add(list, 11);
   /// List.add(list, 12);
-  /// assert Iter.toArray(List.reverseEnumerate(list)) == [(2, 12), (1, 11), (0, 10)];
+  /// assert (List.reverseEnumerate(list)).toArray() == [(2, 12), (1, 11), (0, 10)];
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1910,7 +1910,7 @@ module {
   /// List.add(list, "A");
   /// List.add(list, "B");
   /// List.add(list, "C");
-  /// Iter.toArray(List.keys(list)) // [0, 1, 2]
+  /// (List.keys(list)).toArray() // [0, 1, 2]
   /// ```
   ///
   /// Note: This does not create a snapshot. If the returned iterator is not consumed at once,
@@ -1932,7 +1932,7 @@ module {
   /// let iter = array.vals();
   ///
   /// let list = List.fromIter<Nat>(iter);
-  /// assert Iter.toArray(List.values(list)) == [1, 1, 1];
+  /// assert (List.values(list)).toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -1954,7 +1954,7 @@ module {
   /// let iter = array.vals();
   ///
   /// let list = iter.toList<Nat>();
-  /// assert Iter.toArray(List.values(list)) == [1, 1, 1];
+  /// assert (List.values(list)).toArray() == [1, 1, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2011,7 +2011,7 @@ module {
   /// let list = List.repeat<Nat>(2, 1);
   ///
   /// List.addAll<Nat>(list, iter);
-  /// assert Iter.toArray(List.values(list)) == [2, 1, 1, 1];
+  /// assert (List.values(list)).toArray() == [2, 1, 1, 1];
   /// ```
   ///
   /// The maximum number of elements in a `List` is 2^32.
@@ -2066,7 +2066,7 @@ module {
   ///
   /// let array = [2, 3];
   /// let list = List.fromArray<Nat>(array);
-  /// assert Iter.toArray(List.values(list)) == [2, 3];
+  /// assert (List.values(list)).toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2153,7 +2153,7 @@ module {
   ///
   /// let array = [var 2, 3];
   /// let list = List.fromVarArray<Nat>(array);
-  /// assert Iter.toArray(List.values(list)) == [2, 3];
+  /// assert (List.values(list)).toArray() == [2, 3];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -2976,7 +2976,7 @@ module {
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
   /// List.reverseInPlace<Nat>(list);
-  /// assert Iter.toArray(List.values(list)) == [3, 2, 1];
+  /// assert (List.values(list)).toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -3033,7 +3033,7 @@ module {
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
   /// let rlist = List.reverse<Nat>(list);
-  /// assert Iter.toArray(List.values(rlist)) == [3, 2, 1];
+  /// assert (List.values(rlist)).toArray() == [3, 2, 1];
   /// ```
   ///
   /// Runtime: `O(size)`

--- a/src/List.mo
+++ b/src/List.mo
@@ -64,7 +64,7 @@ module {
   public func singleton<T>(element : T) : List<T> = {
     var blockIndex = 2;
     var blocks = [var [var], [var ?element]];
-    var elementIndex = 0
+    var elementIndex = 0;
   };
 
   func repeatInternal<T>(initValue : ?T, size : Nat) : List<T> {
@@ -90,7 +90,7 @@ module {
     {
       var blocks = dataBlocks;
       var blockIndex = blockIndex;
-      var elementIndex = elementIndex
+      var elementIndex = elementIndex;
     }
   };
 
@@ -195,7 +195,7 @@ module {
   /// @deprecated M0235
   public func fromPure<T>(pure : PureList.List<T>) : List<T> {
     var p = pure;
-    var list = empty<T>();
+    let list = empty<T>();
     loop {
       switch (p) {
         case (?(x, xs)) {
@@ -319,7 +319,7 @@ module {
     if (elementIndex != 0) {
       let block = newBlocks[blockIndex];
       var i = elementIndex;
-      var to = block.size();
+      let to = block.size();
       while (i < to) {
         block[i] := null;
         i += 1

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -64,7 +64,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let pureMap = Map.toPure(map, Nat.compare);
   ///   assert pureMap.entries().toArray() == map.entries().toArray()
   /// }
@@ -92,7 +92,7 @@ module {
   ///
   /// persistent actor {
   ///   let pureMap = PureMap.fromIter(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
   ///   assert map.entries().toArray() == pureMap.entries().toArray()
   /// }
@@ -116,7 +116,7 @@ module {
   ///
   /// persistent actor {
   ///   let originalMap = Map.fromIter<Nat, Text>(
-  ///     [(1, "One"), (2, "Two"), (3, "Three")].vals(), Nat.compare);
+  ///     [(1, "One"), (2, "Two"), (3, "Three")].values(), Nat.compare);
   ///   let clonedMap = Map.clone(originalMap);
   ///   Map.add(originalMap, Nat.compare, 4, "Four");
   ///   assert Map.size(clonedMap) == 3;
@@ -193,7 +193,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.size(map) == 3;
@@ -220,7 +220,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
   ///   assert not Map.isEmpty(map);
@@ -244,7 +244,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.size(map) == 3;
@@ -270,7 +270,7 @@ module {
   ///
   /// persistent actor {
   ///   let map1 = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///   let map2 = Map.clone(map1);
   ///
@@ -317,7 +317,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.containsKey(map, Nat.compare, 1);
@@ -342,7 +342,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.get(map, Nat.compare, 1) == ?"One";
@@ -534,7 +534,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
   ///   Map.remove(map, Nat.compare, 1);
@@ -564,7 +564,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.delete(map, Nat.compare, 1); // present, returns true
@@ -599,7 +599,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
   ///   assert Map.take(map, Nat.compare, 0) == ?"Zero";
@@ -736,7 +736,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
@@ -769,7 +769,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].values(), Nat.compare);
   ///   assert (Map.entriesFrom(map, Nat.compare, 1)).toArray() == [(1, "One"), (3, "Three")];
   ///   assert (Map.entriesFrom(map, Nat.compare, 2)).toArray() == [(3, "Three")];
   /// }
@@ -801,7 +801,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
@@ -834,7 +834,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].values(), Nat.compare);
   ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 0)).toArray() == [(0, "Zero")];
   ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 2)).toArray() == [(1, "One"), (0, "Zero")];
   /// }
@@ -866,7 +866,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
@@ -897,7 +897,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
@@ -991,7 +991,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   var sum = 0;
   ///   var text = "";
   ///   Map.forEach<Nat, Text>(map, func (key, value) {
@@ -1025,7 +1025,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numberNames = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let numberNames = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
@@ -1060,7 +1060,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, _val : Text) : Nat = key * 2;
   ///
@@ -1092,7 +1092,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(accum : (Nat, Text), key : Nat, val : Text) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1127,7 +1127,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(key : Nat, val : Text, accum : (Nat, Text)) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1163,7 +1163,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.all<Nat, Text>(map, func (k, v) = v == Nat.toText(k));
   ///   assert not Map.all<Nat, Text>(map, func (k, v) = k < 2);
@@ -1193,7 +1193,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.any<Nat, Text>(map, func (k, v) = (k >= 0));
   ///   assert not Map.any<Nat, Text>(map, func (k, v) = (k >= 3));
@@ -1227,7 +1227,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, val : Text) : ?Text {
   ///     if(key == 0) {null}
@@ -1294,7 +1294,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   assert Map.toText<Nat, Text>(map, Nat.toText, func t { t }) == "Map{(0, Zero), (1, One), (2, Two)}";
   /// }
   /// ```
@@ -1341,8 +1341,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One")].vals(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two")].vals(), Nat.compare);
+  ///   let map1 = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One")].values(), Nat.compare);
+  ///   let map2 = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two")].values(), Nat.compare);
   ///
   ///   assert Map.compare(map1, map2, Nat.compare, Text.compare) == #less;
   ///   assert Map.compare(map1, map1, Nat.compare, Text.compare) == #equal;

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -66,7 +66,7 @@ module {
   ///   let map = Map.fromIter<Nat, Text>(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let pureMap = Map.toPure(map, Nat.compare);
-  ///   assert (PureMap.entries(pureMap)).toArray() == (Map.entries(map)).toArray()
+  ///   assert pureMap.entries().toArray() == map.entries().toArray()
   /// }
   /// ```
   ///
@@ -78,7 +78,7 @@ module {
   /// Note: Creates `O(n * log(n))` temporary objects that will be collected as garbage.
   /// @deprecated M0235
   public func toPure<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order)) : PureMap.Map<K, V> {
-    PureMap.fromIter(entries(self), compare)
+    PureMap.fromIter(self.entries(), compare)
   };
 
   /// Convert an immutable key-value map to a mutable key-value map.
@@ -94,7 +94,7 @@ module {
   ///   let pureMap = PureMap.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
-  ///   assert (Map.entries(map)).toArray() == (PureMap.entries(pureMap)).toArray()
+  ///   assert map.entries().toArray() == pureMap.entries().toArray()
   /// }
   /// ```
   ///
@@ -104,7 +104,7 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   /// @deprecated M0235
   public func fromPure<K, V>(map : PureMap.Map<K, V>, compare : (implicit : (K, K) -> Order.Order)) : Map<K, V> {
-    fromIter(PureMap.entries(map), compare)
+    fromIter(map.entries(), compare)
   };
 
   /// Create a copy of the mutable key-value map.
@@ -169,7 +169,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.singleton<Nat, Text>(0, "Zero");
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero")];
+  ///   assert map.entries().toArray() == [(0, "Zero")];
   /// }
   /// ```
   ///
@@ -286,7 +286,7 @@ module {
     if (size(self) != size(other)) {
       return false
     };
-    let iterator1 = entries(self);
+    let iterator1 = self.entries();
     let iterator2 = entries(other);
     loop {
       let next1 = iterator1.next();
@@ -377,9 +377,9 @@ module {
   ///   let map = Map.empty<Nat, Text>();
   ///   assert Map.insert(map, Nat.compare, 0, "Zero");
   ///   assert Map.insert(map, Nat.compare, 1, "One");
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One")];
   ///   assert not Map.insert(map, Nat.compare, 0, "Nil");
-  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")]
+  ///   assert map.entries().toArray() == [(0, "Nil"), (1, "One")]
   /// }
   /// ```
   ///
@@ -411,7 +411,7 @@ module {
   ///   Map.add(map, Nat.compare, 1, "One");
   ///   Map.add(map, Nat.compare, 0, "Nil");
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")]
+  ///   assert map.entries().toArray() == [(0, "Nil"), (1, "One")]
   /// }
   /// ```
   ///
@@ -437,10 +437,10 @@ module {
   ///   let map = Map.singleton<Nat, Text>(1, "One");
   ///
   ///   assert Map.swap(map, Nat.compare, 0, "Zero") == null;
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One")];
   ///
   ///   assert Map.swap(map, Nat.compare, 0, "Nil") == ?"Zero";
-  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")];
+  ///   assert map.entries().toArray() == [(0, "Nil"), (1, "One")];
   /// }
   /// ```
   ///
@@ -538,9 +538,9 @@ module {
   ///     Nat.compare);
   ///
   ///   Map.remove(map, Nat.compare, 1);
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (2, "Two")];
   ///   Map.remove(map, Nat.compare, 42);
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -568,10 +568,10 @@ module {
   ///     Nat.compare);
   ///
   ///   assert Map.delete(map, Nat.compare, 1); // present, returns true
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (2, "Two")];
   ///
   ///   assert not Map.delete(map, Nat.compare, 42); // absent, returns false
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -603,10 +603,10 @@ module {
   ///     Nat.compare);
   ///
   ///   assert Map.take(map, Nat.compare, 0) == ?"Zero";
-  ///   assert (Map.entries(map)).toArray() == [(1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(1, "One"), (2, "Two")];
   ///
   ///   assert Map.take(map, Nat.compare, 3) == null;
-  ///   assert (Map.entries(map)).toArray() == [(1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -663,11 +663,11 @@ module {
   };
 
   public func toArray<K, V>(self : Map<K, V>) : [(K, V)] {
-    (entries(self)).toArray()
+    self.entries().toArray()
   };
 
   public func toVarArray<K, V>(self : Map<K, V>) : [var (K, V)] {
-    Iter.toVarArray(entries(self))
+    Iter.toVarArray(self.entries())
   };
 
   /// Retrieves the key-value pair from the map with the maximum key.
@@ -723,7 +723,7 @@ module {
   /// Space: `O(1)`.
   /// where `n` denotes the number of key-value entries stored in the map.
   public func minEntry<K, V>(self : Map<K, V>) : ?(K, V) {
-    entries(self).next()
+    self.entries().next()
   };
 
   /// Returns an iterator over the key-value pairs in the map,
@@ -738,10 +738,10 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
   ///   var text = "";
-  ///   for ((k, v) in Map.entries(map)) { sum += k; text #= v };
+  ///   for ((k, v) in map.entries()) { sum += k; text #= v };
   ///   assert sum == 3;
   ///   assert text == "ZeroOneTwo"
   /// }
@@ -803,10 +803,10 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.reverseEntries(map)).toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
+  ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
   ///   var text = "";
-  ///   for ((k, v) in Map.reverseEntries(map)) { sum += k; text #= v };
+  ///   for ((k, v) in map.reverseEntries()) { sum += k; text #= v };
   ///   assert sum == 3;
   ///   assert text == "TwoOneZero"
   /// }
@@ -868,7 +868,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.keys(map)).toArray() == [0, 1, 2];
+  ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -876,7 +876,7 @@ module {
   /// Space: `O(1)`.
   public func keys<K, V>(self : Map<K, V>) : Types.Iter<K> {
     object {
-      let iterator = entries(self);
+      let iterator = self.entries();
 
       public func next() : ?K {
         switch (iterator.next()) {
@@ -899,7 +899,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.values(map)).toArray() == ["Zero", "One", "Two"];
+  ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -907,7 +907,7 @@ module {
   /// Space: `O(1)`.
   public func values<K, V>(self : Map<K, V>) : Types.Iter<V> {
     object {
-      let iterator = entries(self);
+      let iterator = self.entries();
 
       public func next() : ?V {
         switch (iterator.next()) {
@@ -932,7 +932,7 @@ module {
   ///
   ///   let map = Map.fromIter<Nat, Text>(iter, Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -962,7 +962,7 @@ module {
   ///
   ///   let map = iter.toMap(Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -1009,7 +1009,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func forEach<K, V>(self : Map<K, V>, operation : (K, V) -> ()) {
-    for (entry in entries(self)) {
+    for (entry in self.entries()) {
       operation(entry)
     }
   };
@@ -1031,7 +1031,7 @@ module {
   ///     key % 2 == 0
   ///   });
   ///
-  ///   assert (Map.entries(evenNames)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert evenNames.entries().toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -1041,7 +1041,7 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   public func filter<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order), criterion : (K, V) -> Bool) : Map<K, V> {
     let result = empty<K, V>();
-    for ((key, value) in entries(self)) {
+    for ((key, value) in self.entries()) {
       if (criterion(key, value)) {
         add(result, compare, key, value)
       }
@@ -1066,7 +1066,7 @@ module {
   ///
   ///   let resMap = Map.map<Nat, Text, Nat>(map, f);
   ///
-  ///   assert (Map.entries(resMap)).toArray() == [(0, 0), (1, 2), (2, 4)];
+  ///   assert resMap.entries().toArray() == [(0, 0), (1, 2), (2, 4)];
   /// }
   /// ```
   ///
@@ -1112,7 +1112,7 @@ module {
     combine : (A, K, V) -> A
   ) : A {
     var accumulator = base;
-    for ((key, value) in entries(self)) {
+    for ((key, value) in self.entries()) {
       accumulator := combine(accumulator, key, value)
     };
     accumulator
@@ -1177,7 +1177,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func all<K, V>(self : Map<K, V>, predicate : (K, V) -> Bool) : Bool {
     //TODO: optimize
-    for (entry in entries(self)) {
+    for (entry in self.entries()) {
       if (not predicate(entry)) {
         return false
       }
@@ -1207,7 +1207,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func any<K, V>(self : Map<K, V>, predicate : (K, V) -> Bool) : Bool {
     //TODO: optimize
-    for (entry in entries(self)) {
+    for (entry in self.entries()) {
       if (predicate(entry)) {
         return true
       }
@@ -1236,7 +1236,7 @@ module {
   ///
   ///   let newMap = Map.filterMap<Nat, Text, Text>(map, Nat.compare, f);
   ///
-  ///   assert (Map.entries(newMap)).toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
+  ///   assert newMap.entries().toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
   /// }
   /// ```
   ///
@@ -1247,7 +1247,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func filterMap<K, V1, V2>(self : Map<K, V1>, compare : (implicit : (K, K) -> Order.Order), project : (K, V1) -> ?V2) : Map<K, V2> {
     let result = empty<K, V2>();
-    for ((key, value1) in entries(self)) {
+    for ((key, value1) in self.entries()) {
       switch (project(key, value1)) {
         case null {};
         case (?value2) add(result, compare, key, value2)
@@ -1280,7 +1280,7 @@ module {
         }
       }
     };
-    checkIteration(entries(self), #less);
+    checkIteration(self.entries(), #less);
     checkIteration(reverseEntries(self), #greater)
   };
 
@@ -1308,7 +1308,7 @@ module {
   public func toText<K, V>(self : Map<K, V>, keyFormat : (implicit : (toText : K -> Text)), valueFormat : (implicit : (toText : V -> Text))) : Text {
     var text = "Map{";
     var sep = "";
-    for ((key, value) in entries(self)) {
+    for ((key, value) in self.entries()) {
       text #= sep # "(" # keyFormat(key) # ", " # valueFormat(value) # ")";
       sep := ", "
     };
@@ -1357,7 +1357,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<K, V>(self : Map<K, V>, other : Map<K, V>, compareKey : (implicit : (compare : (K, K) -> Order.Order)), compareValue : (implicit : (compare : (V, V) -> Order.Order))) : Order.Order {
-    let iterator1 = entries(self);
+    let iterator1 = self.entries();
     let iterator2 = entries(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -64,7 +64,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
   ///   let pureMap = Map.toPure(map, Nat.compare);
   ///   assert pureMap.entries().toArray() == map.entries().toArray()
   /// }
@@ -92,7 +92,7 @@ module {
   ///
   /// persistent actor {
   ///   let pureMap = PureMap.fromIter(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
   ///   let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
   ///   assert map.entries().toArray() == pureMap.entries().toArray()
   /// }
@@ -116,7 +116,7 @@ module {
   ///
   /// persistent actor {
   ///   let originalMap = Map.fromIter<Nat, Text>(
-  ///     [(1, "One"), (2, "Two"), (3, "Three")].values(), Nat.compare);
+  ///     [(1, "One"), (2, "Two"), (3, "Three")].vals(), Nat.compare);
   ///   let clonedMap = Map.clone(originalMap);
   ///   Map.add(originalMap, Nat.compare, 4, "Four");
   ///   assert Map.size(clonedMap) == 3;
@@ -193,7 +193,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.size(map) == 3;
@@ -220,7 +220,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///
   ///   assert not Map.isEmpty(map);
@@ -244,7 +244,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.size(map) == 3;
@@ -270,7 +270,7 @@ module {
   ///
   /// persistent actor {
   ///   let map1 = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///   let map2 = Map.clone(map1);
   ///
@@ -287,7 +287,7 @@ module {
       return false
     };
     let iterator1 = self.entries();
-    let iterator2 = entries(other);
+    let iterator2 = other.entries();
     loop {
       let next1 = iterator1.next();
       let next2 = iterator2.next();
@@ -317,7 +317,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.containsKey(map, Nat.compare, 1);
@@ -342,7 +342,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
+  ///     [(0, "Zero"), (1, "One"), (2, "Two")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.get(map, Nat.compare, 1) == ?"One";
@@ -534,7 +534,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
   ///     Nat.compare);
   ///
   ///   Map.remove(map, Nat.compare, 1);
@@ -564,7 +564,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.delete(map, Nat.compare, 1); // present, returns true
@@ -599,7 +599,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>(
-  ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
+  ///     [(0, "Zero"), (2, "Two"), (1, "One")].vals(),
   ///     Nat.compare);
   ///
   ///   assert Map.take(map, Nat.compare, 0) == ?"Zero";
@@ -736,7 +736,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
@@ -769,7 +769,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].vals(), Nat.compare);
   ///   assert (Map.entriesFrom(map, Nat.compare, 1)).toArray() == [(1, "One"), (3, "Three")];
   ///   assert (Map.entriesFrom(map, Nat.compare, 2)).toArray() == [(3, "Three")];
   /// }
@@ -801,7 +801,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
@@ -834,7 +834,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].vals(), Nat.compare);
   ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 0)).toArray() == [(0, "Zero")];
   ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 2)).toArray() == [(1, "One"), (0, "Zero")];
   /// }
@@ -866,7 +866,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
@@ -897,7 +897,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
@@ -991,7 +991,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///   var sum = 0;
   ///   var text = "";
   ///   Map.forEach<Nat, Text>(map, func (key, value) {
@@ -1025,7 +1025,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numberNames = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let numberNames = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
@@ -1060,7 +1060,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func f(key : Nat, _val : Text) : Nat = key * 2;
   ///
@@ -1092,7 +1092,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func folder(accum : (Nat, Text), key : Nat, val : Text) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1127,7 +1127,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func folder(key : Nat, val : Text, accum : (Nat, Text)) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1163,7 +1163,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
   ///
   ///   assert Map.all<Nat, Text>(map, func (k, v) = v == Nat.toText(k));
   ///   assert not Map.all<Nat, Text>(map, func (k, v) = k < 2);
@@ -1193,7 +1193,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
   ///
   ///   assert Map.any<Nat, Text>(map, func (k, v) = (k >= 0));
   ///   assert not Map.any<Nat, Text>(map, func (k, v) = (k >= 3));
@@ -1227,7 +1227,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func f(key : Nat, val : Text) : ?Text {
   ///     if(key == 0) {null}
@@ -1294,7 +1294,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///   assert Map.toText<Nat, Text>(map, Nat.toText, func t { t }) == "Map{(0, Zero), (1, One), (2, Two)}";
   /// }
   /// ```
@@ -1341,8 +1341,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One")].values(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two")].values(), Nat.compare);
+  ///   let map1 = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One")].vals(), Nat.compare);
+  ///   let map2 = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two")].vals(), Nat.compare);
   ///
   ///   assert Map.compare(map1, map2, Nat.compare, Text.compare) == #less;
   ///   assert Map.compare(map1, map1, Nat.compare, Text.compare) == #equal;
@@ -1358,7 +1358,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<K, V>(self : Map<K, V>, other : Map<K, V>, compareKey : (implicit : (compare : (K, K) -> Order.Order)), compareValue : (implicit : (compare : (V, V) -> Order.Order))) : Order.Order {
     let iterator1 = self.entries();
-    let iterator2 = entries(other);
+    let iterator2 = other.entries();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -66,7 +66,7 @@ module {
   ///   let map = Map.fromIter<Nat, Text>(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let pureMap = Map.toPure(map, Nat.compare);
-  ///   assert Iter.toArray(PureMap.entries(pureMap)) == Iter.toArray(Map.entries(map))
+  ///   assert (PureMap.entries(pureMap)).toArray() == (Map.entries(map)).toArray()
   /// }
   /// ```
   ///
@@ -94,7 +94,7 @@ module {
   ///   let pureMap = PureMap.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
-  ///   assert Iter.toArray(Map.entries(map)) == Iter.toArray(PureMap.entries(pureMap))
+  ///   assert (Map.entries(map)).toArray() == (PureMap.entries(pureMap)).toArray()
   /// }
   /// ```
   ///
@@ -169,7 +169,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.singleton<Nat, Text>(0, "Zero");
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero")];
   /// }
   /// ```
   ///
@@ -377,9 +377,9 @@ module {
   ///   let map = Map.empty<Nat, Text>();
   ///   assert Map.insert(map, Nat.compare, 0, "Zero");
   ///   assert Map.insert(map, Nat.compare, 1, "One");
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One")];
   ///   assert not Map.insert(map, Nat.compare, 0, "Nil");
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Nil"), (1, "One")]
+  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")]
   /// }
   /// ```
   ///
@@ -411,7 +411,7 @@ module {
   ///   Map.add(map, Nat.compare, 1, "One");
   ///   Map.add(map, Nat.compare, 0, "Nil");
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Nil"), (1, "One")]
+  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")]
   /// }
   /// ```
   ///
@@ -437,10 +437,10 @@ module {
   ///   let map = Map.singleton<Nat, Text>(1, "One");
   ///
   ///   assert Map.swap(map, Nat.compare, 0, "Zero") == null;
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One")];
   ///
   ///   assert Map.swap(map, Nat.compare, 0, "Nil") == ?"Zero";
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Nil"), (1, "One")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")];
   /// }
   /// ```
   ///
@@ -538,9 +538,9 @@ module {
   ///     Nat.compare);
   ///
   ///   Map.remove(map, Nat.compare, 1);
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
   ///   Map.remove(map, Nat.compare, 42);
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -568,10 +568,10 @@ module {
   ///     Nat.compare);
   ///
   ///   assert Map.delete(map, Nat.compare, 1); // present, returns true
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
   ///
   ///   assert not Map.delete(map, Nat.compare, 42); // absent, returns false
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -603,10 +603,10 @@ module {
   ///     Nat.compare);
   ///
   ///   assert Map.take(map, Nat.compare, 0) == ?"Zero";
-  ///   assert Iter.toArray(Map.entries(map)) == [(1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(1, "One"), (2, "Two")];
   ///
   ///   assert Map.take(map, Nat.compare, 3) == null;
-  ///   assert Iter.toArray(Map.entries(map)) == [(1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -663,7 +663,7 @@ module {
   };
 
   public func toArray<K, V>(self : Map<K, V>) : [(K, V)] {
-    Iter.toArray(entries(self))
+    (entries(self)).toArray()
   };
 
   public func toVarArray<K, V>(self : Map<K, V>) : [var (K, V)] {
@@ -738,7 +738,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
   ///   var text = "";
   ///   for ((k, v) in Map.entries(map)) { sum += k; text #= v };
@@ -770,8 +770,8 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].values(), Nat.compare);
-  ///   assert Iter.toArray(Map.entriesFrom(map, Nat.compare, 1)) == [(1, "One"), (3, "Three")];
-  ///   assert Iter.toArray(Map.entriesFrom(map, Nat.compare, 2)) == [(3, "Three")];
+  ///   assert (Map.entriesFrom(map, Nat.compare, 1)).toArray() == [(1, "One"), (3, "Three")];
+  ///   assert (Map.entriesFrom(map, Nat.compare, 2)).toArray() == [(3, "Three")];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -803,7 +803,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.reverseEntries(map)) == [(2, "Two"), (1, "One"), (0, "Zero")];
+  ///   assert (Map.reverseEntries(map)).toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
   ///   var text = "";
   ///   for ((k, v) in Map.reverseEntries(map)) { sum += k; text #= v };
@@ -835,8 +835,8 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].values(), Nat.compare);
-  ///   assert Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, 0)) == [(0, "Zero")];
-  ///   assert Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, 2)) == [(1, "One"), (0, "Zero")];
+  ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 0)).toArray() == [(0, "Zero")];
+  ///   assert (Map.reverseEntriesFrom(map, Nat.compare, 2)).toArray() == [(1, "One"), (0, "Zero")];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -868,7 +868,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.keys(map)) == [0, 1, 2];
+  ///   assert (Map.keys(map)).toArray() == [0, 1, 2];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -899,7 +899,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.values(map)) == ["Zero", "One", "Two"];
+  ///   assert (Map.values(map)).toArray() == ["Zero", "One", "Two"];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -932,7 +932,7 @@ module {
   ///
   ///   let map = Map.fromIter<Nat, Text>(iter, Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -962,7 +962,7 @@ module {
   ///
   ///   let map = iter.toMap(Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -1031,7 +1031,7 @@ module {
   ///     key % 2 == 0
   ///   });
   ///
-  ///   assert Iter.toArray(Map.entries(evenNames)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(evenNames)).toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -1066,7 +1066,7 @@ module {
   ///
   ///   let resMap = Map.map<Nat, Text, Nat>(map, f);
   ///
-  ///   assert Iter.toArray(Map.entries(resMap)) == [(0, 0), (1, 2), (2, 4)];
+  ///   assert (Map.entries(resMap)).toArray() == [(0, 0), (1, 2), (2, 4)];
   /// }
   /// ```
   ///
@@ -1236,7 +1236,7 @@ module {
   ///
   ///   let newMap = Map.filterMap<Nat, Text, Text>(map, Nat.compare, f);
   ///
-  ///   assert Iter.toArray(Map.entries(newMap)) == [(1, "Twenty One"), (2, "Twenty Two")];
+  ///   assert (Map.entries(newMap)).toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
   /// }
   /// ```
   ///

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -1202,8 +1202,8 @@ module {
       }
     };
 
-    public func writeArray(arr : [Nat8]) : () = writeIter(arr.vals());
-    public func writeBlob(blob : Blob) : () = writeIter(blob.vals());
+    public func writeArray(arr : [Nat8]) : () = writeIter(arr.values());
+    public func writeBlob(blob : Blob) : () = writeIter(blob.values());
 
     public func sum() : Blob {
       // calculate padding

--- a/src/PriorityQueue.mo
+++ b/src/PriorityQueue.mo
@@ -232,7 +232,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
   /// assert PriorityQueue.size(pq) == 3;
   /// assert PriorityQueue.peek(pq) == ?10;
   /// ```
@@ -255,7 +255,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let original = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
+  /// let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
   /// let copy = PriorityQueue.clone(original);
   /// assert PriorityQueue.pop(copy, Nat.compare) == ?10;
   /// assert PriorityQueue.size(original) == 3;
@@ -281,7 +281,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// import Iter "mo:core/Iter";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
   /// assert (PriorityQueue.values(pq, Nat.compare)).toArray() == [10, 5, 3];
   /// ```
   ///

--- a/src/PriorityQueue.mo
+++ b/src/PriorityQueue.mo
@@ -232,7 +232,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
   /// assert PriorityQueue.size(pq) == 3;
   /// assert PriorityQueue.peek(pq) == ?10;
   /// ```
@@ -255,7 +255,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let original = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
   /// let copy = PriorityQueue.clone(original);
   /// assert PriorityQueue.pop(copy, Nat.compare) == ?10;
   /// assert PriorityQueue.size(original) == 3;
@@ -281,7 +281,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// import Iter "mo:core/Iter";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].vals(), Nat.compare);
   /// assert (PriorityQueue.values(pq, Nat.compare)).toArray() == [10, 5, 3];
   /// ```
   ///

--- a/src/PriorityQueue.mo
+++ b/src/PriorityQueue.mo
@@ -282,7 +282,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-  /// assert Iter.toArray(PriorityQueue.values(pq, Nat.compare)) == [10, 5, 3];
+  /// assert (PriorityQueue.values(pq, Nat.compare)).toArray() == [10, 5, 3];
   /// ```
   ///
   /// Runtime: `O(n)` to create the iterator, `O(log n)` per `next()` call.

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -48,7 +48,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   let pureQueue = Queue.toPure<Nat>(queue);
   /// }
   /// ```
@@ -77,7 +77,7 @@ module {
   /// import PureQueue "mo:core/pure/Queue";
   ///
   /// persistent actor {
-  ///   let pureQueue = PureQueue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let pureQueue = PureQueue.fromIter<Nat>([1, 2, 3].values());
   ///   let queue = Queue.fromPure<Nat>(pureQueue);
   /// }
   /// ```
@@ -142,7 +142,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   Queue.clear(queue);
   ///   assert Queue.isEmpty(queue);
   /// }
@@ -163,7 +163,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let original = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let original = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   let copy = Queue.clone(original);
   ///   Queue.clear(original);
   ///   assert Queue.size(original) == 0;
@@ -189,7 +189,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -226,7 +226,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.contains(queue, Nat.equal, 2);
   /// }
   /// ```
@@ -251,7 +251,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.peekFront(queue) == ?1;
   /// }
   /// ```
@@ -273,7 +273,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.peekBack(queue) == ?3;
   /// }
   /// ```
@@ -361,7 +361,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.popFront(queue) == ?1;
   ///   assert Queue.size(queue) == 2;
   /// }
@@ -392,7 +392,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.popBack(queue) == ?3;
   ///   assert Queue.size(queue) == 2;
   /// }
@@ -422,7 +422,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -445,7 +445,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   transient let iter = ["A", "B", "C"].vals();
+  ///   transient let iter = ["A", "B", "C"].values();
   ///
   ///   let queue = iter.toQueue<Text>();
   ///
@@ -479,7 +479,7 @@ module {
   /// `n` denotes the number of elements stored in the array.
   public func fromArray<T>(array : [T]) : Queue<T> {
     let queue = empty<T>();
-    for (element in array.vals()) {
+    for (element in array.values()) {
       pushBack(queue, element)
     };
     queue
@@ -531,7 +531,7 @@ module {
   /// ```motoko
   /// import Queue "mo:core/Queue";
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
   ///   transient let iter = queue.values();
   ///   assert iter.next() == ?"A";
   ///   assert iter.next() == ?"B";
@@ -569,7 +569,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
+  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].values());
   ///   assert Queue.all<Nat>(queue, func(x) { x % 2 == 0 });
   /// }
   /// ```
@@ -592,7 +592,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.any<Nat>(queue, func (x) { x > 2 });
   /// }
   /// ```
@@ -617,7 +617,7 @@ module {
   ///
   /// persistent actor {
   ///   var sum = 0;
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   Queue.forEach<Nat>(queue, func(x) { sum += x });
   ///   assert sum == 6;
   /// }
@@ -639,7 +639,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   let doubled = Queue.map<Nat, Nat>(queue, func(x) { x * 2 });
   ///   assert Queue.peekFront(doubled) == ?2;
   /// }
@@ -663,7 +663,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
   ///   let evens = Queue.filter<Nat>(queue, func(x) { x % 2 == 0 });
   ///   assert Queue.size(evens) == 2;
   /// }
@@ -690,7 +690,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
   ///   let evenDoubled = Queue.filterMap<Nat, Nat>(
   ///     queue,
   ///     func(x) {
@@ -723,8 +723,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   /// }
   /// ```
@@ -763,7 +763,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.toText(queue, Nat.toText) == "Queue[1, 2, 3]";
   /// }
   /// ```
@@ -791,8 +791,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2].vals());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2].values());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -59,7 +59,7 @@ module {
   /// @deprecated M0235
   public func toPure<T>(self : Queue<T>) : PureQueue.Queue<T> {
     let pureQueue = PureQueue.empty<T>();
-    let iter = values(self);
+    let iter = self.values();
     var current = pureQueue;
     loop {
       switch (iter.next()) {
@@ -88,7 +88,7 @@ module {
   /// @deprecated M0235
   public func fromPure<T>(pureQueue : PureQueue.Queue<T>) : Queue<T> {
     let queue = empty<T>();
-    let iter = PureQueue.values(pureQueue);
+    let iter = pureQueue.values();
     loop {
       switch (iter.next()) {
         case null { return queue };
@@ -176,7 +176,7 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func clone<T>(self : Queue<T>) : Queue<T> {
     let copy = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       pushBack(copy, element)
     };
     copy
@@ -235,7 +235,7 @@ module {
   /// Space: O(1)
   /// `n` denotes the number of elements stored in the queue.
   public func contains<T>(self : Queue<T>, equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (existing in values(self)) {
+    for (existing in self.values()) {
       if (equal(existing, element)) {
         return true
       }
@@ -508,7 +508,7 @@ module {
   /// Space: O(n)
   /// `n` denotes the number of elements stored in the queue.
   public func toArray<T>(self : Queue<T>) : [T] {
-    let iter = values(self);
+    let iter = self.values();
     Array.tabulate<T>(
       self.size,
       func(i) {
@@ -532,7 +532,7 @@ module {
   /// import Queue "mo:core/Queue";
   /// persistent actor {
   ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
-  ///   transient let iter = Queue.values(queue);
+  ///   transient let iter = queue.values();
   ///   assert iter.next() == ?"A";
   ///   assert iter.next() == ?"B";
   ///   assert iter.next() == ?"C";
@@ -559,7 +559,7 @@ module {
   };
 
   public func reverseValues<T>(self : Queue<T>) : Iter.Iter<T> {
-    Iter.reverse(values(self))
+    Iter.reverse(self.values())
   };
 
   /// Tests whether all elements in the queue satisfy the given predicate.
@@ -577,7 +577,7 @@ module {
   /// Runtime: O(n)
   /// Space: O(1)
   public func all<T>(self : Queue<T>, predicate : T -> Bool) : Bool {
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (not predicate(element)) {
         return false
       }
@@ -601,7 +601,7 @@ module {
   /// Space: O(1)
   /// `n` denotes the number of elements stored in the queue.
   public func any<T>(self : Queue<T>, predicate : T -> Bool) : Bool {
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (predicate(element)) {
         return true
       }
@@ -627,7 +627,7 @@ module {
   /// Space: O(1)
   /// `n` denotes the number of elements stored in the queue.
   public func forEach<T>(self : Queue<T>, operation : T -> ()) {
-    for (element in values(self)) {
+    for (element in self.values()) {
       operation(element)
     }
   };
@@ -650,7 +650,7 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func map<T, U>(self : Queue<T>, project : T -> U) : Queue<U> {
     let result = empty<U>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       pushBack(result, project(element))
     };
     result
@@ -674,7 +674,7 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func filter<T>(self : Queue<T>, criterion : T -> Bool) : Queue<T> {
     let result = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (criterion(element)) {
         pushBack(result, element)
       }
@@ -706,7 +706,7 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func filterMap<T, U>(self : Queue<T>, project : T -> ?U) : Queue<U> {
     let result = empty<U>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       switch (project(element)) {
         case null {};
         case (?newElement) pushBack(result, newElement)
@@ -736,7 +736,7 @@ module {
     if (size(self) != size(other)) {
       return false
     };
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       let element1 = iterator1.next();
@@ -774,7 +774,7 @@ module {
   public func toText<T>(self : Queue<T>, format : (implicit : (toText : T -> Text))) : Text {
     var text = "Queue[";
     var sep = "";
-    for (element in values(self)) {
+    for (element in self.values()) {
       text #= sep # format(element);
       sep := ", "
     };
@@ -801,7 +801,7 @@ module {
   /// Space: O(1)
   /// `n` denotes the number of elements stored in the queue.
   public func compare<T>(self : Queue<T>, other : Queue<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -48,7 +48,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   let pureQueue = Queue.toPure<Nat>(queue);
   /// }
   /// ```
@@ -77,7 +77,7 @@ module {
   /// import PureQueue "mo:core/pure/Queue";
   ///
   /// persistent actor {
-  ///   let pureQueue = PureQueue.fromIter<Nat>([1, 2, 3].values());
+  ///   let pureQueue = PureQueue.fromIter<Nat>([1, 2, 3].vals());
   ///   let queue = Queue.fromPure<Nat>(pureQueue);
   /// }
   /// ```
@@ -142,7 +142,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   Queue.clear(queue);
   ///   assert Queue.isEmpty(queue);
   /// }
@@ -163,7 +163,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let original = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let original = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   let copy = Queue.clone(original);
   ///   Queue.clear(original);
   ///   assert Queue.size(original) == 0;
@@ -189,7 +189,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -226,7 +226,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.contains(queue, Nat.equal, 2);
   /// }
   /// ```
@@ -251,7 +251,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.peekFront(queue) == ?1;
   /// }
   /// ```
@@ -273,7 +273,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.peekBack(queue) == ?3;
   /// }
   /// ```
@@ -361,7 +361,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.popFront(queue) == ?1;
   ///   assert Queue.size(queue) == 2;
   /// }
@@ -392,7 +392,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.popBack(queue) == ?3;
   ///   assert Queue.size(queue) == 2;
   /// }
@@ -422,7 +422,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -445,7 +445,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   transient let iter = ["A", "B", "C"].values();
+  ///   transient let iter = ["A", "B", "C"].vals();
   ///
   ///   let queue = iter.toQueue<Text>();
   ///
@@ -531,7 +531,7 @@ module {
   /// ```motoko
   /// import Queue "mo:core/Queue";
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].vals());
   ///   transient let iter = queue.values();
   ///   assert iter.next() == ?"A";
   ///   assert iter.next() == ?"B";
@@ -569,7 +569,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].values());
+  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
   ///   assert Queue.all<Nat>(queue, func(x) { x % 2 == 0 });
   /// }
   /// ```
@@ -592,7 +592,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.any<Nat>(queue, func (x) { x > 2 });
   /// }
   /// ```
@@ -617,7 +617,7 @@ module {
   ///
   /// persistent actor {
   ///   var sum = 0;
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   Queue.forEach<Nat>(queue, func(x) { sum += x });
   ///   assert sum == 6;
   /// }
@@ -639,7 +639,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   let doubled = Queue.map<Nat, Nat>(queue, func(x) { x * 2 });
   ///   assert Queue.peekFront(doubled) == ?2;
   /// }
@@ -663,7 +663,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
   ///   let evens = Queue.filter<Nat>(queue, func(x) { x % 2 == 0 });
   ///   assert Queue.size(evens) == 2;
   /// }
@@ -690,7 +690,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
   ///   let evenDoubled = Queue.filterMap<Nat, Nat>(
   ///     queue,
   ///     func(x) {
@@ -723,8 +723,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   /// }
   /// ```
@@ -737,7 +737,7 @@ module {
       return false
     };
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       let element1 = iterator1.next();
       let element2 = iterator2.next();
@@ -763,7 +763,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.toText(queue, Nat.toText) == "Queue[1, 2, 3]";
   /// }
   /// ```
@@ -791,8 +791,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2].vals());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -802,7 +802,7 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func compare<T>(self : Queue<T>, other : Queue<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -73,7 +73,7 @@ module {
   /// Note: Creates `O(n * log(n))` temporary objects that will be collected as garbage.
   /// @deprecated M0235
   public func toPure<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : PureSet.Set<T> {
-    PureSet.fromIter(values(self), compare)
+    PureSet.fromIter(self.values(), compare)
   };
 
   /// Convert an immutable, purely functional set to a mutable set.
@@ -279,7 +279,7 @@ module {
   public func equal<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Types.Order)) : Bool {
     if (self.size != other.size) return false;
     // TODO: optimize
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       let next1 = iterator1.next();
@@ -565,11 +565,11 @@ module {
   /// Space: `O(1)`.
   /// where `n` denotes the number of elements stored in the set.
   public func min<T>(self : Set<T>) : ?T {
-    values(self).next()
+    self.values().next()
   };
 
   public func toArray<T>(self : Set<T>) : [T] {
-    (values(self)).toArray()
+    self.values().toArray()
   };
 
   /// Returns an iterator over the elements in the set,
@@ -777,7 +777,7 @@ module {
   public func isSubset<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Bool {
     if (self.size > other.size) { return false };
     // TODO: optimize
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (not contains(other, compare, element)) {
         return false
       }
@@ -841,7 +841,7 @@ module {
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func intersection<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (contains(other, compare, element)) {
         add(result, compare, element)
       }
@@ -872,7 +872,7 @@ module {
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func difference<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (not contains(other, compare, element)) {
         add(result, compare, element)
       }
@@ -986,7 +986,7 @@ module {
   /// }
   /// ```
   public func retainAll<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), predicate : T -> Bool) : Bool {
-    let array = Array.fromIter<T>(values(self));
+    let array = Array.fromIter<T>(self.values());
     deleteAll(
       self,
       compare,
@@ -1019,7 +1019,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func forEach<T>(self : Set<T>, operation : T -> ()) {
-    for (element in values(self)) {
+    for (element in self.values()) {
       operation(element)
     }
   };
@@ -1050,7 +1050,7 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   public func filter<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), criterion : T -> Bool) : Set<T> {
     let result = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (criterion(element)) {
         add(result, compare, element)
       }
@@ -1086,7 +1086,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func map<T1, T2>(self : Set<T1>, compare : (implicit : (T2, T2) -> Order.Order), project : T1 -> T2) : Set<T2> {
     let result = empty<T2>();
-    for (element1 in values(self)) {
+    for (element1 in self.values()) {
       let element2 = project(element1);
       add(result, compare, element2)
     };
@@ -1126,7 +1126,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func filterMap<T1, T2>(self : Set<T1>, compare : (implicit : (T2, T2) -> Order.Order), project : T1 -> ?T2) : Set<T2> {
     let result = empty<T2>();
-    for (element1 in values(self)) {
+    for (element1 in self.values()) {
       switch (project(element1)) {
         case null {};
         case (?element2) add(result, compare, element2)
@@ -1168,7 +1168,7 @@ module {
     combine : (A, T) -> A
   ) : A {
     var accumulator = base;
-    for (element in values(self)) {
+    for (element in self.values()) {
       accumulator := combine(accumulator, element)
     };
     accumulator
@@ -1283,7 +1283,7 @@ module {
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func flatten<T>(self : Set<Set<T>>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = empty<T>();
-    for (subSet in values(self)) {
+    for (subSet in self.values()) {
       for (element in values(subSet)) {
         add(result, compare, element)
       }
@@ -1317,7 +1317,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func all<T>(self : Set<T>, predicate : T -> Bool) : Bool {
     // TODO optimize, avoiding iterator
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (not predicate(element)) {
         return false
       }
@@ -1351,7 +1351,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func any<T>(self : Set<T>, predicate : T -> Bool) : Bool {
     // TODO optimize, avoiding iterator
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (predicate(element)) {
         return true
       }
@@ -1383,7 +1383,7 @@ module {
         }
       }
     };
-    checkIteration(values(self), #less);
+    checkIteration(self.values(), #less);
     checkIteration(reverseValues(self), #greater)
   };
 
@@ -1412,7 +1412,7 @@ module {
   public func toText<T>(self : Set<T>, toText : (implicit : T -> Text)) : Text {
     var text = "Set{";
     var sep = "";
-    for (element in values(self)) {
+    for (element in self.values()) {
       text #= sep # toText(element);
       sep := ", "
     };
@@ -1456,7 +1456,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -61,7 +61,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
-  ///   assert pureSet.values().toArray() == set.values().toArray();
+  ///   assert pureSet.toArray() == set.toArray();
   /// }
   /// ```
   ///
@@ -88,7 +88,7 @@ module {
   /// persistent actor {
   ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
-  ///   assert set.values().toArray() == pureSet.values().toArray();
+  ///   assert set.toArray() == pureSet.toArray();
   /// }
   /// ```
   ///
@@ -343,7 +343,7 @@ module {
   ///   Set.add(set, Nat.compare, 2);
   ///   Set.add(set, Nat.compare, 1);
   ///   Set.add(set, Nat.compare, 2);
-  ///   assert set.values().toArray() == [1, 2];
+  ///   assert set.toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -369,7 +369,7 @@ module {
   ///   assert Set.insert(set, Nat.compare, 2);
   ///   assert Set.insert(set, Nat.compare, 1);
   ///   assert not Set.insert(set, Nat.compare, 2);
-  ///   assert set.values().toArray() == [1, 2];
+  ///   assert set.toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -432,7 +432,7 @@ module {
   ///   Set.remove(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
   ///
-  ///   assert set.values().toArray() == [1, 3];
+  ///   assert set.toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///
   ///   assert not Set.delete(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
-  ///   assert set.values().toArray() == [1, 3];
+  ///   assert set.toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -710,7 +710,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert set.values().toArray() == [1, 2, 3];
+  ///   assert set.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -741,7 +741,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert set.values().toArray() == [1, 2, 3];
+  ///   assert set.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -800,7 +800,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert union.values().toArray() == [1, 2, 3, 4, 5];
+  ///   assert union.toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -831,7 +831,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert intersection.values().toArray() == [1, 2];
+  ///   assert intersection.toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -862,7 +862,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert difference.values().toArray() == [1, 2];
+  ///   assert difference.toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -892,7 +892,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
-  ///   assert set.values().toArray() == [1, 2, 3, 4, 5];
+  ///   assert set.toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -919,7 +919,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
-  ///   assert set.values().toArray() == [1];
+  ///   assert set.toArray() == [1];
   /// }
   /// ```
   ///
@@ -949,7 +949,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
-  ///   assert set.values().toArray() == [0, 1, 2, 3];
+  ///   assert set.toArray() == [0, 1, 2, 3];
   ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
   /// }
   /// ```
@@ -981,7 +981,7 @@ module {
   ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
-  ///   assert set.values().toArray() == [2];
+  ///   assert set.toArray() == [2];
   ///   assert sizeChanged;
   /// }
   /// ```
@@ -1040,7 +1040,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert evenNumbers.values().toArray() == [0, 2];
+  ///   assert evenNumbers.toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -1074,7 +1074,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert textNumbers.values().toArray() == ["1", "2", "3"];
+  ///   assert textNumbers.toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -1115,7 +1115,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert evenTextNumbers.values().toArray() == ["0", "2"];
+  ///   assert evenTextNumbers.toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -1231,7 +1231,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert combined.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert combined.toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1273,7 +1273,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert flatSet.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert flatSet.toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -61,7 +61,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
-  ///   assert (PureSet.values(pureSet)).toArray() == (Set.values(set)).toArray();
+  ///   assert (pureSet.values()).toArray() == (set.values()).toArray();
   /// }
   /// ```
   ///
@@ -88,7 +88,7 @@ module {
   /// persistent actor {
   ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
-  ///   assert (Set.values(set)).toArray() == (PureSet.values(pureSet)).toArray();
+  ///   assert (set.values()).toArray() == (pureSet.values()).toArray();
   /// }
   /// ```
   ///
@@ -98,7 +98,7 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   /// @deprecated M0235
   public func fromPure<T>(set : PureSet.Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
-    fromIter(PureSet.values(set), compare)
+    fromIter(set.values(), compare)
   };
 
   public func fromArray<T>(array : [T], compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
@@ -343,7 +343,7 @@ module {
   ///   Set.add(set, Nat.compare, 2);
   ///   Set.add(set, Nat.compare, 1);
   ///   Set.add(set, Nat.compare, 2);
-  ///   assert (Set.values(set)).toArray() == [1, 2];
+  ///   assert (set.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -369,7 +369,7 @@ module {
   ///   assert Set.insert(set, Nat.compare, 2);
   ///   assert Set.insert(set, Nat.compare, 1);
   ///   assert not Set.insert(set, Nat.compare, 2);
-  ///   assert (Set.values(set)).toArray() == [1, 2];
+  ///   assert (set.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -432,7 +432,7 @@ module {
   ///   Set.remove(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
   ///
-  ///   assert (Set.values(set)).toArray() == [1, 3];
+  ///   assert (set.values()).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///
   ///   assert not Set.delete(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
-  ///   assert (Set.values(set)).toArray() == [1, 3];
+  ///   assert (set.values()).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -584,7 +584,7 @@ module {
   ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
-  ///   for (number in Set.values(set)) {
+  ///   for (number in set.values()) {
   ///      tmp #= " " # Nat.toText(number);
   ///   };
   ///   assert tmp == " 0 1 2 3";
@@ -647,7 +647,7 @@ module {
   ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
-  ///   for (number in Set.reverseValues(set)) {
+  ///   for (number in set.reverseValues()) {
   ///      tmp #= " " # Nat.toText(number);
   ///   };
   ///   assert tmp == " 3 2 1 0";
@@ -710,7 +710,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
+  ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -741,7 +741,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
+  ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -800,7 +800,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert (Set.values(union)).toArray() == [1, 2, 3, 4, 5];
+  ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -831,7 +831,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert (Set.values(intersection)).toArray() == [1, 2];
+  ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -862,7 +862,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert (Set.values(difference)).toArray() == [1, 2];
+  ///   assert (difference.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -892,7 +892,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
-  ///   assert (Set.values(set)).toArray() == [1, 2, 3, 4, 5];
+  ///   assert (set.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -919,7 +919,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
-  ///   assert (Set.values(set)).toArray() == [1];
+  ///   assert (set.values()).toArray() == [1];
   /// }
   /// ```
   ///
@@ -949,7 +949,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
-  ///   assert (Set.values(set)).toArray() == [0, 1, 2, 3];
+  ///   assert (set.values()).toArray() == [0, 1, 2, 3];
   ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
   /// }
   /// ```
@@ -981,7 +981,7 @@ module {
   ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
-  ///   assert (Set.values(set)).toArray() == [2];
+  ///   assert (set.values()).toArray() == [2];
   ///   assert sizeChanged;
   /// }
   /// ```
@@ -1040,7 +1040,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert (Set.values(evenNumbers)).toArray() == [0, 2];
+  ///   assert (evenNumbers.values()).toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -1074,7 +1074,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert (Set.values(textNumbers)).toArray() == ["1", "2", "3"];
+  ///   assert (textNumbers.values()).toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -1115,7 +1115,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert (Set.values(evenTextNumbers)).toArray() == ["0", "2"];
+  ///   assert (evenTextNumbers.values()).toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -1231,7 +1231,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert (Set.values(combined)).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1273,7 +1273,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (Set.values(flatSet)).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (flat.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -8,7 +8,7 @@
 /// import Nat "mo:core/Nat";
 ///
 /// persistent actor {
-///   let set = Set.fromIter([3, 1, 2, 3].vals(), Nat.compare);
+///   let set = Set.fromIter([3, 1, 2, 3].values(), Nat.compare);
 ///   assert Set.size(set) == 3;
 ///   assert not Set.contains(set, Nat.compare, 4);
 ///   let diff = Set.difference(set, set, Nat.compare);
@@ -59,7 +59,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
   ///   assert (pureSet.values()).toArray() == (set.values()).toArray();
   /// }
@@ -86,7 +86,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let pureSet = PureSet.fromIter([3, 1, 2].vals(), Nat.compare);
+  ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
   ///   assert (set.values()).toArray() == (pureSet.values()).toArray();
   /// }
@@ -113,7 +113,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let originalSet = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let originalSet = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let clonedSet = Set.clone(originalSet);
   ///   Set.add(originalSet, Nat.compare, 4);
   ///   assert Set.size(clonedSet) == 3;
@@ -266,9 +266,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([2, 1, 0].values(), Nat.compare);
   ///   assert Set.equal(set1, set2, Nat.compare);
   ///   assert not Set.equal(set1, set3, Nat.compare);
   /// }
@@ -424,7 +424,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///
   ///   Set.remove(set, Nat.compare, 2);
   ///   assert not Set.contains(set, Nat.compare, 2);
@@ -455,7 +455,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///
   ///   assert Set.delete(set, Nat.compare, 2);
   ///   assert not Set.contains(set, Nat.compare, 2);
@@ -581,7 +581,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.values()) {
@@ -613,7 +613,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1].values(), Nat.compare);
   ///   assert (Set.valuesFrom(set, Nat.compare, 1)).toArray() == [1, 3];
   ///   assert (Set.valuesFrom(set, Nat.compare, 2)).toArray() == [3];
   /// }
@@ -644,7 +644,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.reverseValues()) {
@@ -676,7 +676,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 1, 3].values(), Nat.compare);
   ///   assert (Set.reverseValuesFrom(set, Nat.compare, 0)).toArray() == [0];
   ///   assert (Set.reverseValuesFrom(set, Nat.compare, 2)).toArray() == [1, 0];
   /// }
@@ -709,7 +709,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
   ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -737,7 +737,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 1, 2, 1].vals();
+  ///   transient let iter = [3, 1, 2, 1].values();
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
@@ -762,9 +762,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([3, 4].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1, 0].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([3, 4].values(), Nat.compare);
   ///   assert Set.isSubset(set1, set2, Nat.compare);
   ///   assert not Set.isSubset(set1, set3, Nat.compare);
   /// }
@@ -797,8 +797,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
   ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
@@ -828,8 +828,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
   ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
@@ -859,8 +859,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
   ///   assert (difference.values()).toArray() == [1, 2];
   /// }
@@ -890,8 +890,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   Set.addAll(set, Nat.compare, [3, 4, 5].vals());
+  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
   ///   assert (set.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
@@ -917,8 +917,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 2].vals(), Nat.compare);
-  ///   assert Set.deleteAll(set, Nat.compare, [0, 2].vals());
+  ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
+  ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
   ///   assert (set.values()).toArray() == [1];
   /// }
   /// ```
@@ -947,10 +947,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 2].vals(), Nat.compare);
-  ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].vals());
+  ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
+  ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
   ///   assert (set.values()).toArray() == [0, 1, 2, 3];
-  ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].vals()); // no change
+  ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
   /// }
   /// ```
   ///
@@ -978,7 +978,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
   ///   assert (set.values()).toArray() == [2];
@@ -990,7 +990,7 @@ module {
     deleteAll(
       self,
       compare,
-      Iter.filter<T>(array.vals(), func(element : T) : Bool = not predicate(element))
+      Iter.filter<T>(array.values(), func(element : T) : Bool = not predicate(element))
     )
   };
 
@@ -1003,7 +1003,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   Set.forEach<Nat>(numbers, func (element) {
@@ -1035,7 +1035,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
@@ -1070,7 +1070,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
@@ -1106,7 +1106,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 0, 2, 1].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
   ///
   ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
@@ -1144,7 +1144,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
   ///   let text = Set.foldLeft<Nat, Text>(
   ///      set,
@@ -1183,7 +1183,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
   ///   let text = Set.foldRight<Nat, Text>(
   ///      set,
@@ -1227,10 +1227,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
-  ///   let combined = Set.join([set1, set2, set3].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
+  ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
   ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
@@ -1268,10 +1268,10 @@ module {
   ///      Set.compare(first, second, Nat.compare)
   ///   };
   ///
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
-  ///   let setOfSets = Set.fromIter([set1, set2, set3].vals(), setCompare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
+  ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
   ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
@@ -1301,7 +1301,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let belowTen = Set.all<Nat>(set, func (number) {
   ///     number < 10
@@ -1335,7 +1335,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let aboveTen = Set.any<Nat>(set, func (number) {
   ///     number > 10
@@ -1397,7 +1397,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "Set{0, 1, 2, 3}"
   /// }
@@ -1440,8 +1440,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([0, 2].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([0, 2].values(), Nat.compare);
   ///
   ///   assert Set.compare(set1, set2, Nat.compare) == #less;
   ///   assert Set.compare(set1, set1, Nat.compare) == #equal;

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -59,7 +59,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 2, 1].vals(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
   ///   assert (pureSet.values()).toArray() == (set.values()).toArray();
   /// }
@@ -86,7 +86,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
+  ///   let pureSet = PureSet.fromIter([3, 1, 2].vals(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
   ///   assert (set.values()).toArray() == (pureSet.values()).toArray();
   /// }
@@ -113,7 +113,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let originalSet = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let originalSet = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///   let clonedSet = Set.clone(originalSet);
   ///   Set.add(originalSet, Nat.compare, 4);
   ///   assert Set.size(clonedSet) == 3;
@@ -266,9 +266,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([2, 1, 0].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
   ///   assert Set.equal(set1, set2, Nat.compare);
   ///   assert not Set.equal(set1, set3, Nat.compare);
   /// }
@@ -280,7 +280,7 @@ module {
     if (self.size != other.size) return false;
     // TODO: optimize
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       let next1 = iterator1.next();
       let next2 = iterator2.next();
@@ -424,7 +424,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///
   ///   Set.remove(set, Nat.compare, 2);
   ///   assert not Set.contains(set, Nat.compare, 2);
@@ -455,7 +455,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///
   ///   assert Set.delete(set, Nat.compare, 2);
   ///   assert not Set.contains(set, Nat.compare, 2);
@@ -581,7 +581,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.values()) {
@@ -613,7 +613,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1].vals(), Nat.compare);
   ///   assert (Set.valuesFrom(set, Nat.compare, 1)).toArray() == [1, 3];
   ///   assert (Set.valuesFrom(set, Nat.compare, 2)).toArray() == [3];
   /// }
@@ -644,7 +644,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.reverseValues()) {
@@ -676,7 +676,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 1, 3].vals(), Nat.compare);
   ///   assert (Set.reverseValuesFrom(set, Nat.compare, 0)).toArray() == [0];
   ///   assert (Set.reverseValuesFrom(set, Nat.compare, 2)).toArray() == [1, 0];
   /// }
@@ -709,7 +709,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].vals(), Nat.compare);
   ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -737,7 +737,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 1, 2, 1].values();
+  ///   transient let iter = [3, 1, 2, 1].vals();
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
@@ -762,9 +762,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1, 0].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([3, 4].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([3, 4].vals(), Nat.compare);
   ///   assert Set.isSubset(set1, set2, Nat.compare);
   ///   assert not Set.isSubset(set1, set3, Nat.compare);
   /// }
@@ -797,8 +797,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
   ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
@@ -810,7 +810,7 @@ module {
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func union<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = clone<T>(self);
-    for (element in values(other)) {
+    for (element in other.values()) {
       if (not contains(result, compare, element)) {
         add(result, compare, element)
       }
@@ -828,8 +828,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
   ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
@@ -859,8 +859,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
   ///   assert (difference.values()).toArray() == [1, 2];
   /// }
@@ -890,8 +890,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
+  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   Set.addAll(set, Nat.compare, [3, 4, 5].vals());
   ///   assert (set.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
@@ -917,8 +917,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
-  ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
+  ///   let set = Set.fromIter([0, 1, 2].vals(), Nat.compare);
+  ///   assert Set.deleteAll(set, Nat.compare, [0, 2].vals());
   ///   assert (set.values()).toArray() == [1];
   /// }
   /// ```
@@ -947,10 +947,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
-  ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
+  ///   let set = Set.fromIter([0, 1, 2].vals(), Nat.compare);
+  ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].vals());
   ///   assert (set.values()).toArray() == [0, 1, 2, 3];
-  ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
+  ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].vals()); // no change
   /// }
   /// ```
   ///
@@ -978,7 +978,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2].vals(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
   ///   assert (set.values()).toArray() == [2];
@@ -1003,7 +1003,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   Set.forEach<Nat>(numbers, func (element) {
@@ -1035,7 +1035,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
@@ -1070,7 +1070,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 1, 2].vals(), Nat.compare);
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
@@ -1106,7 +1106,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 0, 2, 1].vals(), Nat.compare);
   ///
   ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
@@ -1144,7 +1144,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
   ///
   ///   let text = Set.foldLeft<Nat, Text>(
   ///      set,
@@ -1183,7 +1183,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
   ///
   ///   let text = Set.foldRight<Nat, Text>(
   ///      set,
@@ -1227,10 +1227,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
-  ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
+  ///   let combined = Set.join([set1, set2, set3].vals(), Nat.compare);
   ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
@@ -1242,7 +1242,7 @@ module {
   public func join<T>(setIterator : Types.Iter<Set<T>>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = empty<T>();
     for (set in setIterator) {
-      for (element in values(set)) {
+      for (element in set.values()) {
         add(result, compare, element)
       }
     };
@@ -1268,12 +1268,12 @@ module {
   ///      Set.compare(first, second, Nat.compare)
   ///   };
   ///
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
-  ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
+  ///   let setOfSets = Set.fromIter([set1, set2, set3].vals(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (flat.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1284,7 +1284,7 @@ module {
   public func flatten<T>(self : Set<Set<T>>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     let result = empty<T>();
     for (subSet in self.values()) {
-      for (element in values(subSet)) {
+      for (element in subSet.values()) {
         add(result, compare, element)
       }
     };
@@ -1301,7 +1301,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let belowTen = Set.all<Nat>(set, func (number) {
   ///     number < 10
@@ -1335,7 +1335,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let aboveTen = Set.any<Nat>(set, func (number) {
   ///     number > 10
@@ -1397,7 +1397,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "Set{0, 1, 2, 3}"
   /// }
@@ -1440,8 +1440,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([0, 2].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([0, 2].vals(), Nat.compare);
   ///
   ///   assert Set.compare(set1, set2, Nat.compare) == #less;
   ///   assert Set.compare(set1, set1, Nat.compare) == #equal;
@@ -1457,7 +1457,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -61,7 +61,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
-  ///   assert Iter.toArray(PureSet.values(pureSet)) == Iter.toArray(Set.values(set));
+  ///   assert (PureSet.values(pureSet)).toArray() == (Set.values(set)).toArray();
   /// }
   /// ```
   ///
@@ -88,7 +88,7 @@ module {
   /// persistent actor {
   ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
-  ///   assert Iter.toArray(Set.values(set)) == Iter.toArray(PureSet.values(pureSet));
+  ///   assert (Set.values(set)).toArray() == (PureSet.values(pureSet)).toArray();
   /// }
   /// ```
   ///
@@ -343,7 +343,7 @@ module {
   ///   Set.add(set, Nat.compare, 2);
   ///   Set.add(set, Nat.compare, 1);
   ///   Set.add(set, Nat.compare, 2);
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2];
+  ///   assert (Set.values(set)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -369,7 +369,7 @@ module {
   ///   assert Set.insert(set, Nat.compare, 2);
   ///   assert Set.insert(set, Nat.compare, 1);
   ///   assert not Set.insert(set, Nat.compare, 2);
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2];
+  ///   assert (Set.values(set)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -432,7 +432,7 @@ module {
   ///   Set.remove(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
   ///
-  ///   assert Iter.toArray(Set.values(set)) == [1, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///
   ///   assert not Set.delete(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
-  ///   assert Iter.toArray(Set.values(set)) == [1, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -569,7 +569,7 @@ module {
   };
 
   public func toArray<T>(self : Set<T>) : [T] {
-    Iter.toArray(values(self))
+    (values(self)).toArray()
   };
 
   /// Returns an iterator over the elements in the set,
@@ -614,8 +614,8 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([0, 3, 1].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.valuesFrom(set, Nat.compare, 1)) == [1, 3];
-  ///   assert Iter.toArray(Set.valuesFrom(set, Nat.compare, 2)) == [3];
+  ///   assert (Set.valuesFrom(set, Nat.compare, 1)).toArray() == [1, 3];
+  ///   assert (Set.valuesFrom(set, Nat.compare, 2)).toArray() == [3];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -677,8 +677,8 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 3].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.reverseValuesFrom(set, Nat.compare, 0)) == [0];
-  ///   assert Iter.toArray(Set.reverseValuesFrom(set, Nat.compare, 2)) == [1, 0];
+  ///   assert (Set.reverseValuesFrom(set, Nat.compare, 0)).toArray() == [0];
+  ///   assert (Set.reverseValuesFrom(set, Nat.compare, 2)).toArray() == [1, 0];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -710,7 +710,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -741,7 +741,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -800,7 +800,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(union)) == [1, 2, 3, 4, 5];
+  ///   assert (Set.values(union)).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -831,7 +831,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(intersection)) == [1, 2];
+  ///   assert (Set.values(intersection)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -862,7 +862,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(difference)) == [1, 2];
+  ///   assert (Set.values(difference)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -892,7 +892,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3, 4, 5];
+  ///   assert (Set.values(set)).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -919,7 +919,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
-  ///   assert Iter.toArray(Set.values(set)) == [1];
+  ///   assert (Set.values(set)).toArray() == [1];
   /// }
   /// ```
   ///
@@ -949,7 +949,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
-  ///   assert Iter.toArray(Set.values(set)) == [0, 1, 2, 3];
+  ///   assert (Set.values(set)).toArray() == [0, 1, 2, 3];
   ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
   /// }
   /// ```
@@ -981,7 +981,7 @@ module {
   ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
-  ///   assert Iter.toArray(Set.values(set)) == [2];
+  ///   assert (Set.values(set)).toArray() == [2];
   ///   assert sizeChanged;
   /// }
   /// ```
@@ -1040,7 +1040,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert Iter.toArray(Set.values(evenNumbers)) == [0, 2];
+  ///   assert (Set.values(evenNumbers)).toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -1074,7 +1074,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert Iter.toArray(Set.values(textNumbers)) == ["1", "2", "3"];
+  ///   assert (Set.values(textNumbers)).toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -1115,7 +1115,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert Iter.toArray(Set.values(evenTextNumbers)) == ["0", "2"];
+  ///   assert (Set.values(evenTextNumbers)).toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -1231,7 +1231,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.values(combined)) == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (Set.values(combined)).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1273,7 +1273,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert Iter.toArray(Set.values(flatSet)) == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (Set.values(flatSet)).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -61,7 +61,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
-  ///   assert pureSet.toArray() == set.toArray();
+  ///   assert pureSet.values().toArray() == set.values().toArray();
   /// }
   /// ```
   ///
@@ -88,7 +88,7 @@ module {
   /// persistent actor {
   ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
-  ///   assert set.toArray() == pureSet.toArray();
+  ///   assert set.values().toArray() == pureSet.values().toArray();
   /// }
   /// ```
   ///

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -61,7 +61,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
-  ///   assert (pureSet.values()).toArray() == (set.values()).toArray();
+  ///   assert pureSet.values().toArray() == set.values().toArray();
   /// }
   /// ```
   ///
@@ -88,7 +88,7 @@ module {
   /// persistent actor {
   ///   let pureSet = PureSet.fromIter([3, 1, 2].values(), Nat.compare);
   ///   let set = Set.fromPure(pureSet, Nat.compare);
-  ///   assert (set.values()).toArray() == (pureSet.values()).toArray();
+  ///   assert set.values().toArray() == pureSet.values().toArray();
   /// }
   /// ```
   ///
@@ -343,7 +343,7 @@ module {
   ///   Set.add(set, Nat.compare, 2);
   ///   Set.add(set, Nat.compare, 1);
   ///   Set.add(set, Nat.compare, 2);
-  ///   assert (set.values()).toArray() == [1, 2];
+  ///   assert set.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -369,7 +369,7 @@ module {
   ///   assert Set.insert(set, Nat.compare, 2);
   ///   assert Set.insert(set, Nat.compare, 1);
   ///   assert not Set.insert(set, Nat.compare, 2);
-  ///   assert (set.values()).toArray() == [1, 2];
+  ///   assert set.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -432,7 +432,7 @@ module {
   ///   Set.remove(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
   ///
-  ///   assert (set.values()).toArray() == [1, 3];
+  ///   assert set.values().toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///
   ///   assert not Set.delete(set, Nat.compare, 4);
   ///   assert not Set.contains(set, Nat.compare, 4);
-  ///   assert (set.values()).toArray() == [1, 3];
+  ///   assert set.values().toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -710,7 +710,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert (set.values()).toArray() == [1, 2, 3];
+  ///   assert set.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -741,7 +741,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert (set.values()).toArray() == [1, 2, 3];
+  ///   assert set.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -800,7 +800,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
+  ///   assert union.values().toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -831,7 +831,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert (intersection.values()).toArray() == [1, 2];
+  ///   assert intersection.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -862,7 +862,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert (difference.values()).toArray() == [1, 2];
+  ///   assert difference.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -892,7 +892,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   Set.addAll(set, Nat.compare, [3, 4, 5].values());
-  ///   assert (set.values()).toArray() == [1, 2, 3, 4, 5];
+  ///   assert set.values().toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -919,7 +919,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.deleteAll(set, Nat.compare, [0, 2].values());
-  ///   assert (set.values()).toArray() == [1];
+  ///   assert set.values().toArray() == [1];
   /// }
   /// ```
   ///
@@ -949,7 +949,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   assert Set.insertAll(set, Nat.compare, [0, 2, 3].values());
-  ///   assert (set.values()).toArray() == [0, 1, 2, 3];
+  ///   assert set.values().toArray() == [0, 1, 2, 3];
   ///   assert not Set.insertAll(set, Nat.compare, [0, 1, 2].values()); // no change
   /// }
   /// ```
@@ -981,7 +981,7 @@ module {
   ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
-  ///   assert (set.values()).toArray() == [2];
+  ///   assert set.values().toArray() == [2];
   ///   assert sizeChanged;
   /// }
   /// ```
@@ -1040,7 +1040,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert (evenNumbers.values()).toArray() == [0, 2];
+  ///   assert evenNumbers.values().toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -1074,7 +1074,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert (textNumbers.values()).toArray() == ["1", "2", "3"];
+  ///   assert textNumbers.values().toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -1115,7 +1115,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert (evenTextNumbers.values()).toArray() == ["0", "2"];
+  ///   assert evenTextNumbers.values().toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -1231,7 +1231,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert combined.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1273,7 +1273,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert flatSet.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -65,11 +65,11 @@ module {
   };
 
   public func toArray<T>(self : Stack<T>) : [T] {
-    values(self).toArray()
+    self.values().toArray()
   };
 
   public func toVarArray<T>(self : Stack<T>) : [var T] {
-    Iter.toVarArray(values(self))
+    Iter.toVarArray(self.values())
   };
 
   /// Convert an immutable, purely functional list to a mutable stack.
@@ -84,7 +84,7 @@ module {
   /// persistent actor {
   ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
-  ///   assert (Stack.values(mutableStack)).toArray() == [1, 2, 3];
+  ///   assert (mutable.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -149,7 +149,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.tabulate<Nat>(3, func(i) { 2 * i });
-  ///   assert (Stack.values(stack)).toArray() == [4, 2, 0];
+  ///   assert (stack.values()).toArray() == [4, 2, 0];
   /// }
   /// ```
   ///
@@ -227,7 +227,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack.
   public func clone<T>(self : Stack<T>) : Stack<T> {
     let copy = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       push(copy, element)
     };
     reverse(copy);
@@ -289,7 +289,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack and assuming
   /// that `equal` has O(1) costs.
   public func contains<T>(self : Stack<T>, equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (existing in values(self)) {
+    for (existing in self.values()) {
       if (equal(existing, element)) {
         return true
       }
@@ -298,7 +298,7 @@ module {
   };
 
   public func reverseValues<T>(self : Stack<T>) : Iter.Iter<T> {
-    Iter.reverse(values(self))
+    Iter.reverse(self.values())
   };
 
   /// Pushes a new element onto the top of the stack.
@@ -443,7 +443,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack.
   public func reverse<T>(self : Stack<T>) {
     var last : List<T> = null;
-    for (element in values(self)) {
+    for (element in self.values()) {
       last := ?(element, last)
     };
     self.top := last
@@ -462,7 +462,7 @@ module {
   ///   Stack.push(stack, 3);
   ///   Stack.push(stack, 2);
   ///   Stack.push(stack, 1);
-  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
+  ///   assert (stack.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -502,7 +502,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack and
   /// assuming that `predicate` has O(1) costs.
   public func all<T>(self : Stack<T>, predicate : T -> Bool) : Bool {
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (not predicate(element)) {
         return false
       }
@@ -527,7 +527,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack and
   /// assuming `predicate` has O(1) costs.
   public func any<T>(self : Stack<T>, predicate : T -> Bool) : Bool {
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (predicate(element)) {
         return true
       }
@@ -559,7 +559,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack and
   /// assuming that `operation` has O(1) costs.
   public func forEach<T>(self : Stack<T>, operation : T -> ()) {
-    for (element in values(self)) {
+    for (element in self.values()) {
       operation(element)
     }
   };
@@ -591,7 +591,7 @@ module {
   /// assuming that `project` has O(1) costs.
   public func map<T, U>(self : Stack<T>, project : T -> U) : Stack<U> {
     let result = empty<U>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       push(result, project(element))
     };
     reverse(result);
@@ -624,7 +624,7 @@ module {
   /// assuming `predicate` has O(1) costs.
   public func filter<T>(self : Stack<T>, predicate : T -> Bool) : Stack<T> {
     let result = empty<T>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       if (predicate(element)) {
         push(result, element)
       }
@@ -666,7 +666,7 @@ module {
   /// assuming that `project` has O(1) costs.
   public func filterMap<T, U>(self : Stack<T>, project : T -> ?U) : Stack<U> {
     let result = empty<U>();
-    for (element in values(self)) {
+    for (element in self.values()) {
       switch (project(element)) {
         case null {};
         case (?newElement) {
@@ -742,7 +742,7 @@ module {
     if (size(self) != size(other)) {
       return false
     };
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       let element1 = iterator1.next();
@@ -772,7 +772,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
-  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
+  ///   assert (stack.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -801,7 +801,7 @@ module {
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
-  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
+  ///   assert (stack.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -833,7 +833,7 @@ module {
   public func toText<T>(self : Stack<T>, format : (implicit : (toText : T -> Text))) : Text {
     var text = "Stack[";
     var sep = "";
-    for (element in values(self)) {
+    for (element in self.values()) {
       text #= sep # format(element);
       sep := ", "
     };
@@ -860,7 +860,7 @@ module {
   /// where `n` denotes the number of elements stored on the stack and
   /// assuming that `compare` has O(1) costs.
   public func compare<T>(self : Stack<T>, other : Stack<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -84,7 +84,7 @@ module {
   /// persistent actor {
   ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
-  ///   assert mutable.toArray() == [1, 2, 3];
+  ///   assert mutableStack.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -82,7 +82,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
+  ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].vals());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
   ///   assert (mutable.values()).toArray() == [1, 2, 3];
   /// }
@@ -195,7 +195,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   Stack.clear(stack);
   ///   assert Stack.isEmpty(stack);
   /// }
@@ -216,7 +216,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let original = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let original = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   let copy = Stack.clone(original);
   ///   assert Stack.equal(copy, original, Nat.equal);
   /// }
@@ -259,7 +259,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.size(stack) == 3;
   /// }
   /// ```
@@ -279,7 +279,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.contains(stack, Nat.equal, 2);
   /// }
   /// ```
@@ -492,7 +492,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([2, 4, 6].values());
+  ///   let stack = Stack.fromIter<Nat>([2, 4, 6].vals());
   ///   assert Stack.all<Nat>(stack, func(n) = n % 2 == 0);
   /// }
   /// ```
@@ -517,7 +517,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.any<Nat>(stack, func(n) = n == 2);
   /// }
   /// ```
@@ -728,8 +728,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack1 = Stack.fromIter<Nat>([3, 2, 1].values());
-  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack1 = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.equal(stack1, stack2, Nat.equal);
   /// }
   /// ```
@@ -743,7 +743,7 @@ module {
       return false
     };
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       let element1 = iterator1.next();
       let element2 = iterator2.next();
@@ -771,7 +771,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert (stack.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -797,7 +797,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 2, 1].values();
+  ///   transient let iter = [3, 2, 1].vals();
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
@@ -821,7 +821,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.toText(stack, Nat.toText) == "Stack[1, 2, 3]";
   /// }
   /// ```
@@ -849,8 +849,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack1 = Stack.fromIter<Nat>([2, 1].values());
-  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack1 = Stack.fromIter<Nat>([2, 1].vals());
+  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].vals());
   ///   assert Stack.compare(stack1, stack2, Nat.compare) == #less;
   /// }
   /// ```
@@ -861,7 +861,7 @@ module {
   /// assuming that `compare` has O(1) costs.
   public func compare<T>(self : Stack<T>, other : Stack<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -84,7 +84,7 @@ module {
   /// persistent actor {
   ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
-  ///   assert mutable.values().toArray() == [1, 2, 3];
+  ///   assert mutable.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -149,7 +149,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.tabulate<Nat>(3, func(i) { 2 * i });
-  ///   assert stack.values().toArray() == [4, 2, 0];
+  ///   assert stack.toArray() == [4, 2, 0];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///   Stack.push(stack, 3);
   ///   Stack.push(stack, 2);
   ///   Stack.push(stack, 1);
-  ///   assert stack.values().toArray() == [1, 2, 3];
+  ///   assert stack.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -772,7 +772,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
-  ///   assert stack.values().toArray() == [1, 2, 3];
+  ///   assert stack.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -801,7 +801,7 @@ module {
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
-  ///   assert stack.values().toArray() == [1, 2, 3];
+  ///   assert stack.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -82,7 +82,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].vals());
+  ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
   ///   assert (mutable.values()).toArray() == [1, 2, 3];
   /// }
@@ -195,7 +195,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   Stack.clear(stack);
   ///   assert Stack.isEmpty(stack);
   /// }
@@ -216,7 +216,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let original = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let original = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   let copy = Stack.clone(original);
   ///   assert Stack.equal(copy, original, Nat.equal);
   /// }
@@ -259,7 +259,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.size(stack) == 3;
   /// }
   /// ```
@@ -279,7 +279,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.contains(stack, Nat.equal, 2);
   /// }
   /// ```
@@ -492,7 +492,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([2, 4, 6].vals());
+  ///   let stack = Stack.fromIter<Nat>([2, 4, 6].values());
   ///   assert Stack.all<Nat>(stack, func(n) = n % 2 == 0);
   /// }
   /// ```
@@ -517,7 +517,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.any<Nat>(stack, func(n) = n == 2);
   /// }
   /// ```
@@ -728,8 +728,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack1 = Stack.fromIter<Nat>([3, 2, 1].vals());
-  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack1 = Stack.fromIter<Nat>([3, 2, 1].values());
+  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.equal(stack1, stack2, Nat.equal);
   /// }
   /// ```
@@ -771,7 +771,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert (stack.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -797,7 +797,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 2, 1].vals();
+  ///   transient let iter = [3, 2, 1].values();
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
@@ -821,7 +821,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.toText(stack, Nat.toText) == "Stack[1, 2, 3]";
   /// }
   /// ```
@@ -849,8 +849,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let stack1 = Stack.fromIter<Nat>([2, 1].vals());
-  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].vals());
+  ///   let stack1 = Stack.fromIter<Nat>([2, 1].values());
+  ///   let stack2 = Stack.fromIter<Nat>([3, 2, 1].values());
   ///   assert Stack.compare(stack1, stack2, Nat.compare) == #less;
   /// }
   /// ```

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -52,7 +52,7 @@ module {
   ///   Stack.push(mutableStack, 2);
   ///   Stack.push(mutableStack, 1);
   ///   let immutableList = Stack.toPure(mutableStack);
-  ///   assert Iter.toArray(PureList.values(immutableList)) == [1, 2, 3];
+  ///   assert (PureList.values(immutableList)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -65,7 +65,7 @@ module {
   };
 
   public func toArray<T>(self : Stack<T>) : [T] {
-    Iter.toArray(values(self))
+    values(self).toArray()
   };
 
   public func toVarArray<T>(self : Stack<T>) : [var T] {
@@ -84,7 +84,7 @@ module {
   /// persistent actor {
   ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
-  ///   assert Iter.toArray(Stack.values(mutableStack)) == [1, 2, 3];
+  ///   assert (Stack.values(mutableStack)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -149,7 +149,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.tabulate<Nat>(3, func(i) { 2 * i });
-  ///   assert Iter.toArray(Stack.values(stack)) == [4, 2, 0];
+  ///   assert (Stack.values(stack)).toArray() == [4, 2, 0];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///   Stack.push(stack, 3);
   ///   Stack.push(stack, 2);
   ///   Stack.push(stack, 1);
-  ///   assert Iter.toArray(Stack.values(stack)) == [1, 2, 3];
+  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -772,7 +772,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
-  ///   assert Iter.toArray(Stack.values(stack)) == [1, 2, 3];
+  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -801,7 +801,7 @@ module {
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
-  ///   assert Iter.toArray(Stack.values(stack)) == [1, 2, 3];
+  ///   assert (Stack.values(stack)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -84,7 +84,7 @@ module {
   /// persistent actor {
   ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
-  ///   assert (mutable.values()).toArray() == [1, 2, 3];
+  ///   assert mutable.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -149,7 +149,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.tabulate<Nat>(3, func(i) { 2 * i });
-  ///   assert (stack.values()).toArray() == [4, 2, 0];
+  ///   assert stack.values().toArray() == [4, 2, 0];
   /// }
   /// ```
   ///
@@ -462,7 +462,7 @@ module {
   ///   Stack.push(stack, 3);
   ///   Stack.push(stack, 2);
   ///   Stack.push(stack, 1);
-  ///   assert (stack.values()).toArray() == [1, 2, 3];
+  ///   assert stack.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -772,7 +772,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.fromIter<Nat>([3, 2, 1].values());
-  ///   assert (stack.values()).toArray() == [1, 2, 3];
+  ///   assert stack.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -801,7 +801,7 @@ module {
   ///
   ///   let stack = iter.toStack<Nat>();
   ///
-  ///   assert (stack.values()).toArray() == [1, 2, 3];
+  ///   assert stack.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -120,7 +120,7 @@ module {
 
   /// Creates a new `Array` containing characters of the given `Text`.
   ///
-  /// Equivalent to `Iter.toArray(t.chars())`.
+  /// Equivalent to `(t.chars()).toArray()`.
   ///
   /// ```motoko include=import
   /// assert Text.toArray("Café") == ['C', 'a', 'f', 'é'];

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -65,7 +65,7 @@ module {
   ///
   /// Runtime: O(a.size())
   /// Space: O(a.size())
-  public func fromArray(a : [Char]) : Text = fromIter(a.vals());
+  public func fromArray(a : [Char]) : Text = fromIter(a.values());
 
   /// Converts the given `[var Char]` to a `Text` value.
   ///
@@ -76,7 +76,7 @@ module {
   ///
   /// Runtime: O(a.size())
   /// Space: O(a.size())
-  public func fromVarArray(a : [var Char]) : Text = fromIter(a.vals());
+  public func fromVarArray(a : [var Char]) : Text = fromIter(a.values());
 
   /// Iterates over each `Char` value in the given `Text`.
   ///
@@ -173,7 +173,7 @@ module {
   /// Creates a `Text` value from a `Char` iterator.
   ///
   /// ```motoko include=import
-  /// let text = Text.fromIter(['a', 'b', 'c'].vals());
+  /// let text = Text.fromIter(['a', 'b', 'c'].values());
   /// assert text == "abc";
   /// ```
   public func fromIter(cs : Iter.Iter<Char>) : Text {
@@ -330,7 +330,7 @@ module {
   /// Join an iterator of `Text` values with a given delimiter.
   ///
   /// ```motoko include=import
-  /// let joined = Text.join(["a", "b", "c"].vals(), ", ");
+  /// let joined = Text.join(["a", "b", "c"].values(), ", ");
   /// assert joined == "a, b, c";
   /// ```
   public func join(self : Iter.Iter<Text>, sep : Text) : Text {

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -173,7 +173,7 @@ module {
   /// Creates a `Text` value from a `Char` iterator.
   ///
   /// ```motoko include=import
-  /// let text = Text.fromIter(['a', 'b', 'c'].values());
+  /// let text = Text.fromIter(['a', 'b', 'c'].vals());
   /// assert text == "abc";
   /// ```
   public func fromIter(cs : Iter.Iter<Char>) : Text {
@@ -330,7 +330,7 @@ module {
   /// Join an iterator of `Text` values with a given delimiter.
   ///
   /// ```motoko include=import
-  /// let joined = Text.join(["a", "b", "c"].values(), ", ");
+  /// let joined = Text.join(["a", "b", "c"].vals(), ", ");
   /// assert joined == "a, b, c";
   /// ```
   public func join(self : Iter.Iter<Text>, sep : Text) : Text {

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -130,7 +130,7 @@ module {
   ///
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func find<T>(self : [var T], predicate : T -> Bool) : ?T {
-    for (element in self.vals()) {
+    for (element in self.values()) {
       if (predicate element) {
         return ?element
       }
@@ -417,7 +417,7 @@ module {
   ///
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func forEach<T>(self : [var T], f : T -> ()) {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       f(item)
     }
   };
@@ -671,7 +671,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let array = [var 1, 2, 3, 4];
-  /// let newArray = VarArray.flatMap<Nat, Int>(array, func x = [x, -x].vals());
+  /// let newArray = VarArray.flatMap<Nat, Int>(array, func x = [x, -x].values());
   /// assert VarArray.equal(newArray, [var 1, -1, 2, -2, 3, -3, 4, -4], Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -731,7 +731,7 @@ module {
   /// *Runtime and space assumes that `combine` runs in O(1) time and space.
   public func foldLeft<T, A>(self : [var T], base : A, combine : (A, T) -> A) : A {
     var acc = base;
-    for (element in self.vals()) {
+    for (element in self.values()) {
       acc := combine(acc, element)
     };
     acc
@@ -774,7 +774,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let arrays : [[var Nat]] = [[var 0, 1, 2], [var 2, 3], [var], [var 4]];
-  /// let joinedArray = VarArray.join<Nat>(arrays.vals());
+  /// let joinedArray = VarArray.join<Nat>(arrays.values());
   /// assert VarArray.equal(joinedArray, [var 0, 1, 2, 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -803,7 +803,7 @@ module {
   /// Space: O(number of elements in array)
   public func flatten<T>(self : [var [var T]]) : [var T] {
     var flatSize = 0;
-    for (subArray in self.vals()) {
+    for (subArray in self.values()) {
       flatSize += subArray.size()
     };
 
@@ -937,7 +937,7 @@ module {
   /// Runtime: O(1)
   ///
   /// Space: O(1)
-  public func values<T>(self : [var T]) : Types.Iter<T> = self.vals();
+  public func values<T>(self : [var T]) : Types.Iter<T> = self.values();
 
   /// Returns an iterator that provides pairs of (index, element) in order, or `null`
   /// when out of elements to iterate over.
@@ -1110,7 +1110,7 @@ module {
   ///
   /// Space: O(1)
   public func contains<T>(self : [var T], equal : (implicit : (T, T) -> Bool), element : T) : Bool {
-    for (item in self.vals()) {
+    for (item in self.values()) {
       if (equal(item, element)) {
         return true
       }

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -1035,7 +1035,7 @@ module {
   /// import List "mo:core/pure/List";
   ///
   /// persistent actor {
-  ///   let list = List.fromIter([0, 1, 2, 3, 4].vals());
+  ///   let list = List.fromIter([0, 1, 2, 3, 4].values());
   ///   assert list == ?(0, ?(1, ?(2, ?(3, ?(4, null)))));
   /// }
   /// ```
@@ -1057,7 +1057,7 @@ module {
   /// import List "mo:core/pure/List";
   ///
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].vals();
+  ///   transient let iter = [0, 1, 2, 3, 4].values();
   ///
   ///   let list = iter.toList();
   ///

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -113,7 +113,7 @@ module {
   /// import Map "mo:core/pure/Map";
   /// import Nat "mo:core/Nat";
   ///
-  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   /// assert Map.size(map) == 3;
   /// ```
@@ -130,7 +130,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Map.containsKey(map, Nat.compare, 1);
   ///   assert not Map.containsKey(map, Nat.compare, 42);
@@ -151,7 +151,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Map.get(map, Nat.compare, 1) == ?"One";
   ///   assert Map.get(map, Nat.compare, 42) == null;
@@ -246,7 +246,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map0 = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map0 = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   do {
   ///      let (map1, old1) = Map.swap(map0, Nat.compare, 0, "Nil");
@@ -321,7 +321,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let map1 = Map.remove(map0, Nat.compare, 1);
   ///   assert map1.entries().toArray() == [(0, "Zero"), (2, "Two")];
@@ -357,7 +357,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   do {
   ///     let (map1, pres1) = Map.delete(map0, Nat.compare, 1);
@@ -395,7 +395,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map0 =  Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map0 =  Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   do {
   ///     let (map1, prev1) = Map.take(map0, Nat.compare, 0);
@@ -432,7 +432,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Map.maxEntry(map) == ?(2, "Two");
   ///   assert Map.maxEntry(Map.empty<Nat, Text>()) == null;
@@ -452,7 +452,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Map.minEntry(map) == ?(0, "Zero");
   ///   assert Map.minEntry(Map.empty()) == null;
@@ -475,7 +475,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
@@ -504,7 +504,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
@@ -533,7 +533,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
@@ -557,7 +557,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
@@ -635,7 +635,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, _val : Text) : Nat = key * 2;
   ///
@@ -661,7 +661,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(accum : (Nat, Text), key : Nat, val : Text) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -692,7 +692,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(key : Nat, val : Text, accum : (Nat, Text)) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -721,7 +721,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.all<Nat, Text>(map, func (k, v) = v == Nat.toText(k));
   ///   assert not Map.all<Nat, Text>(map, func (k, v) = k < 2);
@@ -741,7 +741,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.any<Nat, Text>(map, func (k, v) = (k >= 0));
   ///   assert not Map.any<Nat, Text>(map, func (k, v) = (k >= 3));
@@ -784,7 +784,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   var sum = 0;
   ///   var text = "";
   ///   Map.forEach<Nat, Text>(map, func (key, value) {
@@ -812,7 +812,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
@@ -841,7 +841,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, val : Text) : ?Text {
   ///     if(key == 0) {null}
@@ -873,7 +873,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   assert Map.toText<Nat, Text>(map, Nat.toText, func t { t }) == "PureMap{(0, Zero), (1, One), (2, Two)}";
   /// }
   /// ```
@@ -903,8 +903,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(2, "Two"), (1, "One"), (0, "Zero")].vals(), Nat.compare);
+  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
+  ///   let map2 = Map.fromIter<Nat, Text>([(2, "Two"), (1, "One"), (0, "Zero")].values(), Nat.compare);
   ///   assert(Map.equal(map1, map2, Nat.compare, Text.equal));
   /// }
   /// ```
@@ -959,8 +959,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One")].vals(), Nat.compare);
-  ///   let map2 = Map.fromIter([(0, "Zero"), (2, "Two")].vals(), Nat.compare);
+  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One")].values(), Nat.compare);
+  ///   let map2 = Map.fromIter([(0, "Zero"), (2, "Two")].values(), Nat.compare);
   ///
   ///   assert Map.compare(map1, map2, Nat.compare, Text.compare) == #less;
   ///   assert Map.compare(map1, map1, Nat.compare, Text.compare) == #equal;

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -178,10 +178,10 @@ module {
   ///
   ///   do {
   ///     let (map1, new1) = Map.insert(map0, Nat.compare, 0, "Zero");
-  ///     assert (Map.entries(map1)).toArray() == [(0, "Zero")];
+  ///     assert map1.entries().toArray() == [(0, "Zero")];
   ///     assert new1;
   ///     let (map2, new2) = Map.insert(map1, Nat.compare, 0, "Nil");
-  ///     assert (Map.entries(map2)).toArray() == [(0, "Nil")];
+  ///     assert map2.entries().toArray() == [(0, "Nil")];
   ///     assert not new2
   ///   }
   /// }
@@ -219,7 +219,7 @@ module {
   ///   map := Map.add(map, Nat.compare, 1, "One");
   ///   map := Map.add(map, Nat.compare, 0, "Nil");
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")];
+  ///   assert map.entries().toArray() == [(0, "Nil"), (1, "One")];
   /// }
   /// ```
   ///
@@ -250,11 +250,11 @@ module {
   ///
   ///   do {
   ///      let (map1, old1) = Map.swap(map0, Nat.compare, 0, "Nil");
-  ///      assert (Map.entries(map1)).toArray() == [(0, "Nil"), (1, "One"), (2, "Two")];
+  ///      assert map1.entries().toArray() == [(0, "Nil"), (1, "One"), (2, "Two")];
   ///      assert old1 == ?"Zero";
   ///
   ///      let (map2, old2) = Map.swap(map0, Nat.compare, 3, "Three");
-  ///      assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two"), (3, "Three")];
+  ///      assert map2.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two"), (3, "Three")];
   ///      assert old2 == null;
   ///   }
   /// }
@@ -324,9 +324,9 @@ module {
   ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let map1 = Map.remove(map0, Nat.compare, 1);
-  ///   assert (Map.entries(map1)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert map1.entries().toArray() == [(0, "Zero"), (2, "Two")];
   ///   let map2 = Map.remove(map0, Nat.compare, 42);
-  ///   assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map2.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -361,11 +361,11 @@ module {
   ///
   ///   do {
   ///     let (map1, pres1) = Map.delete(map0, Nat.compare, 1);
-  ///     assert (Map.entries(map1)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///     assert map1.entries().toArray() == [(0, "Zero"), (2, "Two")];
   ///     assert pres1;
   ///     let (map2, pres2) = Map.delete(map0, Nat.compare, 42);
   ///     assert not pres2;
-  ///     assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///     assert map2.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   }
   /// }
   /// ```
@@ -399,11 +399,11 @@ module {
   ///
   ///   do {
   ///     let (map1, prev1) = Map.take(map0, Nat.compare, 0);
-  ///     assert (Map.entries(map1)).toArray() == [(1, "One"), (2, "Two")];
+  ///     assert map1.entries().toArray() == [(1, "One"), (2, "Two")];
   ///     assert prev1 == ?"Zero";
   ///
   ///     let (map2, prev2) = Map.take(map0, Nat.compare, 42);
-  ///     assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///     assert map2.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///     assert prev2 == null;
   ///   }
   /// }
@@ -477,10 +477,10 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
   ///   var text = "";
-  ///   for ((k, v) in Map.entries(map)) { sum += k; text #= v };
+  ///   for ((k, v) in map.entries()) { sum += k; text #= v };
   ///   assert sum == 3;
   ///   assert text == "ZeroOneTwo"
   /// }
@@ -506,10 +506,10 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.reverseEntries(map)).toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
+  ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
   ///   var text = "";
-  ///   for ((k, v) in Map.reverseEntries(map)) { sum += k; text #= v };
+  ///   for ((k, v) in map.reverseEntries()) { sum += k; text #= v };
   ///   assert sum == 3;
   ///   assert text == "TwoOneZero"
   /// }
@@ -535,7 +535,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.keys(map)).toArray() == [0, 1, 2];
+  ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -544,7 +544,7 @@ module {
   /// where `n` denotes the number of key-value entries stored in the map.
   ///
   /// Note: Full map iteration creates `O(n)` temporary objects that will be collected as garbage.
-  public func keys<K, V>(self : Map<K, V>) : Iter.Iter<K> = Iter.map(entries(self), func(kv : (K, V)) : K { kv.0 });
+  public func keys<K, V>(self : Map<K, V>) : Iter.Iter<K> = Iter.map(self.entries(), func(kv : (K, V)) : K { kv.0 });
 
   /// Given a `map`, returns an Iterator (`Iter`) over the values of the map.
   /// Iterator provides a single method `next()`, which returns
@@ -559,7 +559,7 @@ module {
   /// persistent actor {
   /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert (Map.values(map)).toArray() == ["Zero", "One", "Two"];
+  ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -568,7 +568,7 @@ module {
   /// where `n` denotes the number of key-value entries stored in the map.
   ///
   /// Note: Full map iteration creates `O(n)` temporary objects that will be collected as garbage.
-  public func values<K, V>(self : Map<K, V>) : Iter.Iter<V> = Iter.map(entries(self), func(kv : (K, V)) : V { kv.1 });
+  public func values<K, V>(self : Map<K, V>) : Iter.Iter<V> = Iter.map(self.entries(), func(kv : (K, V)) : V { kv.1 });
 
   /// Returns a new map, containing all entries given by the iterator `i`.
   /// If there are multiple entries with the same key the last one is taken.
@@ -585,7 +585,7 @@ module {
   ///
   ///   let map = Map.fromIter(iter, Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -612,7 +612,7 @@ module {
   ///
   ///   let map = iter.toMap(Nat.compare);
   ///
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -641,7 +641,7 @@ module {
   ///
   ///   let resMap = Map.map(map, f);
   ///
-  ///   assert (Map.entries(resMap)).toArray() == [(0, 0), (1, 2), (2, 4)];
+  ///   assert resMap.entries().toArray() == [(0, 0), (1, 2), (2, 4)];
   /// }
   /// ```
   ///
@@ -762,7 +762,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.singleton<Nat, Text>(0, "Zero");
-  ///   assert (Map.entries(map)).toArray() == [(0, "Zero")];
+  ///   assert map.entries().toArray() == [(0, "Zero")];
   /// }
   /// ```
   ///
@@ -818,7 +818,7 @@ module {
   ///     key % 2 == 0
   ///   });
   ///
-  ///   assert (Map.entries(evenNames)).toArray() == [(0, "Zero"), (2, "Two")];
+  ///   assert evenNames.entries().toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -850,7 +850,7 @@ module {
   ///
   ///   let newMap = Map.filterMap(map, Nat.compare, f);
   ///
-  ///   assert (Map.entries(newMap)).toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
+  ///   assert newMap.entries().toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
   /// }
   /// ```
   ///
@@ -886,7 +886,7 @@ module {
   public func toText<K, V>(self : Map<K, V>, keyFormat : (implicit : (toText : K -> Text)), valueFormat : (implicit : (toText : V -> Text))) : Text {
     var text = "PureMap{";
     var sep = "";
-    for ((k, v) in entries(self)) {
+    for ((k, v) in self.entries()) {
       text #= sep # "(" # keyFormat(k) # ", " # valueFormat(v) # ")";
       sep := ", "
     };
@@ -915,7 +915,7 @@ module {
     if (self.size != other.size) {
       return false
     };
-    let iterator1 = entries(self);
+    let iterator1 = self.entries();
     let iterator2 = entries(other);
     loop {
       let next1 = iterator1.next();
@@ -975,7 +975,7 @@ module {
   ///
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<K, V>(self : Map<K, V>, other : Map<K, V>, compareKey : (implicit : (compare : (K, K) -> Order.Order)), compareValue : (implicit : (compare : (V, V) -> Order.Order))) : Order.Order {
-    let iterator1 = entries(self);
+    let iterator1 = self.entries();
     let iterator2 = entries(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -113,7 +113,7 @@ module {
   /// import Map "mo:core/pure/Map";
   /// import Nat "mo:core/Nat";
   ///
-  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   /// assert Map.size(map) == 3;
   /// ```
@@ -130,7 +130,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert Map.containsKey(map, Nat.compare, 1);
   ///   assert not Map.containsKey(map, Nat.compare, 42);
@@ -151,7 +151,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert Map.get(map, Nat.compare, 1) == ?"One";
   ///   assert Map.get(map, Nat.compare, 42) == null;
@@ -246,7 +246,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map0 = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map0 = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   do {
   ///      let (map1, old1) = Map.swap(map0, Nat.compare, 0, "Nil");
@@ -321,7 +321,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   let map1 = Map.remove(map0, Nat.compare, 1);
   ///   assert map1.entries().toArray() == [(0, "Zero"), (2, "Two")];
@@ -357,7 +357,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   do {
   ///     let (map1, pres1) = Map.delete(map0, Nat.compare, 1);
@@ -395,7 +395,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map0 =  Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map0 =  Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   do {
   ///     let (map1, prev1) = Map.take(map0, Nat.compare, 0);
@@ -432,7 +432,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert Map.maxEntry(map) == ?(2, "Two");
   ///   assert Map.maxEntry(Map.empty<Nat, Text>()) == null;
@@ -452,7 +452,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert Map.minEntry(map) == ?(0, "Zero");
   ///   assert Map.minEntry(Map.empty()) == null;
@@ -475,7 +475,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.entries().toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
@@ -504,7 +504,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.reverseEntries().toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
@@ -533,7 +533,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.keys().toArray() == [0, 1, 2];
   /// }
@@ -557,7 +557,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   assert map.values().toArray() == ["Zero", "One", "Two"];
   /// }
@@ -635,7 +635,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func f(key : Nat, _val : Text) : Nat = key * 2;
   ///
@@ -661,7 +661,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func folder(accum : (Nat, Text), key : Nat, val : Text) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -692,7 +692,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func folder(key : Nat, val : Text, accum : (Nat, Text)) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -721,7 +721,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
   ///
   ///   assert Map.all<Nat, Text>(map, func (k, v) = v == Nat.toText(k));
   ///   assert not Map.all<Nat, Text>(map, func (k, v) = k < 2);
@@ -741,7 +741,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].vals(), Nat.compare);
   ///
   ///   assert Map.any<Nat, Text>(map, func (k, v) = (k >= 0));
   ///   assert not Map.any<Nat, Text>(map, func (k, v) = (k >= 3));
@@ -784,7 +784,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///   var sum = 0;
   ///   var text = "";
   ///   Map.forEach<Nat, Text>(map, func (key, value) {
@@ -812,7 +812,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
@@ -841,7 +841,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///
   ///   func f(key : Nat, val : Text) : ?Text {
   ///     if(key == 0) {null}
@@ -873,7 +873,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].vals(), Nat.compare);
   ///   assert Map.toText<Nat, Text>(map, Nat.toText, func t { t }) == "PureMap{(0, Zero), (1, One), (2, Two)}";
   /// }
   /// ```
@@ -903,8 +903,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(2, "Two"), (1, "One"), (0, "Zero")].values(), Nat.compare);
+  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One"), (2, "Two")].vals(), Nat.compare);
+  ///   let map2 = Map.fromIter<Nat, Text>([(2, "Two"), (1, "One"), (0, "Zero")].vals(), Nat.compare);
   ///   assert(Map.equal(map1, map2, Nat.compare, Text.equal));
   /// }
   /// ```
@@ -916,7 +916,7 @@ module {
       return false
     };
     let iterator1 = self.entries();
-    let iterator2 = entries(other);
+    let iterator2 = other.entries();
     loop {
       let next1 = iterator1.next();
       let next2 = iterator2.next();
@@ -959,8 +959,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One")].values(), Nat.compare);
-  ///   let map2 = Map.fromIter([(0, "Zero"), (2, "Two")].values(), Nat.compare);
+  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One")].vals(), Nat.compare);
+  ///   let map2 = Map.fromIter([(0, "Zero"), (2, "Two")].vals(), Nat.compare);
   ///
   ///   assert Map.compare(map1, map2, Nat.compare, Text.compare) == #less;
   ///   assert Map.compare(map1, map1, Nat.compare, Text.compare) == #equal;
@@ -976,7 +976,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<K, V>(self : Map<K, V>, other : Map<K, V>, compareKey : (implicit : (compare : (K, K) -> Order.Order)), compareValue : (implicit : (compare : (V, V) -> Order.Order))) : Order.Order {
     let iterator1 = self.entries();
-    let iterator2 = entries(other);
+    let iterator2 = other.entries();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -178,10 +178,10 @@ module {
   ///
   ///   do {
   ///     let (map1, new1) = Map.insert(map0, Nat.compare, 0, "Zero");
-  ///     assert Iter.toArray(Map.entries(map1)) == [(0, "Zero")];
+  ///     assert (Map.entries(map1)).toArray() == [(0, "Zero")];
   ///     assert new1;
   ///     let (map2, new2) = Map.insert(map1, Nat.compare, 0, "Nil");
-  ///     assert Iter.toArray(Map.entries(map2)) == [(0, "Nil")];
+  ///     assert (Map.entries(map2)).toArray() == [(0, "Nil")];
   ///     assert not new2
   ///   }
   /// }
@@ -219,7 +219,7 @@ module {
   ///   map := Map.add(map, Nat.compare, 1, "One");
   ///   map := Map.add(map, Nat.compare, 0, "Nil");
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Nil"), (1, "One")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Nil"), (1, "One")];
   /// }
   /// ```
   ///
@@ -250,11 +250,11 @@ module {
   ///
   ///   do {
   ///      let (map1, old1) = Map.swap(map0, Nat.compare, 0, "Nil");
-  ///      assert Iter.toArray(Map.entries(map1)) == [(0, "Nil"), (1, "One"), (2, "Two")];
+  ///      assert (Map.entries(map1)).toArray() == [(0, "Nil"), (1, "One"), (2, "Two")];
   ///      assert old1 == ?"Zero";
   ///
   ///      let (map2, old2) = Map.swap(map0, Nat.compare, 3, "Three");
-  ///      assert Iter.toArray(Map.entries(map2)) == [(0, "Zero"), (1, "One"), (2, "Two"), (3, "Three")];
+  ///      assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two"), (3, "Three")];
   ///      assert old2 == null;
   ///   }
   /// }
@@ -324,9 +324,9 @@ module {
   ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let map1 = Map.remove(map0, Nat.compare, 1);
-  ///   assert Iter.toArray(Map.entries(map1)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(map1)).toArray() == [(0, "Zero"), (2, "Two")];
   ///   let map2 = Map.remove(map0, Nat.compare, 42);
-  ///   assert Iter.toArray(Map.entries(map2)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -361,11 +361,11 @@ module {
   ///
   ///   do {
   ///     let (map1, pres1) = Map.delete(map0, Nat.compare, 1);
-  ///     assert Iter.toArray(Map.entries(map1)) == [(0, "Zero"), (2, "Two")];
+  ///     assert (Map.entries(map1)).toArray() == [(0, "Zero"), (2, "Two")];
   ///     assert pres1;
   ///     let (map2, pres2) = Map.delete(map0, Nat.compare, 42);
   ///     assert not pres2;
-  ///     assert Iter.toArray(Map.entries(map2)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///     assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   }
   /// }
   /// ```
@@ -399,11 +399,11 @@ module {
   ///
   ///   do {
   ///     let (map1, prev1) = Map.take(map0, Nat.compare, 0);
-  ///     assert Iter.toArray(Map.entries(map1)) == [(1, "One"), (2, "Two")];
+  ///     assert (Map.entries(map1)).toArray() == [(1, "One"), (2, "Two")];
   ///     assert prev1 == ?"Zero";
   ///
   ///     let (map2, prev2) = Map.take(map0, Nat.compare, 42);
-  ///     assert Iter.toArray(Map.entries(map2)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///     assert (Map.entries(map2)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///     assert prev2 == null;
   ///   }
   /// }
@@ -477,7 +477,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
   ///   var text = "";
   ///   for ((k, v) in Map.entries(map)) { sum += k; text #= v };
@@ -506,7 +506,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.reverseEntries(map)) == [(2, "Two"), (1, "One"), (0, "Zero")];
+  ///   assert (Map.reverseEntries(map)).toArray() == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
   ///   var text = "";
   ///   for ((k, v) in Map.reverseEntries(map)) { sum += k; text #= v };
@@ -535,7 +535,7 @@ module {
   /// persistent actor {
   ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.keys(map)) == [0, 1, 2];
+  ///   assert (Map.keys(map)).toArray() == [0, 1, 2];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -559,7 +559,7 @@ module {
   /// persistent actor {
   /// let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.values(map)) == ["Zero", "One", "Two"];
+  ///   assert (Map.values(map)).toArray() == ["Zero", "One", "Two"];
   /// }
   /// ```
   /// Cost of iteration over all elements:
@@ -585,7 +585,7 @@ module {
   ///
   ///   let map = Map.fromIter(iter, Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -612,7 +612,7 @@ module {
   ///
   ///   let map = iter.toMap(Nat.compare);
   ///
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -641,7 +641,7 @@ module {
   ///
   ///   let resMap = Map.map(map, f);
   ///
-  ///   assert Iter.toArray(Map.entries(resMap)) == [(0, 0), (1, 2), (2, 4)];
+  ///   assert (Map.entries(resMap)).toArray() == [(0, 0), (1, 2), (2, 4)];
   /// }
   /// ```
   ///
@@ -762,7 +762,7 @@ module {
   ///
   /// persistent actor {
   ///   let map = Map.singleton<Nat, Text>(0, "Zero");
-  ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero")];
+  ///   assert (Map.entries(map)).toArray() == [(0, "Zero")];
   /// }
   /// ```
   ///
@@ -818,7 +818,7 @@ module {
   ///     key % 2 == 0
   ///   });
   ///
-  ///   assert Iter.toArray(Map.entries(evenNames)) == [(0, "Zero"), (2, "Two")];
+  ///   assert (Map.entries(evenNames)).toArray() == [(0, "Zero"), (2, "Two")];
   /// }
   /// ```
   ///
@@ -850,7 +850,7 @@ module {
   ///
   ///   let newMap = Map.filterMap(map, Nat.compare, f);
   ///
-  ///   assert Iter.toArray(Map.entries(newMap)) == [(1, "Twenty One"), (2, "Twenty Two")];
+  ///   assert (Map.entries(newMap)).toArray() == [(1, "Twenty One"), (2, "Twenty Two")];
   /// }
   /// ```
   ///

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -392,7 +392,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   assert (queue.values()).toArray() == [1, 2, 3];
+  ///   assert queue.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -512,7 +512,7 @@ module {
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2].values());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
-  ///   assert (textQueue.values()).toArray() == ["0", "1", "2"];
+  ///   assert textQueue.values().toArray() == ["0", "1", "2"];
   /// }
   /// ```
   ///

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -392,7 +392,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   assert queue.values().toArray() == [1, 2, 3];
+  ///   assert queue.toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -512,7 +512,7 @@ module {
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2].values());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
-  ///   assert textQueue.values().toArray() == ["0", "1", "2"];
+  ///   assert textQueue.toArray() == ["0", "1", "2"];
   /// }
   /// ```
   ///

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -392,7 +392,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   assert Iter.toArray(Queue.values(queue)) == [1, 2, 3];
+  ///   assert (Queue.values(queue)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -512,7 +512,7 @@ module {
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2].values());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
-  ///   assert Iter.toArray(Queue.values(textQueue)) == ["0", "1", "2"];
+  ///   assert (Queue.values(textQueue)).toArray() == ["0", "1", "2"];
   /// }
   /// ```
   ///

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -116,7 +116,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   assert Queue.contains(queue, Nat.equal, 2);
   ///   assert not Queue.contains(queue, Nat.equal, 4);
   /// }
@@ -299,7 +299,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter([0, 1, 2, 3, 4].vals());
   ///   assert Queue.size(queue) == 5;
   /// }
   /// ```
@@ -316,7 +316,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].values();
+  ///   transient let iter = [0, 1, 2, 3, 4].vals();
   ///
   ///   let queue = iter.toQueue();
   ///   assert Queue.size(queue) == 5;
@@ -391,7 +391,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -408,9 +408,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter([1, 2].values());
-  ///   let queue2 = Queue.fromIter([1, 2].values());
-  ///   let queue3 = Queue.fromIter([1, 3].values());
+  ///   let queue1 = Queue.fromIter([1, 2].vals());
+  ///   let queue2 = Queue.fromIter([1, 2].vals());
+  ///   let queue3 = Queue.fromIter([1, 3].vals());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   ///   assert not Queue.equal(queue1, queue3, Nat.equal);
   /// }
@@ -441,7 +441,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   let allGreaterThanOne = Queue.all<Nat>(queue, func n = n > 1);
   ///   assert not allGreaterThanOne; // false because 1 is not > 1
   /// }
@@ -453,7 +453,7 @@ module {
   ///
   /// *Runtime and space assumes that the `predicate` runs in `O(1)` time and space.
   public func all<T>(self : Queue<T>, predicate : T -> Bool) : Bool {
-    for (item in values self) if (not (predicate item)) return false;
+    for (item in self.values()) if (not (predicate item)) return false;
     return true
   };
 
@@ -463,7 +463,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   let hasGreaterThanOne = Queue.any<Nat>(queue, func n = n > 1);
   ///   assert hasGreaterThanOne; // true because 2 and 3 are > 1
   /// }
@@ -475,7 +475,7 @@ module {
   ///
   /// *Runtime and space assumes that the `predicate` runs in `O(1)` time and space.
   public func any<T>(self : Queue<T>, predicate : T -> Bool) : Bool {
-    for (item in values self) if (predicate item) return true;
+    for (item in self.values()) if (predicate item) return true;
     return false
   };
 
@@ -486,7 +486,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   var text = "";
-  ///   let queue = Queue.fromIter(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter(["A", "B", "C"].vals());
   ///   Queue.forEach<Text>(queue, func n = text #= n);
   ///   assert text == "ABC";
   /// }
@@ -497,7 +497,7 @@ module {
   /// Space: `O(size)`
   ///
   /// *Runtime and space assumes that `f` runs in `O(1)` time and space.
-  public func forEach<T>(self : Queue<T>, f : T -> ()) = for (item in values self) f item;
+  public func forEach<T>(self : Queue<T>, f : T -> ()) = for (item in self.values()) f item;
 
   /// Call the given function `f` on each queue element and collect the results
   /// in a new queue.
@@ -510,9 +510,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2].values());
+  ///   let queue = Queue.fromIter([0, 1, 2].vals());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
-  ///   assert (text.values()).toArray() == ["0", "1", "2"];
+  ///   assert (textQueue.values()).toArray() == ["0", "1", "2"];
   /// }
   /// ```
   ///
@@ -534,7 +534,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2, 1].values());
+  ///   let queue = Queue.fromIter([0, 1, 2, 1].vals());
   ///   let filtered = Queue.filter<Nat>(queue, func n = n != 1);
   ///   assert Queue.size(filtered) == 2;
   /// }
@@ -560,7 +560,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   let doubled = Queue.filterMap<Nat, Nat>(
   ///     queue,
   ///     func n = if (n > 1) ?(n * 2) else null
@@ -589,7 +589,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   assert Queue.toText(queue, Nat.toText) == "PureQueue[1, 2, 3]";
   /// }
   /// ```
@@ -615,8 +615,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter([1, 2].values());
-  ///   let queue2 = Queue.fromIter([1, 3].values());
+  ///   let queue1 = Queue.fromIter([1, 2].vals());
+  ///   let queue2 = Queue.fromIter([1, 3].vals());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -627,7 +627,7 @@ module {
   ///
   /// *Runtime and space assumes that argument `compareItem` runs in `O(1)` time and space.
   public func compare<T>(self : Queue<T>, other : Queue<T>, compareItem : (implicit : (compare : (T, T) -> Order.Order))) : Order.Order {
-    let (i1, i2) = (values self, values other);
+    let (i1, i2) = (self.values(), other.values());
     loop switch (i1.next(), i2.next()) {
       case (?v1, ?v2) switch (compareItem(v1, v2)) {
         case (#equal) ();
@@ -645,7 +645,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].vals());
   ///   let reversed = Queue.reverse(queue);
   ///   assert Queue.peekFront(reversed) == ?3;
   ///   assert Queue.peekBack(reversed) == ?1;

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -368,7 +368,7 @@ module {
   ///
   /// Space: O(size)
   public func toArray<T>(self : Queue<T>) : [T] {
-    let iter = values(self);
+    let iter = self.values();
     Array.tabulate<T>(
       self.1,
       func(i) {
@@ -392,7 +392,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   assert (Queue.values(queue)).toArray() == [1, 2, 3];
+  ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -423,7 +423,7 @@ module {
     if (self.1 != other.1) {
       return false
     };
-    let (iter1, iter2) = (values(self), values(other));
+    let (iter1, iter2) = (self.values(), other.values());
     loop {
       switch (iter1.next(), iter2.next()) {
         case (null, null) { return true };
@@ -512,7 +512,7 @@ module {
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2].values());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
-  ///   assert (Queue.values(textQueue)).toArray() == ["0", "1", "2"];
+  ///   assert (text.values()).toArray() == ["0", "1", "2"];
   /// }
   /// ```
   ///

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -116,7 +116,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert Queue.contains(queue, Nat.equal, 2);
   ///   assert not Queue.contains(queue, Nat.equal, 4);
   /// }
@@ -299,7 +299,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter([0, 1, 2, 3, 4].values());
   ///   assert Queue.size(queue) == 5;
   /// }
   /// ```
@@ -316,7 +316,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].vals();
+  ///   transient let iter = [0, 1, 2, 3, 4].values();
   ///
   ///   let queue = iter.toQueue();
   ///   assert Queue.size(queue) == 5;
@@ -391,7 +391,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -408,9 +408,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter([1, 2].vals());
-  ///   let queue2 = Queue.fromIter([1, 2].vals());
-  ///   let queue3 = Queue.fromIter([1, 3].vals());
+  ///   let queue1 = Queue.fromIter([1, 2].values());
+  ///   let queue2 = Queue.fromIter([1, 2].values());
+  ///   let queue3 = Queue.fromIter([1, 3].values());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   ///   assert not Queue.equal(queue1, queue3, Nat.equal);
   /// }
@@ -441,7 +441,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   let allGreaterThanOne = Queue.all<Nat>(queue, func n = n > 1);
   ///   assert not allGreaterThanOne; // false because 1 is not > 1
   /// }
@@ -463,7 +463,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   let hasGreaterThanOne = Queue.any<Nat>(queue, func n = n > 1);
   ///   assert hasGreaterThanOne; // true because 2 and 3 are > 1
   /// }
@@ -486,7 +486,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   var text = "";
-  ///   let queue = Queue.fromIter(["A", "B", "C"].vals());
+  ///   let queue = Queue.fromIter(["A", "B", "C"].values());
   ///   Queue.forEach<Text>(queue, func n = text #= n);
   ///   assert text == "ABC";
   /// }
@@ -510,7 +510,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2].vals());
+  ///   let queue = Queue.fromIter([0, 1, 2].values());
   ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
   ///   assert (textQueue.values()).toArray() == ["0", "1", "2"];
   /// }
@@ -534,7 +534,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([0, 1, 2, 1].vals());
+  ///   let queue = Queue.fromIter([0, 1, 2, 1].values());
   ///   let filtered = Queue.filter<Nat>(queue, func n = n != 1);
   ///   assert Queue.size(filtered) == 2;
   /// }
@@ -560,7 +560,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   let doubled = Queue.filterMap<Nat, Nat>(
   ///     queue,
   ///     func n = if (n > 1) ?(n * 2) else null
@@ -589,7 +589,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert Queue.toText(queue, Nat.toText) == "PureQueue[1, 2, 3]";
   /// }
   /// ```
@@ -615,8 +615,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter([1, 2].vals());
-  ///   let queue2 = Queue.fromIter([1, 3].vals());
+  ///   let queue1 = Queue.fromIter([1, 2].values());
+  ///   let queue2 = Queue.fromIter([1, 3].values());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -645,7 +645,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   let reversed = Queue.reverse(queue);
   ///   assert Queue.peekFront(reversed) == ?3;
   ///   assert Queue.peekBack(reversed) == ?1;

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -576,7 +576,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   assert (Queue.values(queue)).toArray() == [1, 2, 3];
+  ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -576,7 +576,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   assert (queue.values()).toArray() == [1, 2, 3];
+  ///   assert queue.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -530,7 +530,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([0, 1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter<Nat>([0, 1, 2, 3, 4].values());
   ///   assert Queue.peekFront(queue) == ?0;
   ///   assert Queue.peekBack(queue) == ?4;
   ///   assert Queue.size(queue) == 5;
@@ -551,7 +551,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].vals();
+  ///   transient let iter = [0, 1, 2, 3, 4].values();
   ///
   ///   let queue = iter.toQueue();
   ///
@@ -575,7 +575,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -606,9 +606,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
-  ///   let queue3 = Queue.fromIter<Nat>([1, 3, 2].vals());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue3 = Queue.fromIter<Nat>([1, 3, 2].values());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   ///   assert not Queue.equal(queue1, queue3, Nat.equal);
   /// }
@@ -637,8 +637,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 4].vals());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 4].values());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -663,7 +663,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
+  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].values());
   ///   assert Queue.all<Nat>(queue, func n = n % 2 == 0);
   ///   assert not Queue.all<Nat>(queue, func n = n > 4);
   /// }
@@ -690,7 +690,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.any<Nat>(queue, func n = n > 2);
   ///   assert not Queue.any<Nat>(queue, func n = n > 3);
   /// }
@@ -719,7 +719,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// persistent actor {
   ///   var text = "";
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   Queue.forEach<Nat>(queue, func n = text #= Nat.toText(n));
   ///   assert text == "123";
   /// }
@@ -750,7 +750,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   let mapped = Queue.map<Nat, Nat>(queue, func n = n * 2);
   ///   assert Queue.size(mapped) == 3;
   ///   assert Queue.peekFront(mapped) == ?2;
@@ -784,7 +784,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
   ///   let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
@@ -809,7 +809,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
   ///   let filtered = Queue.filterMap<Nat, Nat>(queue, func n = if (n % 2 == 0) { ?n } else null);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
@@ -840,7 +840,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   assert Queue.toText(queue, Nat.toText) == "RealTimeQueue[1, 2, 3]";
   /// }
   /// ```
@@ -866,7 +866,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
   ///   let reversed = Queue.reverse(queue);
   ///   assert Queue.peekFront(reversed) == ?3;
   ///   assert Queue.peekBack(reversed) == ?1;

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -576,7 +576,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   assert Iter.toArray(Queue.values(queue)) == [1, 2, 3];
+  ///   assert (Queue.values(queue)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -530,7 +530,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([0, 1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter<Nat>([0, 1, 2, 3, 4].vals());
   ///   assert Queue.peekFront(queue) == ?0;
   ///   assert Queue.peekBack(queue) == ?4;
   ///   assert Queue.size(queue) == 5;
@@ -551,7 +551,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   transient let iter = [0, 1, 2, 3, 4].values();
+  ///   transient let iter = [0, 1, 2, 3, 4].vals();
   ///
   ///   let queue = iter.toQueue();
   ///
@@ -575,7 +575,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert (queue.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -606,9 +606,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue3 = Queue.fromIter<Nat>([1, 3, 2].values());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue3 = Queue.fromIter<Nat>([1, 3, 2].vals());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   ///   assert not Queue.equal(queue1, queue3, Nat.equal);
   /// }
@@ -637,8 +637,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 4].values());
+  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].vals());
+  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 4].vals());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -663,7 +663,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].values());
+  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
   ///   assert Queue.all<Nat>(queue, func n = n % 2 == 0);
   ///   assert not Queue.all<Nat>(queue, func n = n > 4);
   /// }
@@ -680,7 +680,7 @@ module {
     case (#two(x, y)) predicate x and predicate y;
     case (#three(x, y, z)) predicate x and predicate y and predicate z;
     case _ {
-      for (item in values self) if (not (predicate item)) return false;
+      for (item in self.values()) if (not (predicate item)) return false;
       return true
     }
   };
@@ -690,7 +690,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.any<Nat>(queue, func n = n > 2);
   ///   assert not Queue.any<Nat>(queue, func n = n > 3);
   /// }
@@ -707,7 +707,7 @@ module {
     case (#two(x, y)) predicate x or predicate y;
     case (#three(x, y, z)) predicate x or predicate y or predicate z;
     case _ {
-      for (item in values self) if (predicate item) return true;
+      for (item in self.values()) if (predicate item) return true;
       return false
     }
   };
@@ -719,7 +719,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// persistent actor {
   ///   var text = "";
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   Queue.forEach<Nat>(queue, func n = text #= Nat.toText(n));
   ///   assert text == "123";
   /// }
@@ -737,7 +737,7 @@ module {
     case (#three(x, y, z)) { f x; f y; f z };
     // Preserve the order when visiting the elements. Note that the #idles case would require reversing the second stack.
     case _ {
-      for (t in values self) f t
+      for (t in self.values()) f t
     }
   };
 
@@ -750,7 +750,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   let mapped = Queue.map<Nat, Nat>(queue, func n = n * 2);
   ///   assert Queue.size(mapped) == 3;
   ///   assert Queue.peekFront(mapped) == ?2;
@@ -773,7 +773,7 @@ module {
       // No reason to rebuild the #rebal state.
       // future work: It could be further optimized by building a balanced #idles state directly since we know the sizes.
       var q = empty<T2>();
-      for (t in values self) q := pushBack(q, f t);
+      for (t in self.values()) q := pushBack(q, f t);
       q
     }
   };
@@ -784,7 +784,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
   ///   let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
@@ -799,7 +799,7 @@ module {
   /// *Runtime and space assumes that `predicate` runs in `O(1)` time and space.
   public func filter<T>(self : Queue<T>, predicate : T -> Bool) : Queue<T> {
     var q = empty<T>();
-    for (t in values self) if (predicate t) q := pushBack(q, t);
+    for (t in self.values()) if (predicate t) q := pushBack(q, t);
     q
   };
 
@@ -809,7 +809,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
   ///   let filtered = Queue.filterMap<Nat, Nat>(queue, func n = if (n % 2 == 0) { ?n } else null);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
@@ -824,7 +824,7 @@ module {
   /// *Runtime and space assumes that f runs in `O(1)` time and space.
   public func filterMap<T, U>(self : Queue<T>, f : T -> ?U) : Queue<U> {
     var q = empty<U>();
-    for (t in values self) {
+    for (t in self.values()) {
       switch (f t) {
         case (?x) q := pushBack(q, x);
         case null ()
@@ -840,7 +840,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   assert Queue.toText(queue, Nat.toText) == "RealTimeQueue[1, 2, 3]";
   /// }
   /// ```
@@ -853,7 +853,7 @@ module {
   public func toText<T>(self : Queue<T>, f : (implicit : (toText : T -> Text))) : Text {
     var text = "RealTimeQueue[";
     var first = true;
-    for (t in values self) {
+    for (t in self.values()) {
       if (first) first := false else text #= ", ";
       text #= f(t)
     };
@@ -866,7 +866,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
   ///   let reversed = Queue.reverse(queue);
   ///   assert Queue.peekFront(reversed) == ?3;
   ///   assert Queue.peekBack(reversed) == ?1;

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -8,7 +8,7 @@
 /// import Nat "mo:core/Nat";
 ///
 /// persistent actor {
-///   let set = Set.fromIter([3, 1, 2, 3].values(), Nat.compare);
+///   let set = Set.fromIter([3, 1, 2, 3].vals(), Nat.compare);
 ///   assert Set.size(set) == 3;
 ///   assert not Set.contains(set, Nat.compare, 4);
 ///   let diff = Set.difference(set, set, Nat.compare);
@@ -65,7 +65,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2, 1].vals(), Nat.compare);
   ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -95,7 +95,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 1, 2, 1].values();
+  ///   transient let iter = [3, 1, 2, 1].vals();
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
@@ -189,7 +189,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
@@ -218,7 +218,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///   do {
   ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
   ///     assert contained1;
@@ -250,7 +250,7 @@ module {
   /// import Bool "mo:core/Bool";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2].vals(), Nat.compare);
   ///
   ///   assert Set.contains(set, Nat.compare, 1);
   ///   assert not Set.contains(set, Nat.compare, 4);
@@ -271,7 +271,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
+  ///   let set1 = Set.fromIter<Nat>([0, 2, 1].vals(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.max(set1) == ?2;
   ///   assert Set.max(set2) == null;
@@ -292,7 +292,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([2, 0, 1].values(), Nat.compare);
+  ///   let set1 = Set.fromIter<Nat>([2, 0, 1].vals(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.min(set1) == ?0;
   ///   assert Set.min(set2) == null;
@@ -316,8 +316,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
   ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
@@ -347,8 +347,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
   ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
@@ -394,8 +394,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
   ///   assert (difference.values()).toArray() == [1, 2];
   /// }
@@ -444,7 +444,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 1, 2].vals(), Nat.compare);
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
@@ -469,7 +469,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   var text = "";
   ///   Set.forEach<Nat>(numbers, func (element) {
@@ -498,7 +498,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
@@ -534,7 +534,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 0, 2, 1].vals(), Nat.compare);
   ///
   ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
@@ -579,9 +579,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1, 0].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([3, 4].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([3, 4].vals(), Nat.compare);
   ///   assert Set.isSubset(set1, set2, Nat.compare);
   ///   assert not Set.isSubset(set1, set3, Nat.compare);
   /// }
@@ -605,9 +605,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([2, 1, 0].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
   ///   assert Set.equal(set1, set2, Nat.compare);
   ///   assert not Set.equal(set1, set3, Nat.compare);
   /// }
@@ -665,8 +665,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([0, 2].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([0, 2].vals(), Nat.compare);
   ///
   ///   assert Set.compare(set1, set2, Nat.compare) == #less;
   ///   assert Set.compare(set1, set1, Nat.compare) == #equal;
@@ -683,7 +683,7 @@ module {
   public func compare<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
     // TODO: optimize using recursion on self?
     let iterator1 = self.values();
-    let iterator2 = values(other);
+    let iterator2 = other.values();
     loop {
       switch (iterator1.next(), iterator2.next()) {
         case (null, null) return #equal;
@@ -708,7 +708,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
   ///
   ///   var text = "";
   ///   for (number in set.values()) {
@@ -734,7 +734,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.reverseValues()) {
@@ -800,7 +800,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1, 3].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1, 3].vals(), Nat.compare);
   ///
   ///   assert Set.size(set) == 4;
   /// }
@@ -819,7 +819,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
   ///
   ///   let text = Set.foldLeft<Nat, Text>(
   ///      set,
@@ -850,7 +850,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
   ///
   ///   let text = Set.foldRight<Nat, Text>(
   ///      set,
@@ -907,7 +907,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let belowTen = Set.all<Nat>(set, func (number) {
   ///     number < 10
@@ -931,7 +931,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   let aboveTen = Set.any<Nat>(set, func (number) {
   ///     number > 10
@@ -961,7 +961,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "PureSet{0, 1, 2, 3}";
   /// }
@@ -1002,12 +1002,12 @@ module {
   ///      Set.compare(first, second, Nat.compare)
   ///   };
   ///
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
-  ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
+  ///   let setOfSets = Set.fromIter([set1, set2, set3].vals(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (flat.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1037,10 +1037,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
-  ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
+  ///   let combined = Set.join([set1, set2, set3].vals(), Nat.compare);
   ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -8,7 +8,7 @@
 /// import Nat "mo:core/Nat";
 ///
 /// persistent actor {
-///   let set = Set.fromIter([3, 1, 2, 3].vals(), Nat.compare);
+///   let set = Set.fromIter([3, 1, 2, 3].values(), Nat.compare);
 ///   assert Set.size(set) == 3;
 ///   assert not Set.contains(set, Nat.compare, 4);
 ///   let diff = Set.difference(set, set, Nat.compare);
@@ -65,7 +65,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
   ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
@@ -95,7 +95,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   transient let iter = [3, 1, 2, 1].vals();
+  ///   transient let iter = [3, 1, 2, 1].values();
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
@@ -189,7 +189,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
@@ -218,7 +218,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   do {
   ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
   ///     assert contained1;
@@ -250,7 +250,7 @@ module {
   /// import Bool "mo:core/Bool";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   assert Set.contains(set, Nat.compare, 1);
   ///   assert not Set.contains(set, Nat.compare, 4);
@@ -271,7 +271,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([0, 2, 1].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.max(set1) == ?2;
   ///   assert Set.max(set2) == null;
@@ -292,7 +292,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([2, 0, 1].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter<Nat>([2, 0, 1].values(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.min(set1) == ?0;
   ///   assert Set.min(set2) == null;
@@ -316,8 +316,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
   ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
@@ -347,8 +347,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
   ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
@@ -394,8 +394,8 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
   ///   assert (difference.values()).toArray() == [1, 2];
   /// }
@@ -444,7 +444,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
@@ -469,7 +469,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   var text = "";
   ///   Set.forEach<Nat>(numbers, func (element) {
@@ -498,7 +498,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
@@ -534,7 +534,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numbers = Set.fromIter([3, 0, 2, 1].vals(), Nat.compare);
+  ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
   ///
   ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
@@ -579,9 +579,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([3, 4].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1, 0].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([3, 4].values(), Nat.compare);
   ///   assert Set.isSubset(set1, set2, Nat.compare);
   ///   assert not Set.isSubset(set1, set3, Nat.compare);
   /// }
@@ -605,9 +605,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([2, 1].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([2, 1, 0].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([2, 1].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([2, 1, 0].values(), Nat.compare);
   ///   assert Set.equal(set1, set2, Nat.compare);
   ///   assert not Set.equal(set1, set3, Nat.compare);
   /// }
@@ -665,8 +665,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([0, 1].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([0, 2].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 1].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([0, 2].values(), Nat.compare);
   ///
   ///   assert Set.compare(set1, set2, Nat.compare) == #less;
   ///   assert Set.compare(set1, set1, Nat.compare) == #equal;
@@ -708,7 +708,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var text = "";
   ///   for (number in set.values()) {
@@ -734,7 +734,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 2, 3, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
   ///   for (number in set.reverseValues()) {
@@ -800,7 +800,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1, 3].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1, 3].values(), Nat.compare);
   ///
   ///   assert Set.size(set) == 4;
   /// }
@@ -819,7 +819,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
   ///   let text = Set.foldLeft<Nat, Text>(
   ///      set,
@@ -850,7 +850,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter([0, 3, 2, 1].vals(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
   ///   let text = Set.foldRight<Nat, Text>(
   ///      set,
@@ -907,7 +907,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let belowTen = Set.all<Nat>(set, func (number) {
   ///     number < 10
@@ -931,7 +931,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   let aboveTen = Set.any<Nat>(set, func (number) {
   ///     number > 10
@@ -961,7 +961,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].vals(), Nat.compare);
+  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "PureSet{0, 1, 2, 3}";
   /// }
@@ -1002,10 +1002,10 @@ module {
   ///      Set.compare(first, second, Nat.compare)
   ///   };
   ///
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
-  ///   let setOfSets = Set.fromIter([set1, set2, set3].vals(), setCompare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
+  ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
   ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
@@ -1037,10 +1037,10 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter([1, 2, 3].vals(), Nat.compare);
-  ///   let set2 = Set.fromIter([3, 4, 5].vals(), Nat.compare);
-  ///   let set3 = Set.fromIter([5, 6, 7].vals(), Nat.compare);
-  ///   let combined = Set.join([set1, set2, set3].vals(), Nat.compare);
+  ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
+  ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
+  ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
+  ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
   ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -66,7 +66,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -99,7 +99,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
+  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -129,10 +129,10 @@ module {
   ///   let set1 = Set.add(set0, Nat.compare, 2);
   ///   let set2 = Set.add(set1, Nat.compare, 1);
   ///   let set3 = Set.add(set2, Nat.compare, 2);
-  ///   assert Iter.toArray(Set.values(set0)) == [];
-  ///   assert Iter.toArray(Set.values(set1)) == [2];
-  ///   assert Iter.toArray(Set.values(set2)) == [1, 2];
-  ///   assert Iter.toArray(Set.values(set3)) == [1, 2];
+  ///   assert (Set.values(set0)).toArray() == [];
+  ///   assert (Set.values(set1)).toArray() == [2];
+  ///   assert (Set.values(set2)).toArray() == [1, 2];
+  ///   assert (Set.values(set3)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -165,7 +165,7 @@ module {
   ///     assert new2;
   ///     let (set3, new3) = Set.insert(set2, Nat.compare, 2);
   ///     assert not new3;
-  ///     assert Iter.toArray(Set.values(set3)) == [1, 2]
+  ///     assert (Set.values(set3)).toArray() == [1, 2]
   ///   }
   /// }
   /// ```
@@ -193,7 +193,7 @@ module {
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
-  ///   assert Iter.toArray(Set.values(set2)) == [1, 3];
+  ///   assert (Set.values(set2)).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -222,10 +222,10 @@ module {
   ///   do {
   ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
   ///     assert contained1;
-  ///     assert Iter.toArray(Set.values(set1)) == [1, 3];
+  ///     assert (Set.values(set1)).toArray() == [1, 3];
   ///     let (set2, contained2) = Set.delete(set1, Nat.compare, 4);
   ///     assert not contained2;
-  ///     assert Iter.toArray(Set.values(set2)) == [1, 3];
+  ///     assert (Set.values(set2)).toArray() == [1, 3];
   ///   }
   /// }
   /// ```
@@ -319,7 +319,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(union)) == [1, 2, 3, 4, 5];
+  ///   assert (Set.values(union)).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -350,7 +350,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(intersection)) == [1, 2];
+  ///   assert (Set.values(intersection)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -397,7 +397,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert Iter.toArray(Set.values(difference)) == [1, 2];
+  ///   assert (Set.values(difference)).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -448,7 +448,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert Iter.toArray(Set.values(textNumbers)) == ["1", "2", "3"];
+  ///   assert (Set.values(textNumbers)).toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -503,7 +503,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert Iter.toArray(Set.values(evenNumbers)) == [0, 2];
+  ///   assert (Set.values(evenNumbers)).toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -543,7 +543,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert Iter.toArray(Set.values(evenTextNumbers)) == ["0", "2"];
+  ///   assert (Set.values(evenTextNumbers)).toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -761,7 +761,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.empty<Nat>();
-  ///   assert Iter.toArray(Set.values(set)) == [];
+  ///   assert (Set.values(set)).toArray() == [];
   /// }
   /// ```
   ///
@@ -779,7 +779,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.singleton(0);
-  ///   assert Iter.toArray(Set.values(set)) == [0];
+  ///   assert (Set.values(set)).toArray() == [0];
   /// }
   /// ```
   ///
@@ -1007,7 +1007,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert Iter.toArray(Set.values(flatSet)) == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (Set.values(flatSet)).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1041,7 +1041,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert Iter.toArray(Set.values(combined)) == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (Set.values(combined)).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -66,7 +66,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
+  ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -99,7 +99,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert (Set.values(set)).toArray() == [1, 2, 3];
+  ///   assert (set.values()).toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -129,10 +129,10 @@ module {
   ///   let set1 = Set.add(set0, Nat.compare, 2);
   ///   let set2 = Set.add(set1, Nat.compare, 1);
   ///   let set3 = Set.add(set2, Nat.compare, 2);
-  ///   assert (Set.values(set0)).toArray() == [];
-  ///   assert (Set.values(set1)).toArray() == [2];
-  ///   assert (Set.values(set2)).toArray() == [1, 2];
-  ///   assert (Set.values(set3)).toArray() == [1, 2];
+  ///   assert (set0.values()).toArray() == [];
+  ///   assert (set1.values()).toArray() == [2];
+  ///   assert (set2.values()).toArray() == [1, 2];
+  ///   assert (set3.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -165,7 +165,7 @@ module {
   ///     assert new2;
   ///     let (set3, new3) = Set.insert(set2, Nat.compare, 2);
   ///     assert not new3;
-  ///     assert (Set.values(set3)).toArray() == [1, 2]
+  ///     assert (set3.values()).toArray() == [1, 2]
   ///   }
   /// }
   /// ```
@@ -193,7 +193,7 @@ module {
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
-  ///   assert (Set.values(set2)).toArray() == [1, 3];
+  ///   assert (set2.values()).toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -222,10 +222,10 @@ module {
   ///   do {
   ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
   ///     assert contained1;
-  ///     assert (Set.values(set1)).toArray() == [1, 3];
+  ///     assert (set1.values()).toArray() == [1, 3];
   ///     let (set2, contained2) = Set.delete(set1, Nat.compare, 4);
   ///     assert not contained2;
-  ///     assert (Set.values(set2)).toArray() == [1, 3];
+  ///     assert (set2.values()).toArray() == [1, 3];
   ///   }
   /// }
   /// ```
@@ -319,7 +319,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert (Set.values(union)).toArray() == [1, 2, 3, 4, 5];
+  ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -350,7 +350,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert (Set.values(intersection)).toArray() == [1, 2];
+  ///   assert (intersection.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -397,7 +397,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert (Set.values(difference)).toArray() == [1, 2];
+  ///   assert (difference.values()).toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -448,7 +448,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert (Set.values(textNumbers)).toArray() == ["1", "2", "3"];
+  ///   assert (textNumbers.values()).toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -503,7 +503,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert (Set.values(evenNumbers)).toArray() == [0, 2];
+  ///   assert (evenNumbers.values()).toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -543,7 +543,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert (Set.values(evenTextNumbers)).toArray() == ["0", "2"];
+  ///   assert (evenTextNumbers.values()).toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -682,7 +682,7 @@ module {
   /// Note: Creates `O(log(n))` temporary objects that will be collected as garbage.
   public func compare<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Order.Order {
     // TODO: optimize using recursion on self?
-    let iterator1 = values(self);
+    let iterator1 = self.values();
     let iterator2 = values(other);
     loop {
       switch (iterator1.next(), iterator2.next()) {
@@ -711,7 +711,7 @@ module {
   ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var text = "";
-  ///   for (number in Set.values(set)) {
+  ///   for (number in set.values()) {
   ///      text #= " " # Nat.toText(number);
   ///   };
   ///   assert text == " 0 1 2 3";
@@ -737,7 +737,7 @@ module {
   ///   let set = Set.fromIter([0, 2, 3, 1].values(), Nat.compare);
   ///
   ///   var tmp = "";
-  ///   for (number in Set.reverseValues(set)) {
+  ///   for (number in set.reverseValues()) {
   ///      tmp #= " " # Nat.toText(number);
   ///   };
   ///   assert tmp == " 3 2 1 0";
@@ -761,7 +761,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.empty<Nat>();
-  ///   assert (Set.values(set)).toArray() == [];
+  ///   assert (set.values()).toArray() == [];
   /// }
   /// ```
   ///
@@ -779,7 +779,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.singleton(0);
-  ///   assert (Set.values(set)).toArray() == [0];
+  ///   assert (set.values()).toArray() == [0];
   /// }
   /// ```
   ///
@@ -976,7 +976,7 @@ module {
   public func toText<T>(self : Set<T>, elementFormat : (implicit : (toText : T -> Text))) : Text {
     var text = "PureSet{";
     var sep = "";
-    for (element in values(self)) {
+    for (element in self.values()) {
       text #= sep # elementFormat(element);
       sep := ", "
     };
@@ -1007,7 +1007,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (Set.values(flatSet)).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (flat.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1017,7 +1017,7 @@ module {
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func flatten<T>(self : Set<Set<T>>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
     var result = empty<T>();
-    for (set in values(self)) {
+    for (set in self.values()) {
       result := union(result, set, compare)
     };
     result
@@ -1041,7 +1041,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert (Set.values(combined)).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -66,7 +66,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
-  ///   assert (set.values()).toArray() == [1, 2, 3];
+  ///   assert set.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -99,7 +99,7 @@ module {
   ///
   ///   let set = iter.toSet(Nat.compare);
   ///
-  ///   assert (set.values()).toArray() == [1, 2, 3];
+  ///   assert set.values().toArray() == [1, 2, 3];
   /// }
   /// ```
   ///
@@ -129,10 +129,10 @@ module {
   ///   let set1 = Set.add(set0, Nat.compare, 2);
   ///   let set2 = Set.add(set1, Nat.compare, 1);
   ///   let set3 = Set.add(set2, Nat.compare, 2);
-  ///   assert (set0.values()).toArray() == [];
-  ///   assert (set1.values()).toArray() == [2];
-  ///   assert (set2.values()).toArray() == [1, 2];
-  ///   assert (set3.values()).toArray() == [1, 2];
+  ///   assert set0.values().toArray() == [];
+  ///   assert set1.values().toArray() == [2];
+  ///   assert set2.values().toArray() == [1, 2];
+  ///   assert set3.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -165,7 +165,7 @@ module {
   ///     assert new2;
   ///     let (set3, new3) = Set.insert(set2, Nat.compare, 2);
   ///     assert not new3;
-  ///     assert (set3.values()).toArray() == [1, 2]
+  ///     assert set3.values().toArray() == [1, 2]
   ///   }
   /// }
   /// ```
@@ -193,7 +193,7 @@ module {
   ///
   ///   let set1 = Set.remove(set, Nat.compare, 2);
   ///   let set2 = Set.remove(set1, Nat.compare, 4);
-  ///   assert (set2.values()).toArray() == [1, 3];
+  ///   assert set2.values().toArray() == [1, 3];
   /// }
   /// ```
   ///
@@ -222,10 +222,10 @@ module {
   ///   do {
   ///     let (set1, contained1) = Set.delete(set, Nat.compare, 2);
   ///     assert contained1;
-  ///     assert (set1.values()).toArray() == [1, 3];
+  ///     assert set1.values().toArray() == [1, 3];
   ///     let (set2, contained2) = Set.delete(set1, Nat.compare, 4);
   ///     assert not contained2;
-  ///     assert (set2.values()).toArray() == [1, 3];
+  ///     assert set2.values().toArray() == [1, 3];
   ///   }
   /// }
   /// ```
@@ -319,7 +319,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let union = Set.union(set1, set2, Nat.compare);
-  ///   assert (union.values()).toArray() == [1, 2, 3, 4, 5];
+  ///   assert union.values().toArray() == [1, 2, 3, 4, 5];
   /// }
   /// ```
   ///
@@ -350,7 +350,7 @@ module {
   ///   let set1 = Set.fromIter([0, 1, 2].values(), Nat.compare);
   ///   let set2 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let intersection = Set.intersection(set1, set2, Nat.compare);
-  ///   assert (intersection.values()).toArray() == [1, 2];
+  ///   assert intersection.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -397,7 +397,7 @@ module {
   ///   let set1 = Set.fromIter([1, 2, 3].values(), Nat.compare);
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let difference = Set.difference(set1, set2, Nat.compare);
-  ///   assert (difference.values()).toArray() == [1, 2];
+  ///   assert difference.values().toArray() == [1, 2];
   /// }
   /// ```
   ///
@@ -448,7 +448,7 @@ module {
   ///
   ///   let textNumbers =
   ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
-  ///   assert (textNumbers.values()).toArray() == ["1", "2", "3"];
+  ///   assert textNumbers.values().toArray() == ["1", "2", "3"];
   /// }
   /// ```
   ///
@@ -503,7 +503,7 @@ module {
   ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
-  ///   assert (evenNumbers.values()).toArray() == [0, 2];
+  ///   assert evenNumbers.values().toArray() == [0, 2];
   /// }
   /// ```
   ///
@@ -543,7 +543,7 @@ module {
   ///        null // discard odd numbers
   ///     }
   ///   });
-  ///   assert (evenTextNumbers.values()).toArray() == ["0", "2"];
+  ///   assert evenTextNumbers.values().toArray() == ["0", "2"];
   /// }
   /// ```
   ///
@@ -761,7 +761,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.empty<Nat>();
-  ///   assert (set.values()).toArray() == [];
+  ///   assert set.values().toArray() == [];
   /// }
   /// ```
   ///
@@ -779,7 +779,7 @@ module {
   ///
   /// persistent actor {
   ///   let set = Set.singleton(0);
-  ///   assert (set.values()).toArray() == [0];
+  ///   assert set.values().toArray() == [0];
   /// }
   /// ```
   ///
@@ -1007,7 +1007,7 @@ module {
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let setOfSets = Set.fromIter([set1, set2, set3].values(), setCompare);
   ///   let flatSet = Set.flatten(setOfSets, Nat.compare);
-  ///   assert (flatSet.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert flatSet.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///
@@ -1041,7 +1041,7 @@ module {
   ///   let set2 = Set.fromIter([3, 4, 5].values(), Nat.compare);
   ///   let set3 = Set.fromIter([5, 6, 7].values(), Nat.compare);
   ///   let combined = Set.join([set1, set2, set3].values(), Nat.compare);
-  ///   assert (combined.values()).toArray() == [1, 2, 3, 4, 5, 6, 7];
+  ///   assert combined.values().toArray() == [1, 2, 3, 4, 5, 6, 7];
   /// }
   /// ```
   ///

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -302,19 +302,19 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "flatMap",
-      Array.flatMap<Int, Int>([0, 1, 2], func x = [x, -x].vals()),
+      Array.flatMap<Int, Int>([0, 1, 2], func x = [x, -x].values()),
       M.equals(T.array<Int>(T.intTestable, [0, 0, 1, -1, 2, -2]))
     ),
     Suite.test(
       "flatMap empty",
-      Array.flatMap<Int, Int>([], func x = [x, -x].vals()),
+      Array.flatMap<Int, Int>([], func x = [x, -x].values()),
       M.equals(T.array<Int>(T.intTestable, []))
     ),
     Suite.test(
       "flatMap mix",
       Array.flatMap<Nat, Nat>(
         [1, 2, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -322,7 +322,7 @@ let suite = Suite.suite(
       "flatMap mix empty right",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -330,7 +330,7 @@ let suite = Suite.suite(
       "flatMap mix empties right",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3, 0, 0, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -338,7 +338,7 @@ let suite = Suite.suite(
       "flatMap mix empty left",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -346,7 +346,7 @@ let suite = Suite.suite(
       "flatMap mix empties left",
       Array.flatMap<Nat, Nat>(
         [0, 0, 0, 1, 2, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -354,7 +354,7 @@ let suite = Suite.suite(
       "flatMap mix empties middle",
       Array.flatMap<Nat, Nat>(
         [0, 1, 2, 0, 0, 0, 1, 2, 3],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, [0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -362,7 +362,7 @@ let suite = Suite.suite(
       "flatMap mix empties",
       Array.flatMap<Nat, Nat>(
         [0, 0, 0],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, []))
     ),
@@ -370,7 +370,7 @@ let suite = Suite.suite(
       "flatMap mix empty",
       Array.flatMap<Nat, Nat>(
         [],
-        func n = Array.tabulate<Nat>(n, func i = i).vals()
+        func n = Array.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(T.array<Nat>(T.natTestable, []))
     ),

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -715,53 +715,53 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "binarySearch found",
-      Array.binarySearch<Nat>([1, 3, 5, 7, 9, 11], Nat.compare, 5) == #found(2),
+      ([1, 3, 5, 7, 9, 11]).binarySearch<Nat>(5) == #found(2),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch not found",
-      Array.binarySearch<Nat>([1, 3, 5, 7, 9, 11], Nat.compare, 6) == #insertionIndex(3),
+      ([1, 3, 5, 7, 9, 11]).binarySearch<Nat>(6) == #insertionIndex(3),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch first element",
       do {
-        Array.binarySearch<Nat>([1, 3, 5, 7, 9, 11], Nat.compare, 1) == #found(0)
+        ([1, 3, 5, 7, 9, 11]).binarySearch<Nat>(1) == #found(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch last element",
       do {
-        Array.binarySearch<Nat>([1, 3, 5, 7, 9, 11], Nat.compare, 11) == #found(5)
+        ([1, 3, 5, 7, 9, 11]).binarySearch<Nat>(11) == #found(5)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch empty array",
       do {
-        Array.binarySearch<Nat>([], Nat.compare, 5) == #insertionIndex(0)
+        ([]).binarySearch<Nat>(5) == #insertionIndex(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch single element found",
       do {
-        Array.binarySearch<Nat>([42], Nat.compare, 42) == #found(0)
+        ([42]).binarySearch<Nat>(42) == #found(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch single element not found",
       do {
-        Array.binarySearch<Nat>([42], Nat.compare, 43) == #insertionIndex(1)
+        ([42]).binarySearch<Nat>(43) == #insertionIndex(1)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch duplicates",
       do {
-        let result = Array.binarySearch<Nat>([1, 2, 2, 2, 3], Nat.compare, 2);
+        let result = ([1, 2, 2, 2, 3]).binarySearch<Nat>(2);
         switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }
@@ -771,32 +771,32 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "isSorted empty array",
-      Array.isSorted<Nat>([], Nat.compare),
+      ([]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted single element",
-      Array.isSorted<Nat>([42], Nat.compare),
+      ([42]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted already sorted",
-      Array.isSorted<Nat>([1, 2, 3, 4, 5], Nat.compare),
+      ([1, 2, 3, 4, 5]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted with duplicates",
-      Array.isSorted<Nat>([1, 2, 2, 3, 3, 3], Nat.compare),
+      ([1, 2, 2, 3, 3, 3]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted not sorted",
-      Array.isSorted<Nat>([1, 3, 2, 4, 5], Nat.compare),
+      ([1, 3, 2, 4, 5]).isSorted<Nat>(),
       M.equals(T.bool(false))
     ),
     Suite.test(
       "isSorted reverse sorted",
-      Array.isSorted<Nat>([5, 4, 3, 2, 1], Nat.compare),
+      ([5, 4, 3, 2, 1]).isSorted<Nat>(),
       M.equals(T.bool(false))
     )
   ]

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -320,7 +320,7 @@ suite(
       "converts iterator to array",
       func() {
         let expected = [1, 2, 3];
-        let actual = (expected.values()).toArray<Nat>();
+        let actual = expected.values().toArray<Nat>();
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -79,7 +79,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.filterMap<Nat, Nat>(inputs.vals(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [20, 40]));
     test("none", func() = mk([1, 3, 5, 7], []));
@@ -92,7 +92,7 @@ suite(
   func() {
     func mk(inputs : [[Nat]], expected : [Nat]) {
       let actual = Iter.flatten(Iter.map<[Nat], Iter.Iter<Nat>>(inputs.vals(), func(x) = Iter.fromArray<Nat>(x)));
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([[1, 2], [3], [4, 5, 6]], [1, 2, 3, 4, 5, 6]));
     test("none", func() = mk([[], []], []));
@@ -105,7 +105,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.flatMap<Nat, Nat>(inputs.vals(), func(x) = [x, x * 10].vals());
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3], [1, 10, 2, 20, 3, 30]));
     test("none", func() = mk([], []))
@@ -117,7 +117,7 @@ suite(
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
       let actual = Iter.take<Nat>(inputs.vals(), n);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [1, 2, 3]));
     test("zero", func() = mk([1, 2, 3], 0, []));
@@ -132,7 +132,7 @@ suite(
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
       let actual = Iter.drop<Nat>(inputs.vals(), n);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [4, 5]));
     test("zero", func() = mk([1, 2, 3], 0, [1, 2, 3]));
@@ -147,7 +147,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.takeWhile<Nat>(inputs.vals(), func(x) = x < 4);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3]));
     test("none", func() = mk([4, 5, 6], []));
@@ -161,7 +161,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.dropWhile<Nat>(inputs.vals(), func(x) = x < 4);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [4, 5, 4, 3, 2, 1]));
     test("all", func() = mk([4, 5, 6], [4, 5, 6]));
@@ -175,7 +175,7 @@ suite(
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [(Nat, Nat)]) {
       let actual = Iter.zip<Nat, Nat>(input1.vals(), input2.vals());
-      expect.array<(Nat, Nat)>(Iter.toArray(actual), Tuple2.makeToText<Nat, Nat>(Nat.toText, Nat.toText), Tuple2.makeEqual<Nat, Nat>(Nat.equal, Nat.equal)).equal(expected)
+      expect.array<(Nat, Nat)>(actual.toArray(), Tuple2.makeToText<Nat, Nat>(Nat.toText, Nat.toText), Tuple2.makeEqual<Nat, Nat>(Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [(1, 4), (2, 5), (3, 6)]));
     test("left skipped", func() = mk([1, 2, 3], [4, 5], [(1, 4), (2, 5)]));
@@ -191,7 +191,7 @@ suite(
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [Nat]) {
       let actual = Iter.zipWith<Nat, Nat, Nat>(input1.vals(), input2.vals(), func(x, y) = x + y);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [5, 7, 9]));
     test("left skipped", func() = mk([1, 2, 3], [4, 5], [5, 7]));
@@ -207,7 +207,7 @@ suite(
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [(Nat, Nat, Nat)]) {
       let actual = Iter.zip3<Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals());
-      expect.array<(Nat, Nat, Nat)>(Iter.toArray(actual), Tuple3.makeToText<Nat, Nat, Nat>(Nat.toText, Nat.toText, Nat.toText), Tuple3.makeEqual<Nat, Nat, Nat>(Nat.equal, Nat.equal, Nat.equal)).equal(expected)
+      expect.array<(Nat, Nat, Nat)>(actual.toArray(), Tuple3.makeToText<Nat, Nat, Nat>(Nat.toText, Nat.toText, Nat.toText), Tuple3.makeEqual<Nat, Nat, Nat>(Nat.equal, Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [(1, 4, 7), (2, 5, 8), (3, 6, 9)]));
     test("left skipped", func() = mk([1, 2, 3], [4, 5], [7, 8, 9], [(1, 4, 7), (2, 5, 8)]));
@@ -224,7 +224,7 @@ suite(
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [Nat]) {
       let actual = Iter.zipWith3<Nat, Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals(), func(x, y, z) = x + y + z);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [12, 15, 18]));
     test("left skipped", func() = mk([1, 2, 3], [4, 5], [7, 8, 9], [12, 15]));
@@ -320,7 +320,7 @@ suite(
       "converts iterator to array",
       func() {
         let expected = [1, 2, 3];
-        let actual = Iter.toArray<Nat>(expected.vals());
+        let actual = (expected.vals()).toArray<Nat>();
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -355,7 +355,7 @@ suite(
       func() {
         let input : [Nat] = [4, 3, 1, 2, 5];
         let expected : [Nat] = [1, 2, 3, 4, 5];
-        let actual = Iter.toArray(Iter.sort<Nat>(input.vals(), Nat.compare));
+        let actual = (Iter.sort<Nat>(input.vals(), Nat.compare)).toArray();
         expect.array<Nat>(actual, Nat.toText, Nat.equal).equal(expected)
       }
     )
@@ -696,7 +696,7 @@ suite(
       let iter = inputs.vals();
       let actual = Iter.all<Nat>(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
-      let remaining = Iter.toArray(iter);
+      let remaining = iter.toArray();
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
     };
     test("empty", func() = mk([], true, []));
@@ -712,7 +712,7 @@ suite(
       let iter = inputs.vals();
       let actual = Iter.any<Nat>(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
-      let remaining = Iter.toArray(iter);
+      let remaining = iter.toArray();
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
     };
     test("empty", func() = mk([], false, []));
@@ -728,7 +728,7 @@ suite(
       let iter = inputs.vals();
       let actual = Iter.find<Nat>(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
-      let remaining = Iter.toArray(iter);
+      let remaining = iter.toArray();
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
     };
     test("empty", func() = mk([], null, []));
@@ -744,7 +744,7 @@ suite(
       let iter = inputs.vals();
       let actual = Iter.findIndex<Nat>(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
-      let remaining = Iter.toArray(iter);
+      let remaining = iter.toArray();
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
     };
     test("empty", func() = mk([], null, []));
@@ -760,7 +760,7 @@ suite(
       let iter = inputs.vals();
       let actual = Iter.contains<Nat>(iter, Nat.equal, x);
       expect.bool(actual).equal(expected);
-      let remaining = Iter.toArray(iter);
+      let remaining = iter.toArray();
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
     };
     test("empty", func() = mk([], 1, false, []));
@@ -811,7 +811,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.scanLeft<Nat, Nat>(inputs.vals(), 0, func(acc, x) = acc + x);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 1, 3, 6, 10]));
     test("empty", func() = mk([], [0]))
@@ -823,7 +823,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
       let actual = Iter.scanRight<Nat, Nat>(inputs.vals(), 0, func(x, acc) = acc + x);
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 4, 7, 9, 10]));
     test("empty", func() = mk([], [0]))
@@ -835,7 +835,7 @@ suite(
   func() {
     func mk(n : Nat, expected : [Nat]) {
       let actual = Iter.unfold<Nat, Nat>(n, func(x) = if (x == 0) null else ?(x, x - 1));
-      expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
+      expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk(5, [5, 4, 3, 2, 1]));
     test("zero", func() = mk(0, []))

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -18,7 +18,7 @@ suite(
         var z = 0;
 
         Iter.forEach<(Nat, Text)>(
-          Iter.enumerate(xs.vals()),
+          Iter.enumerate(xs.values()),
           func(i, x) {
             y := y # x;
             z += i
@@ -39,7 +39,7 @@ suite(
       "maps elements using provided function",
       func() {
         let isEven = func(x : Int) : Bool { x % 2 == 0 };
-        let _actual = Iter.map<Nat, Bool>([1, 2, 3].vals(), isEven);
+        let _actual = Iter.map<Nat, Bool>([1, 2, 3].values(), isEven);
         let actual = [var true, false, true];
         Iter.forEach<(Nat, Bool)>(
           Iter.enumerate(_actual),
@@ -62,7 +62,7 @@ suite(
       "filters elements using predicate",
       func() {
         let isOdd = func(x : Int) : Bool { x % 2 == 1 };
-        let _actual = Iter.filter<Nat>([1, 2, 3].vals(), isOdd);
+        let _actual = Iter.filter<Nat>([1, 2, 3].values(), isOdd);
         let actual = [var 0, 0];
         Iter.forEach<(Nat, Nat)>(
           Iter.enumerate(_actual),
@@ -78,7 +78,7 @@ suite(
   "filterMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.filterMap<Nat, Nat>(inputs.vals(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
+      let actual = Iter.filterMap<Nat, Nat>(inputs.values(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [20, 40]));
@@ -91,7 +91,7 @@ suite(
   "flatten",
   func() {
     func mk(inputs : [[Nat]], expected : [Nat]) {
-      let actual = Iter.flatten(Iter.map<[Nat], Iter.Iter<Nat>>(inputs.vals(), func(x) = Iter.fromArray<Nat>(x)));
+      let actual = Iter.flatten(Iter.map<[Nat], Iter.Iter<Nat>>(inputs.values(), func(x) = Iter.fromArray<Nat>(x)));
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([[1, 2], [3], [4, 5, 6]], [1, 2, 3, 4, 5, 6]));
@@ -104,7 +104,7 @@ suite(
   "flatMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.flatMap<Nat, Nat>(inputs.vals(), func(x) = [x, x * 10].vals());
+      let actual = Iter.flatMap<Nat, Nat>(inputs.values(), func(x) = [x, x * 10].values());
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3], [1, 10, 2, 20, 3, 30]));
@@ -116,7 +116,7 @@ suite(
   "take",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.take<Nat>(inputs.vals(), n);
+      let actual = Iter.take<Nat>(inputs.values(), n);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [1, 2, 3]));
@@ -131,7 +131,7 @@ suite(
   "drop",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.drop<Nat>(inputs.vals(), n);
+      let actual = Iter.drop<Nat>(inputs.values(), n);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [4, 5]));
@@ -146,7 +146,7 @@ suite(
   "takeWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.takeWhile<Nat>(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.takeWhile<Nat>(inputs.values(), func(x) = x < 4);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3]));
@@ -160,7 +160,7 @@ suite(
   "dropWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.dropWhile<Nat>(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.dropWhile<Nat>(inputs.values(), func(x) = x < 4);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [4, 5, 4, 3, 2, 1]));
@@ -174,7 +174,7 @@ suite(
   "zip",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [(Nat, Nat)]) {
-      let actual = Iter.zip<Nat, Nat>(input1.vals(), input2.vals());
+      let actual = Iter.zip<Nat, Nat>(input1.values(), input2.values());
       expect.array<(Nat, Nat)>(actual.toArray(), Tuple2.makeToText<Nat, Nat>(Nat.toText, Nat.toText), Tuple2.makeEqual<Nat, Nat>(Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [(1, 4), (2, 5), (3, 6)]));
@@ -190,7 +190,7 @@ suite(
   "zipWith",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith<Nat, Nat, Nat>(input1.vals(), input2.vals(), func(x, y) = x + y);
+      let actual = Iter.zipWith<Nat, Nat, Nat>(input1.values(), input2.values(), func(x, y) = x + y);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [5, 7, 9]));
@@ -206,7 +206,7 @@ suite(
   "zip3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [(Nat, Nat, Nat)]) {
-      let actual = Iter.zip3<Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals());
+      let actual = Iter.zip3<Nat, Nat, Nat>(input1.values(), input2.values(), input3.values());
       expect.array<(Nat, Nat, Nat)>(actual.toArray(), Tuple3.makeToText<Nat, Nat, Nat>(Nat.toText, Nat.toText, Nat.toText), Tuple3.makeEqual<Nat, Nat, Nat>(Nat.equal, Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [(1, 4, 7), (2, 5, 8), (3, 6, 9)]));
@@ -223,7 +223,7 @@ suite(
   "zipWith3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith3<Nat, Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals(), func(x, y, z) = x + y + z);
+      let actual = Iter.zipWith3<Nat, Nat, Nat, Nat>(input1.values(), input2.values(), input3.values(), func(x, y, z) = x + y + z);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [12, 15, 18]));
@@ -320,7 +320,7 @@ suite(
       "converts iterator to array",
       func() {
         let expected = [1, 2, 3];
-        let actual = (expected.vals()).toArray<Nat>();
+        let actual = (expected.values()).toArray<Nat>();
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -337,7 +337,7 @@ suite(
       "converts iterator to var array",
       func() {
         let expected = [var 1, 2, 3];
-        let actual = Iter.toVarArray<Nat>(expected.vals());
+        let actual = Iter.toVarArray<Nat>(expected.values());
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -355,7 +355,7 @@ suite(
       func() {
         let input : [Nat] = [4, 3, 1, 2, 5];
         let expected : [Nat] = [1, 2, 3, 4, 5];
-        let actual = (Iter.sort<Nat>(input.vals(), Nat.compare)).toArray();
+        let actual = (Iter.sort<Nat>(input.values(), Nat.compare)).toArray();
         expect.array<Nat>(actual, Nat.toText, Nat.equal).equal(expected)
       }
     )
@@ -500,7 +500,7 @@ suite(
       "reverses elements in iterator",
       func() {
         let array1 = [1, 2, 3, 4];
-        let iter1 = Iter.reverse(array1.vals());
+        let iter1 = Iter.reverse(array1.values());
         assert (iter1.next() == ?4);
         assert (iter1.next() == ?3);
         assert (iter1.next() == ?2);
@@ -513,7 +513,7 @@ suite(
       "empty array remains empty",
       func() {
         let array2 = ([] : [Nat]);
-        let iter2 = Iter.reverse(array2.vals());
+        let iter2 = Iter.reverse(array2.values());
         assert (iter2.next() == null)
       }
     );
@@ -522,7 +522,7 @@ suite(
       "single element array remains unchanged",
       func() {
         let array3 = ['a'];
-        let iter3 = Iter.reverse(array3.vals());
+        let iter3 = Iter.reverse(array3.values());
         assert (iter3.next() == ?'a');
         assert (iter3.next() == null)
       }
@@ -550,7 +550,7 @@ suite(
       "returns correct size for various iterators",
       func() {
         expect.nat(Iter.size(Iter.empty<Nat>())).equal(0);
-        expect.nat(Iter.size([1, 2, 3].vals())).equal(3);
+        expect.nat(Iter.size([1, 2, 3].values())).equal(3);
 
         let boundedIter = object {
           var count = 0;
@@ -581,7 +581,7 @@ suite(
     test(
       "single element returns tuple with index 0",
       func() {
-        let singleEnum = Iter.enumerate(["a"].vals());
+        let singleEnum = Iter.enumerate(["a"].values());
         assert (singleEnum.next() == ?(0, "a"));
         assert (singleEnum.next() == null)
       }
@@ -590,7 +590,7 @@ suite(
     test(
       "multiple elements return tuples with increasing indices",
       func() {
-        let multiEnum = Iter.enumerate([10, 20, 30].vals());
+        let multiEnum = Iter.enumerate([10, 20, 30].values());
         assert (multiEnum.next() == ?(0, 10));
         assert (multiEnum.next() == ?(1, 20));
         assert (multiEnum.next() == ?(2, 30));
@@ -606,7 +606,7 @@ suite(
     test(
       "step of zero returns empty iterator",
       func() {
-        let step0 = Iter.step([1, 2, 3, 4, 5].vals(), 0);
+        let step0 = Iter.step([1, 2, 3, 4, 5].values(), 0);
         assert (step0.next() == null)
       }
     );
@@ -614,7 +614,7 @@ suite(
     test(
       "step of one returns all elements",
       func() {
-        let step1 = Iter.step([1, 2, 3].vals(), 1);
+        let step1 = Iter.step([1, 2, 3].values(), 1);
         assert (step1.next() == ?1);
         assert (step1.next() == ?2);
         assert (step1.next() == ?3);
@@ -625,7 +625,7 @@ suite(
     test(
       "step of two returns every other element",
       func() {
-        let step2 = Iter.step([1, 2, 3, 4, 5].vals(), 2);
+        let step2 = Iter.step([1, 2, 3, 4, 5].values(), 2);
         assert (step2.next() == ?1);
         assert (step2.next() == ?3);
         assert (step2.next() == ?5);
@@ -636,7 +636,7 @@ suite(
     test(
       "step larger than size returns first element only",
       func() {
-        let stepBig = Iter.step([1, 2, 3].vals(), 4);
+        let stepBig = Iter.step([1, 2, 3].values(), 4);
         assert (stepBig.next() == ?1);
         assert (stepBig.next() == null)
       }
@@ -658,7 +658,7 @@ suite(
     test(
       "left empty returns right iterator",
       func() {
-        let leftEmpty = Iter.concat(Iter.empty<Nat>(), [1, 2].vals());
+        let leftEmpty = Iter.concat(Iter.empty<Nat>(), [1, 2].values());
         assert (leftEmpty.next() == ?1);
         assert (leftEmpty.next() == ?2);
         assert (leftEmpty.next() == null)
@@ -668,7 +668,7 @@ suite(
     test(
       "right empty returns left iterator",
       func() {
-        let rightEmpty = Iter.concat([1, 2].vals(), Iter.empty());
+        let rightEmpty = Iter.concat([1, 2].values(), Iter.empty());
         assert (rightEmpty.next() == ?1);
         assert (rightEmpty.next() == ?2);
         assert (rightEmpty.next() == null)
@@ -678,7 +678,7 @@ suite(
     test(
       "concatenates two non-empty iterators",
       func() {
-        let fullConcat = Iter.concat([1, 2].vals(), [3, 4].vals());
+        let fullConcat = Iter.concat([1, 2].values(), [3, 4].values());
         assert (fullConcat.next() == ?1);
         assert (fullConcat.next() == ?2);
         assert (fullConcat.next() == ?3);
@@ -693,7 +693,7 @@ suite(
   "all",
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.all<Nat>(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = iter.toArray();
@@ -709,7 +709,7 @@ suite(
   "any",
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.any<Nat>(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = iter.toArray();
@@ -725,7 +725,7 @@ suite(
   "find",
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.find<Nat>(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = iter.toArray();
@@ -741,7 +741,7 @@ suite(
   "findIndex",
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.findIndex<Nat>(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = iter.toArray();
@@ -757,7 +757,7 @@ suite(
   "contains",
   func() {
     func mk(inputs : [Nat], x : Nat, expected : Bool, rest : [Nat]) {
-      let iter = inputs.vals();
+      let iter = inputs.values();
       let actual = Iter.contains<Nat>(iter, Nat.equal, x);
       expect.bool(actual).equal(expected);
       let remaining = iter.toArray();
@@ -773,7 +773,7 @@ suite(
   "foldLeft",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldLeft<Text, Text>(inputs.vals(), "S", func(acc, x) = "(" # acc # x # ")");
+      let actual = Iter.foldLeft<Text, Text>(inputs.values(), "S", func(acc, x) = "(" # acc # x # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(((SA)B)C)"));
@@ -785,7 +785,7 @@ suite(
   "foldRight",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldRight<Text, Text>(inputs.vals(), "S", func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.foldRight<Text, Text>(inputs.values(), "S", func(x, acc) = "(" # x # acc # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(A(B(CS)))"));
@@ -797,7 +797,7 @@ suite(
   "reduce",
   func() {
     func mk(inputs : [Text], expected : ?Text) {
-      let actual = Iter.reduce<Text>(inputs.vals(), func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.reduce<Text>(inputs.values(), func(x, acc) = "(" # x # acc # ")");
       expect.option(actual, func(x : Text) : Text = x, Text.equal).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], ?"((AB)C)"));
@@ -810,7 +810,7 @@ suite(
   "scanLeft",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanLeft<Nat, Nat>(inputs.vals(), 0, func(acc, x) = acc + x);
+      let actual = Iter.scanLeft<Nat, Nat>(inputs.values(), 0, func(acc, x) = acc + x);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 1, 3, 6, 10]));
@@ -822,7 +822,7 @@ suite(
   "scanRight",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanRight<Nat, Nat>(inputs.vals(), 0, func(x, acc) = acc + x);
+      let actual = Iter.scanRight<Nat, Nat>(inputs.values(), 0, func(x, acc) = acc + x);
       expect.array<Nat>(actual.toArray(), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 4, 7, 9, 10]));
@@ -846,7 +846,7 @@ suite(
   "max",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.max<Nat>(inputs.vals(), Nat.compare);
+      let actual = Iter.max<Nat>(inputs.values(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 2, 3], ?3));
@@ -858,7 +858,7 @@ suite(
   "min",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.min<Nat>(inputs.vals(), Nat.compare);
+      let actual = Iter.min<Nat>(inputs.values(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 1, 4], ?1));

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1044,7 +1044,7 @@ run(
 // Helper function to run tests
 func runTest(name : Text, test : (Nat) -> Bool) {
   let testSizes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100];
-  for (n in testSizes.vals()) {
+  for (n in testSizes.values()) {
     if (test(n)) {
       Debug.print("✅ " # name # " passed for n = " # Nat.toText(n))
     } else {
@@ -1339,7 +1339,7 @@ func testMapInPlace(n : Nat) : Bool {
 
 func testFlatMap(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
-  let flatMapped = List.flatMap<Nat, Nat>(vec, func(x) = [x, x].vals());
+  let flatMapped = List.flatMap<Nat, Nat>(vec, func(x) = [x, x].values());
 
   let expected = List.fromArray<Nat>(Array.tabulate<Nat>(2 * n, func(i) = i / 2));
   List.equal(flatMapped, expected, Nat.equal)
@@ -1494,7 +1494,7 @@ func testDeduplicate(n : Nat) : Bool {
     List.fromArray<Nat>([1, 1, 2, 3])
   ];
 
-  for (list in lists.vals()) {
+  for (list in lists.values()) {
     List.deduplicate(list, Nat.equal);
     if (not List.equal(list, List.fromArray<Nat>([1, 2, 3]), Nat.equal)) {
       Debug.print("Deduplicate failed for " # List.toText(list, Nat.toText));
@@ -1754,7 +1754,7 @@ func testJoin(n : Nat) : Bool {
   let iter = Array.tabulate<List.List<Nat>>(
     n,
     func(i) = List.fromArray<Nat>(Array.tabulate<Nat>(i + 1, func(j) = j))
-  ).vals();
+  ).values();
   let flattened = List.join<Nat>(iter);
   let expectedSize = (n * (n + 1)) / 2;
 

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -320,7 +320,7 @@ run(
       ),
       test(
         "add many with vals",
-        Iter.toArray(for_add_many.values()),
+        (for_add_many.values()).toArray(),
         M.equals(T.array(T.natTestable, Array.tabulate<Nat>(2 * n, func(_) = 0)))
       ),
       test(
@@ -1350,7 +1350,7 @@ func testRange(n : Nat) : Bool {
   let vec = List.tabulate<Nat>(n, func(i) = i);
   for (left in Nat.range(0, n)) {
     for (right in Nat.range(left, n + 1)) {
-      let range = Iter.toArray<Nat>(List.range<Nat>(vec, left, right));
+      let range = (List.range<Nat>(vec, left, right)).toArray<Nat>();
       let expected = Array.tabulate<Nat>(right - left, func(i) = left + i);
       if (range != expected) {
         Debug.print(

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1694,17 +1694,17 @@ func testForEach(n : Nat) : Bool {
 func testBinarySearch(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i * 2));
   if (n == 0) {
-    return List.binarySearch(vec, Nat.compare, 0) == #insertionIndex(0) and List.binarySearch(vec, Nat.compare, 1) == #insertionIndex(0)
+    return vec.binarySearch(0) == #insertionIndex(0) and vec.binarySearch(1) == #insertionIndex(0)
   };
   for (i in Nat.range(0, n)) {
     let value = i * 2;
-    let index = List.binarySearch(vec, Nat.compare, value);
+    let index = vec.binarySearch(value);
     if (index != #found i) {
       Debug.print("binarySearch failed for value = " # Nat.toText(value) # ", expected #found " # Nat.toText(i) # ", got " # debug_show (index));
       Debug.print("vec = " # debug_show (vec));
       return false
     };
-    let notFoundIndex = List.binarySearch(vec, Nat.compare, value + 1);
+    let notFoundIndex = vec.binarySearch(value + 1);
     if (notFoundIndex != #insertionIndex(i + 1)) {
       Debug.print("binarySearch should have returned null for value = " # Nat.toText(value + 1) # ", but got " # debug_show (notFoundIndex));
       return false
@@ -1712,7 +1712,7 @@ func testBinarySearch(n : Nat) : Bool {
   };
   do {
     let vec = List.repeat<Nat>(0, n);
-    switch (List.binarySearch(vec, Nat.compare, 0)) {
+    switch (vec.binarySearch(0)) {
       case (#insertionIndex index) {
         Debug.print("binarySearch on all-equal elements failed, expected #found 0, got #insertionIndex " # Nat.toText(index));
         return false
@@ -1720,7 +1720,7 @@ func testBinarySearch(n : Nat) : Bool {
       case (_) {}
     }
   };
-  List.binarySearch(vec, Nat.compare, n * 2) == #insertionIndex(n)
+  vec.binarySearch(n * 2) == #insertionIndex(n)
 };
 
 func testFlatten(n : Nat) : Bool {
@@ -2074,8 +2074,8 @@ Test.suite(
     Test.test(
       "binarySearch",
       func() {
-        let result1 = List.binarySearch<Nat>(empty, Nat.compare, 0);
-        let result2 = List.binarySearch<Nat>(emptied, Nat.compare, 0);
+        let result1 = empty.binarySearch<Nat>(0);
+        let result2 = emptied.binarySearch<Nat>(0);
         Test.expect.bool(result1 == #insertionIndex(0)).equal(true);
         Test.expect.bool(result2 == #insertionIndex(0)).equal(true)
       }
@@ -2091,7 +2091,7 @@ Test.suite(
       "found",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 5);
+        let result = list.binarySearch<Nat>(5);
         Test.expect.bool(result == #found(2)).equal(true)
       }
     );
@@ -2099,7 +2099,7 @@ Test.suite(
       "not found",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 6);
+        let result = list.binarySearch<Nat>(6);
         Test.expect.bool(result == #insertionIndex(3)).equal(true)
       }
     );
@@ -2107,7 +2107,7 @@ Test.suite(
       "first element",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 1);
+        let result = list.binarySearch<Nat>(1);
         Test.expect.bool(result == #found(0)).equal(true)
       }
     );
@@ -2115,7 +2115,7 @@ Test.suite(
       "last element",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 11);
+        let result = list.binarySearch<Nat>(11);
         Test.expect.bool(result == #found(5)).equal(true)
       }
     );
@@ -2123,7 +2123,7 @@ Test.suite(
       "single element found",
       func() {
         let list = List.fromArray<Nat>([42]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 42);
+        let result = list.binarySearch<Nat>(42);
         Test.expect.bool(result == #found(0)).equal(true)
       }
     );
@@ -2131,7 +2131,7 @@ Test.suite(
       "single element not found",
       func() {
         let list = List.fromArray<Nat>([42]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 43);
+        let result = list.binarySearch<Nat>(43);
         Test.expect.bool(result == #insertionIndex(1)).equal(true)
       }
     );
@@ -2139,7 +2139,7 @@ Test.suite(
       "duplicates",
       func() {
         let list = List.fromArray<Nat>([1, 2, 2, 2, 3]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 2);
+        let result = list.binarySearch<Nat>(2);
         let ok = switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -256,7 +256,7 @@ run(
     [
       test(
         "values",
-        list.values().toArray(),
+        list.toArray(),
         M.equals(T.array(T.natTestable, Nat.rangeInclusive(0, n).toArray()))
       ),
       test(
@@ -310,7 +310,7 @@ run(
       ),
       test(
         "init with values",
-        List.repeat<Nat>(0, n).values().toArray(),
+        List.repeat<Nat>(0, n).toArray(),
         M.equals(T.array(T.natTestable, Array.tabulate<Nat>(n, func(_) = 0)))
       ),
       test(
@@ -320,7 +320,7 @@ run(
       ),
       test(
         "add many with vals",
-        for_add_many.values().toArray(),
+        for_add_many.toArray(),
         M.equals(T.array(T.natTestable, Array.tabulate<Nat>(2 * n, func(_) = 0)))
       ),
       test(

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -320,7 +320,7 @@ run(
       ),
       test(
         "add many with vals",
-        (for_add_many.values()).toArray(),
+        for_add_many.values().toArray(),
         M.equals(T.array(T.natTestable, Array.tabulate<Nat>(2 * n, func(_) = 0)))
       ),
       test(

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -582,7 +582,7 @@ run(
         do {
           let map = Map.fromIter<Nat, Text>(Iter.fromArray<(Nat, Text)>([(0, "0")]), Nat.compare);
           assert (map.get(0) == ?"0");
-          assert (Map.equal(map, Map.singleton<Nat, Text>(0, "0"), Nat.compare, Text.equal));
+          assert (map.equal(Map.singleton<Nat, Text>(0, "0")));
           map.size()
         },
         M.equals(T.nat(1))
@@ -999,7 +999,7 @@ run(
           for (index in Nat.range(0, smallSize)) {
             assert (map.get(index) == ?Nat.toText(index))
           };
-          assert (Map.equal(map, smallMap(), Nat.compare, Text.equal));
+          assert (map.equal(smallMap()));
           map.size()
         },
         M.equals(T.nat(smallSize))

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -35,7 +35,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           map.add(0, "0");
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -44,7 +44,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert map.insert(0, "0");
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -53,7 +53,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           map.remove(0);
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -62,7 +62,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert (not map.delete(0));
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -95,12 +95,12 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.empty<Nat, Text>().entries()),
+        (Map.empty<Nat, Text>().entries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.empty<Nat, Text>().reverseEntries()),
+        (Map.empty<Nat, Text>().reverseEntries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
@@ -173,12 +173,12 @@ run(
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.empty<Nat, Text>().keys()),
+        (Map.empty<Nat, Text>().keys()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.empty<Nat, Text>().values()),
+        (Map.empty<Nat, Text>().values()).toArray(),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
@@ -334,7 +334,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.add(0, "1");
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -343,7 +343,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.add(1, "1");
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -352,7 +352,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (not map.insert(0, "1"));
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -361,7 +361,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert map.insert(1, "1");
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -370,7 +370,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.remove(0);
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -379,7 +379,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.remove(1);
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -388,7 +388,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (map.delete(0));
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -397,7 +397,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (not map.delete(1));
-          Iter.toArray(map.entries())
+          (map.entries()).toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -441,12 +441,12 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.singleton<Nat, Text>(0, "0").entries()),
+        (Map.singleton<Nat, Text>(0, "0").entries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.singleton<Nat, Text>(0, "0").reverseEntries()),
+        (Map.singleton<Nat, Text>(0, "0").reverseEntries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
@@ -569,12 +569,12 @@ run(
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.singleton<Nat, Text>(0, "0").keys()),
+        (Map.singleton<Nat, Text>(0, "0").keys()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.singleton<Nat, Text>(0, "0").values()),
+        (Map.singleton<Nat, Text>(0, "0").values()).toArray(),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
@@ -823,7 +823,7 @@ run(
           let original = smallMap();
           let copy = smallMap();
           let clone = original.clone();
-          let keys = Iter.toArray(original.keys());
+          let keys = (original.keys()).toArray();
           for (key in keys.vals()) {
             original.add(key, "X")
           };
@@ -836,7 +836,7 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(smallMap().entries()),
+        (smallMap().entries()).toArray(),
         M.equals(
           T.array<(Nat, Text)>(
             entryTestable,
@@ -846,7 +846,7 @@ run(
       ),
       test(
         "iterate backward",
-        Iter.toArray(smallMap().reverseEntries()),
+        (smallMap().reverseEntries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) }))))
       ),
       test(
@@ -983,12 +983,12 @@ run(
       ),
       test(
         "iterate keys",
-        Iter.toArray(smallMap().keys()),
+        (smallMap().keys()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "iterate values",
-        Iter.toArray(smallMap().values()),
+        (smallMap().values()).toArray(),
         M.equals(T.array<Text>(T.textTestable, Array.tabulate<Text>(smallSize, func(index) { Nat.toText(index) })))
       ),
       test(
@@ -1524,7 +1524,7 @@ Test.suite(
         map.add(2, "2");
         map.add(4, "4");
         func check(from : Nat, expected : [(Nat, Text)]) {
-          let actual = Iter.toArray(map.entriesFrom(from));
+          let actual = (map.entriesFrom(from)).toArray();
           Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
         };
         check(0, [(1, "1"), (2, "2"), (4, "4")]);
@@ -1543,8 +1543,8 @@ Test.suite(
         for (i in Nat.rangeBy(1, n, 2)) {
           map.add(i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(map.entriesFrom(j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(map.entries(), func(k, v) = k < j));
+            let actual = (map.entriesFrom(j)).toArray();
+            let expected = (Iter.dropWhile<(Nat, Text)>(map.entries(), func(k, v) = k < j)).toArray();
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }
@@ -1564,7 +1564,7 @@ Test.suite(
         map.add(2, "2");
         map.add(4, "4");
         func check(from : Nat, expected : [(Nat, Text)]) {
-          let actual = Iter.toArray(map.reverseEntriesFrom(from));
+          let actual = (map.reverseEntriesFrom(from)).toArray();
           Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
         };
         check(0, []);
@@ -1583,8 +1583,8 @@ Test.suite(
         for (i in Nat.rangeBy(1, n, 2)) {
           map.add(i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(map.reverseEntriesFrom(j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(map.reverseEntries(), func(k, v) = k > j));
+            let actual = (map.reverseEntriesFrom(j)).toArray();
+            let expected = (Iter.dropWhile<(Nat, Text)>(map.reverseEntries(), func(k, v) = k > j)).toArray();
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -826,10 +826,10 @@ run(
           let copy = smallMap();
           let clone = original.clone();
           let keys = original.keys().toArray();
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             original.add(key, "X")
           };
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             assert clone.get(key) == copy.get(key)
           };
           clone.size()

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -34,8 +34,8 @@ run(
         "add empty",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.add(map, Nat.compare, 0, "0");
-          Iter.toArray(Map.entries(map))
+          map.add(0, "0");
+          Iter.toArray(map.entries())
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -44,7 +44,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert map.insert(0, "0");
-          Iter.toArray(Map.entries(map))
+          Iter.toArray(map.entries())
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -53,7 +53,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           map.remove(0);
-          Iter.toArray(Map.entries(map))
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -62,7 +62,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert (not map.delete(0));
-          Iter.toArray(Map.entries(map))
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -78,8 +78,8 @@ run(
         "clone",
         do {
           let original = Map.empty<Nat, Text>();
-          let clone = Map.clone(original);
-          Map.size(clone)
+          let clone = original.clone();
+          clone.size()
         },
         M.equals(T.nat(0))
       ),
@@ -87,20 +87,20 @@ run(
         "clone no alias",
         do {
           let original = Map.empty<Nat, Text>();
-          let clone = Map.clone(original);
+          let clone = original.clone();
           original.add(0, "0");
-          Map.size(clone)
+          clone.size()
         },
         M.equals(T.nat(0))
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.entries(Map.empty<Nat, Text>())),
+        Iter.toArray(Map.empty<Nat, Text>().entries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.reverseEntries(Map.empty<Nat, Text>())),
+        Iter.toArray(Map.empty<Nat, Text>().reverseEntries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
@@ -132,7 +132,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert (map.replace(0, "0") == null);
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -140,8 +140,8 @@ run(
         "clear",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.clear(map);
-          Map.isEmpty(map)
+          map.clear();
+          map.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -159,7 +159,7 @@ run(
         "maximum entry",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.maxEntry(map)
+          map.maxEntry()
         },
         M.equals(T.optional(entryTestable, null : ?(Nat, Text)))
       ),
@@ -167,25 +167,25 @@ run(
         "minimum entry",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.minEntry(map)
+          map.minEntry()
         },
         M.equals(T.optional(entryTestable, null : ?(Nat, Text)))
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.keys(Map.empty<Nat, Text>())),
+        Iter.toArray(Map.empty<Nat, Text>().keys()),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.values(Map.empty<Nat, Text>())),
+        Iter.toArray(Map.empty<Nat, Text>().values()),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
         "from iterator",
         do {
           let map = Map.fromIter<Nat, Text>(Iter.fromArray<(Nat, Text)>([]));
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -193,13 +193,12 @@ run(
         "for each",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(_, _) {
               assert false
             }
           );
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -212,7 +211,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -220,13 +219,12 @@ run(
         "map",
         do {
           let input = Map.empty<Nat, Text>();
-          let output = Map.map<Nat, Text, Int>(
-            input,
+          let output = input.map<Nat, Text, Int>(
             func(_, _) {
               Runtime.trap("test failed")
             }
           );
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -239,7 +237,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -247,8 +245,7 @@ run(
         "fold left",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.foldLeft<Nat, Text, Nat>(
-            map,
+          map.foldLeft<Nat, Text, Nat>(
             0,
             func(_, _, _) {
               Runtime.trap("test failed")
@@ -261,8 +258,7 @@ run(
         "fold right",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.foldRight<Nat, Text, Nat>(
-            map,
+          map.foldRight<Nat, Text, Nat>(
             0,
             func(_, _, _) {
               Runtime.trap("test failed")
@@ -275,8 +271,7 @@ run(
         "all",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.all<Nat, Text>(
-            map,
+          map.all<Nat, Text>(
             func(_, _) {
               Runtime.trap("test failed")
             }
@@ -288,8 +283,7 @@ run(
         "any",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.any<Nat, Text>(
-            map,
+          map.any<Nat, Text>(
             func(_, _) {
               Runtime.trap("test failed")
             }
@@ -311,7 +305,7 @@ run(
           let map1 = Map.empty<Nat, Text>();
           let map2 = Map.empty<Nat, Text>();
           // NOTE: Can't make both compare's implicit because of the name overlap
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -339,8 +333,8 @@ run(
         "add singleton old",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.add(map, Nat.compare, 0, "1");
-          Iter.toArray(Map.entries(map))
+          map.add(0, "1");
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -348,8 +342,8 @@ run(
         "add singleton new",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.add(map, Nat.compare, 1, "1");
-          Iter.toArray(Map.entries(map))
+          map.add(1, "1");
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -357,8 +351,8 @@ run(
         "insert singleton old",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert (not Map.insert(map, Nat.compare, 0, "1"));
-          Iter.toArray(Map.entries(map))
+          assert (not map.insert(0, "1"));
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -366,8 +360,8 @@ run(
         "insert singleton new",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert Map.insert(map, Nat.compare, 1, "1");
-          Iter.toArray(Map.entries(map))
+          assert map.insert(1, "1");
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -375,8 +369,8 @@ run(
         "remove singleton old",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.remove(map, Nat.compare, 0);
-          Iter.toArray(Map.entries(map))
+          map.remove(0);
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -384,8 +378,8 @@ run(
         "remove singleton new",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.remove(map, Nat.compare, 1);
-          Iter.toArray(Map.entries(map))
+          map.remove(1);
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -393,8 +387,8 @@ run(
         "delete singleton old",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.delete(map, Nat.compare, 0));
-          Iter.toArray(Map.entries(map))
+          assert (map.delete(0));
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -402,8 +396,8 @@ run(
         "delete singleton new",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert (not Map.delete(map, Nat.compare, 1));
-          Iter.toArray(Map.entries(map))
+          assert (not map.delete(1));
+          Iter.toArray(map.entries())
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -411,7 +405,7 @@ run(
         "take function result",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.take(map, Nat.compare, 0)
+          map.take(0)
         },
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
@@ -419,8 +413,8 @@ run(
         "take map result",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          ignore Map.take(map, Nat.compare, 0);
-          Map.size(map)
+          ignore map.take(0);
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -428,9 +422,9 @@ run(
         "clone",
         do {
           let original = Map.singleton<Nat, Text>(0, "0");
-          let clone = Map.clone(original);
-          assert (Map.equal(original, clone, Nat.compare, Text.equal));
-          Map.size(clone)
+          let clone = original.clone();
+          assert (original.equal(clone));
+          clone.size()
         },
         M.equals(T.nat(1))
       ),
@@ -438,28 +432,28 @@ run(
         "clone no alias",
         do {
           let original = Map.singleton<Nat, Text>(0, "0");
-          let clone = Map.clone(original);
-          Map.add(original, Nat.compare, 0, "1");
-          assert (Map.get(clone, Nat.compare, 0) == ?"0");
-          Map.size(clone)
+          let clone = original.clone();
+          original.add(0, "1");
+          assert (clone.get(0) == ?"0");
+          clone.size()
         },
         M.equals(T.nat(1))
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.entries(Map.singleton<Nat, Text>(0, "0"))),
+        Iter.toArray(Map.singleton<Nat, Text>(0, "0").entries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.reverseEntries(Map.singleton<Nat, Text>(0, "0"))),
+        Iter.toArray(Map.singleton<Nat, Text>(0, "0").reverseEntries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
         "contains present key",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.containsKey(map, Nat.compare, 0)
+          map.containsKey(0)
         },
         M.equals(T.bool(true))
       ),
@@ -467,7 +461,7 @@ run(
         "contains absent key",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.containsKey(map, Nat.compare, 1)
+          map.containsKey(1)
         },
         M.equals(T.bool(false))
       ),
@@ -475,7 +469,7 @@ run(
         "get present",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.get(map, Nat.compare, 0)
+          map.get(0)
         },
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
@@ -483,7 +477,7 @@ run(
         "get absent",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.get(map, Nat.compare, 1)
+          map.get(1)
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -491,7 +485,7 @@ run(
         "update present",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.swap(map, Nat.compare, 0, "Zero")
+          map.swap(0, "Zero")
         },
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
@@ -499,7 +493,7 @@ run(
         "update absent",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.swap(map, Nat.compare, 1, "1")
+          map.swap(1, "1")
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -507,8 +501,8 @@ run(
         "replace if exists present",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.replace(map, Nat.compare, 0, "Zero") == ?"0");
-          Map.size(map)
+          assert (map.replace(0, "Zero") == ?"0");
+          map.size()
         },
         M.equals(T.nat(1))
       ),
@@ -516,8 +510,8 @@ run(
         "replace if exists absent",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.replace(map, Nat.compare, 1, "1") == null);
-          Map.size(map)
+          assert (map.replace(1, "1") == null);
+          map.size()
         },
         M.equals(T.nat(1))
       ),
@@ -525,8 +519,8 @@ run(
         "delete",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          assert Map.delete(map, Nat.compare, 0);
-          Map.size(map)
+          assert map.delete(0);
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -534,8 +528,8 @@ run(
         "clear",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.clear(map);
-          Map.isEmpty(map)
+          map.clear();
+          map.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -544,7 +538,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          map1.equal(map2)
         },
         M.equals(T.bool(true))
       ),
@@ -553,7 +547,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(1, "1");
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          map1.equal(map2)
         },
         M.equals(T.bool(false))
       ),
@@ -561,7 +555,7 @@ run(
         "maximum entry",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.maxEntry(map)
+          map.maxEntry()
         },
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
@@ -569,27 +563,27 @@ run(
         "minimum entry",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.minEntry(map)
+          map.minEntry()
         },
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.keys(Map.singleton<Nat, Text>(0, "0"))),
+        Iter.toArray(Map.singleton<Nat, Text>(0, "0").keys()),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.values(Map.singleton<Nat, Text>(0, "0"))),
+        Iter.toArray(Map.singleton<Nat, Text>(0, "0").values()),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
         "from iterator",
         do {
           let map = Map.fromIter<Nat, Text>(Iter.fromArray<(Nat, Text)>([(0, "0")]), Nat.compare);
-          assert (Map.get(map, Nat.compare, 0) == ?"0");
+          assert (map.get(0) == ?"0");
           assert (Map.equal(map, Map.singleton<Nat, Text>(0, "0"), Nat.compare, Text.equal));
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(1))
       ),
@@ -597,14 +591,13 @@ run(
         "for each",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(key, value) {
               assert (key == 0);
               assert (value == "0")
             }
           );
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(1))
       ),
@@ -612,17 +605,14 @@ run(
         "filter",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filter<Nat, Text>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filter<Nat, Text>(func(key, value) {
               assert (key == 0);
               assert (value == "0");
               true
             }
           );
-          assert (Map.equal(input, output, Nat.compare, Text.equal));
-          Map.size(output)
+          assert (input.equal(output));
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -630,16 +620,15 @@ run(
         "map",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.map<Nat, Text, Int>(
-            input,
+          let output = input.map<Nat, Text, Int>(
             func(key, value) {
               assert (key == 0);
               assert (value == "0");
               +key
             }
           );
-          assert (Map.get(output, Nat.compare, 0) == ?+0);
-          Map.size(output)
+          assert (output.get(0) == ?+0);
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -647,17 +636,14 @@ run(
         "filter map",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filterMap<Nat, Text, Int>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filterMap<Nat, Text, Int>(func(key, value) {
               assert (key == 0);
               assert (value == "0");
               ?+key
             }
           );
-          assert (Map.get(output, Nat.compare, 0) == ?+0);
-          Map.size(output)
+          assert (output.get(0) == ?+0);
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -665,8 +651,7 @@ run(
         "fold left",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.foldLeft<Nat, Text, Nat>(
-            map,
+          map.foldLeft<Nat, Text, Nat>(
             0,
             func(accumulator, key, value) {
               accumulator + key
@@ -679,8 +664,7 @@ run(
         "fold right",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.foldRight<Nat, Text, Nat>(
-            map,
+          map.foldRight<Nat, Text, Nat>(
             0,
             func(key, value, accumulator) {
               key + accumulator
@@ -693,8 +677,7 @@ run(
         "all",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.all<Nat, Text>(
-            map,
+          map.all<Nat, Text>(
             func(key, value) {
               key == 1 and value == "1"
             }
@@ -706,8 +689,7 @@ run(
         "not all",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.all<Nat, Text>(
-            map,
+          map.all<Nat, Text>(
             func(key, value) {
               key == 0
             }
@@ -719,8 +701,7 @@ run(
         "any",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.any<Nat, Text>(
-            map,
+          map.any<Nat, Text>(
             func(key, value) {
               key == 1 and value == "1"
             }
@@ -732,8 +713,7 @@ run(
         "not any",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.any<Nat, Text>(
-            map,
+          map.any<Nat, Text>(
             func(key, value) {
               key == 0
             }
@@ -745,7 +725,7 @@ run(
         "to text",
         do {
           let map = Map.singleton<Nat, Text>(1, "1");
-          Map.toText<Nat, Text>(map, Nat.toText, func(value) { value })
+          map.toText()
         },
         M.equals(T.text("Map{(1, 1)}"))
       ),
@@ -754,7 +734,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(1, "1");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -764,7 +744,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(0, "Zero");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -774,7 +754,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -784,7 +764,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(1, "1");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -794,7 +774,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "Zero");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -808,7 +788,7 @@ let smallSize = 100;
 func smallMap() : Map.Map<Nat, Text> {
   let map = Map.empty<Nat, Text>();
   for (index in Nat.range(0, smallSize)) {
-    Map.add(map, Nat.compare, index, Nat.toText(index))
+    map.add(index, Nat.toText(index))
   };
   map
 };
@@ -831,9 +811,9 @@ run(
         "clone",
         do {
           let original = smallMap();
-          let clone = Map.clone(original);
-          assert (Map.equal(original, clone, Nat.compare, Text.equal));
-          Map.size(clone)
+          let clone = original.clone();
+          assert (original.equal(clone));
+          clone.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -842,21 +822,21 @@ run(
         do {
           let original = smallMap();
           let copy = smallMap();
-          let clone = Map.clone(original);
-          let keys = Iter.toArray(Map.keys(original));
+          let clone = original.clone();
+          let keys = Iter.toArray(original.keys());
           for (key in keys.vals()) {
-            Map.add(original, Nat.compare, key, "X")
+            original.add(key, "X")
           };
           for (key in keys.vals()) {
-            assert Map.get(clone, Nat.compare, key) == Map.get(copy, Nat.compare, key)
+            assert clone.get(key) == copy.get(key)
           };
-          Map.size(clone)
+          clone.size()
         },
         M.equals(T.nat(smallSize))
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.entries(smallMap())),
+        Iter.toArray(smallMap().entries()),
         M.equals(
           T.array<(Nat, Text)>(
             entryTestable,
@@ -866,7 +846,7 @@ run(
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.reverseEntries(smallMap())),
+        Iter.toArray(smallMap().reverseEntries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) }))))
       ),
       test(
@@ -874,7 +854,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.containsKey(map, Nat.compare, index))
+            assert (map.containsKey(index))
           };
           true
         },
@@ -884,7 +864,7 @@ run(
         "contains absent key",
         do {
           let map = smallMap();
-          Map.containsKey(map, Nat.compare, smallSize)
+          map.containsKey(smallSize)
         },
         M.equals(T.bool(false))
       ),
@@ -893,7 +873,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
           true
         },
@@ -903,7 +883,7 @@ run(
         "get absent",
         do {
           let map = smallMap();
-          Map.get(map, Nat.compare, smallSize)
+          map.get(smallSize)
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -912,7 +892,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.swap(map, Nat.compare, index, Nat.toText(index) # "!") == ?Nat.toText(index))
+            assert (map.swap(index, Nat.toText(index) # "!") == ?Nat.toText(index))
           };
           true
         },
@@ -922,7 +902,7 @@ run(
         "update absent",
         do {
           let map = smallMap();
-          Map.swap(map, Nat.compare, smallSize, Nat.toText(smallSize))
+          map.swap(smallSize, Nat.toText(smallSize))
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -931,9 +911,9 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.replace(map, Nat.compare, index, Nat.toText(index) # "!") == ?Nat.toText(index))
+            assert (map.replace(index, Nat.toText(index) # "!") == ?Nat.toText(index))
           };
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -941,8 +921,8 @@ run(
         "replace if exists absent",
         do {
           let map = smallMap();
-          assert (Map.replace(map, Nat.compare, smallSize, Nat.toText(smallSize)) == null);
-          Map.size(map)
+          assert (map.replace(smallSize, Nat.toText(smallSize)) == null);
+          map.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -951,9 +931,9 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert Map.delete(map, Nat.compare, index)
+            assert map.delete(index)
           };
-          Map.isEmpty(map)
+          map.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -961,8 +941,8 @@ run(
         "clear",
         do {
           let map = smallMap();
-          Map.clear(map);
-          Map.isEmpty(map)
+          map.clear();
+          map.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -971,7 +951,7 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          map1.equal(map2)
         },
         M.equals(T.bool(true))
       ),
@@ -980,8 +960,8 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          assert Map.delete(map2, Nat.compare, smallSize - 1 : Nat);
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          assert map2.delete(smallSize - 1 : Nat);
+          map1.equal(map2)
         },
         M.equals(T.bool(false))
       ),
@@ -989,7 +969,7 @@ run(
         "maximum entry",
         do {
           let map = smallMap();
-          Map.maxEntry(map)
+          map.maxEntry()
         },
         M.equals(T.optional(entryTestable, ?(smallSize - 1 : Nat, Nat.toText(smallSize - 1))))
       ),
@@ -997,18 +977,18 @@ run(
         "minimum entry",
         do {
           let map = smallMap();
-          Map.minEntry(map)
+          map.minEntry()
         },
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.keys(smallMap())),
+        Iter.toArray(smallMap().keys()),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.values(smallMap())),
+        Iter.toArray(smallMap().values()),
         M.equals(T.array<Text>(T.textTestable, Array.tabulate<Text>(smallSize, func(index) { Nat.toText(index) })))
       ),
       test(
@@ -1017,10 +997,10 @@ run(
           let array = Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) });
           let map = Map.fromIter<Nat, Text>(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
           assert (Map.equal(map, smallMap(), Nat.compare, Text.equal));
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1029,15 +1009,14 @@ run(
         do {
           let map = smallMap();
           var index = 0;
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(key, value) {
               assert (key == index);
               assert (value == Nat.toText(index));
               index += 1
             }
           );
-          Map.size(map)
+          map.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1045,24 +1024,21 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = Map.filter<Nat, Text>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filter<Nat, Text>(func(key, value) {
               key % 2 == 0
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            let present = Map.containsKey(output, Nat.compare, index);
+            let present = output.containsKey(index);
             if (index % 2 == 0) {
               assert (present);
-              assert (Map.get(output, Nat.compare, index) == ?Nat.toText(index))
+              assert (output.get(index) == ?Nat.toText(index))
             } else {
               assert (not present);
-              assert (Map.get(output, Nat.compare, index) == null)
+              assert (output.get(index) == null)
             }
           };
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1070,16 +1046,15 @@ run(
         "map",
         do {
           let input = smallMap();
-          let output = Map.map<Nat, Text, Int>(
-            input,
+          let output = input.map<Nat, Text, Int>(
             func(key, value) {
               +key
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(output, Nat.compare, index) == ?+index)
+            assert (output.get(index) == ?+index)
           };
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1087,10 +1062,7 @@ run(
         "filter map",
         do {
           let input = smallMap();
-          let output = Map.filterMap<Nat, Text, Int>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filterMap<Nat, Text, Int>(func(key, value) {
               if (key % 2 == 0) {
                 ?+key
               } else {
@@ -1099,16 +1071,16 @@ run(
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            let present = Map.containsKey(output, Nat.compare, index);
+            let present = output.containsKey(index);
             if (index % 2 == 0) {
               assert (present);
-              assert (Map.get(output, Nat.compare, index) == ?+index)
+              assert (output.get(index) == ?+index)
             } else {
               assert (not present);
-              assert (Map.get(output, Nat.compare, index) == null)
+              assert (output.get(index) == null)
             }
           };
-          Map.size(output)
+          output.size()
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1116,8 +1088,7 @@ run(
         "fold left",
         do {
           let map = smallMap();
-          Map.foldLeft<Nat, Text, Nat>(
-            map,
+          map.foldLeft<Nat, Text, Nat>(
             0,
             func(accumulator, key, value) {
               accumulator + key
@@ -1130,8 +1101,7 @@ run(
         "fold right",
         do {
           let map = smallMap();
-          Map.foldRight<Nat, Text, Nat>(
-            map,
+          map.foldRight<Nat, Text, Nat>(
             0,
             func(key, value, accumulator) {
               key + accumulator
@@ -1144,8 +1114,7 @@ run(
         "all",
         do {
           let map = smallMap();
-          Map.all<Nat, Text>(
-            map,
+          map.all<Nat, Text>(
             func(key, value) {
               key < smallSize
             }
@@ -1157,8 +1126,7 @@ run(
         "any",
         do {
           let map = smallMap();
-          Map.any<Nat, Text>(
-            map,
+          map.any<Nat, Text>(
             func(key, value) {
               key == (smallSize - 1 : Nat)
             }
@@ -1170,7 +1138,7 @@ run(
         "to text",
         do {
           let map = smallMap();
-          Map.toText<Nat, Text>(map, Nat.toText, func(value) { value })
+          map.toText()
         },
         do {
           var text = "Map{";
@@ -1188,9 +1156,9 @@ run(
         "compare less key",
         do {
           let map1 = smallMap();
-          assert Map.delete(map1, Nat.compare, smallSize - 1 : Nat);
+          assert map1.delete(smallSize - 1 : Nat);
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -1200,8 +1168,8 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          ignore Map.swap(map2, Nat.compare, smallSize - 1 : Nat, "Last");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          ignore map2.swap(smallSize - 1 : Nat, "Last");
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -1211,7 +1179,7 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -1221,8 +1189,8 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          assert Map.delete(map2, Nat.compare, smallSize - 1 : Nat);
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert map2.delete(smallSize - 1 : Nat);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -1231,9 +1199,9 @@ run(
         "compare greater value",
         do {
           let map1 = smallMap();
-          ignore Map.swap(map1, Nat.compare, smallSize - 1 : Nat, "Last");
+          ignore map1.swap(smallSize - 1 : Nat, "Last");
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -1269,16 +1237,16 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            Map.add(map, Nat.compare, index, Nat.toText(index));
-            assert (Map.size(map) == index + 1);
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            map.add(index, Nat.toText(index));
+            assert (map.size() == index + 1);
+            assert (map.get(index) == ?Nat.toText(index))
           };
           for (index in Nat.range(0, numberOfEntries)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
-          assert (Map.get(map, Nat.compare, numberOfEntries) == null);
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          assert (map.get(numberOfEntries) == null);
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(numberOfEntries))
       ),
@@ -1287,17 +1255,17 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            assert Map.insert(map, Nat.compare, index, Nat.toText(index));
-            assert (Map.size(map) == index + 1);
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert map.insert(index, Nat.toText(index));
+            assert (map.size() == index + 1);
+            assert (map.get(index) == ?Nat.toText(index))
           };
           for (index in Nat.range(0, numberOfEntries)) {
-            assert (not Map.insert(map, Nat.compare, index, Nat.toText(index)));
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (not map.insert(index, Nat.toText(index)));
+            assert (map.get(index) == ?Nat.toText(index))
           };
-          assert (Map.get(map, Nat.compare, numberOfEntries) == null);
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          assert (map.get(numberOfEntries) == null);
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(numberOfEntries))
       ),
@@ -1308,12 +1276,12 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            ignore Map.swap(map, Nat.compare, key, Nat.toText(key))
+            ignore map.swap(key, Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.get(map, Nat.compare, key) == ?Nat.toText(key))
+            assert (map.get(key) == ?Nat.toText(key))
           };
           true
         },
@@ -1326,22 +1294,22 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            ignore Map.swap(map, Nat.compare, key, Nat.toText(key))
+            ignore map.swap(key, Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.containsKey(map, Nat.compare, key));
-            let oldValue = Map.swap(map, Nat.compare, key, Nat.toText(key) # "!");
+            assert (map.containsKey(key));
+            let oldValue = map.swap(key, Nat.toText(key) # "!");
             assert (oldValue != null)
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.containsKey(map, Nat.compare, key));
-            assert (Map.get(map, Nat.compare, key) == ?(Nat.toText(key) # "!"))
+            assert (map.containsKey(key));
+            assert (map.get(key) == ?(Nat.toText(key) # "!"))
           };
-          Map.assertValid(map, Nat.compare);
+          map.assertValid();
           true
         },
         M.equals(T.bool(true))
@@ -1353,27 +1321,27 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            ignore Map.swap(map, Nat.compare, key, Nat.toText(key))
+            ignore map.swap(key, Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.containsKey(map, Nat.compare, key));
-            assert (Map.get(map, Nat.compare, key) == ?Nat.toText(key))
+            assert (map.containsKey(key));
+            assert (map.get(key) == ?Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            if (Map.containsKey(map, Nat.compare, key)) {
-              Map.remove(map, Nat.compare, key);
-              assert (not Map.containsKey(map, Nat.compare, key))
+            if (map.containsKey(key)) {
+              map.remove(key);
+              assert (not map.containsKey(key))
             } else {
-              Map.remove(map, Nat.compare, key)
+              map.remove(key)
             };
-            assert (Map.get(map, Nat.compare, key) == null)
+            assert (map.get(key) == null)
           };
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1384,27 +1352,27 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            ignore Map.swap(map, Nat.compare, key, Nat.toText(key))
+            ignore map.swap(key, Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.containsKey(map, Nat.compare, key));
-            assert (Map.get(map, Nat.compare, key) == ?Nat.toText(key))
+            assert (map.containsKey(key));
+            assert (map.get(key) == ?Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            if (Map.containsKey(map, Nat.compare, key)) {
-              assert Map.delete(map, Nat.compare, key);
-              assert (not Map.containsKey(map, Nat.compare, key))
+            if (map.containsKey(key)) {
+              assert map.delete(key);
+              assert (not map.containsKey(key))
             } else {
-              assert not Map.delete(map, Nat.compare, key)
+              assert not map.delete(key)
             };
-            assert (Map.get(map, Nat.compare, key) == null)
+            assert (map.get(key) == null)
           };
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1415,27 +1383,27 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            ignore Map.swap(map, Nat.compare, key, Nat.toText(key))
+            ignore map.swap(key, Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            assert (Map.containsKey(map, Nat.compare, key));
-            assert (Map.get(map, Nat.compare, key) == ?Nat.toText(key))
+            assert (map.containsKey(key));
+            assert (map.get(key) == ?Nat.toText(key))
           };
           random.reset();
           for (index in Nat.range(0, numberOfEntries)) {
             let key = random.next();
-            if (Map.containsKey(map, Nat.compare, key)) {
-              assert Map.take(map, Nat.compare, key) == ?(Nat.toText(key));
-              assert (not Map.containsKey(map, Nat.compare, key))
+            if (map.containsKey(key)) {
+              assert map.take(key) == ?(Nat.toText(key));
+              assert (not map.containsKey(key))
             } else {
-              assert Map.take(map, Nat.compare, key) == null
+              assert map.take(key) == null
             };
-            assert (Map.get(map, Nat.compare, key) == null)
+            assert (map.get(key) == null)
           };
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1444,10 +1412,10 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            Map.add(map, Nat.compare, index, Nat.toText(index))
+            map.add(index, Nat.toText(index))
           };
           var index = 0;
-          for ((key, value) in Map.entries(map)) {
+          for ((key, value) in map.entries()) {
             assert (key == index);
             assert (value == Nat.toText(index));
             index += 1
@@ -1461,10 +1429,10 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            Map.add(map, Nat.compare, index, Nat.toText(index))
+            map.add(index, Nat.toText(index))
           };
           var index = numberOfEntries;
-          for ((key, value) in Map.reverseEntries(map)) {
+          for ((key, value) in map.reverseEntries()) {
             index -= 1;
             assert (key == index);
             assert (value == Nat.toText(index))
@@ -1485,9 +1453,9 @@ run(
         "add disjoint",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.add(map, Nat.compare, 0, "0");
-          Map.add(map, Nat.compare, 1, "1");
-          Map.size(map)
+          map.add(0, "0");
+          map.add(1, "1");
+          map.size()
         },
         M.equals(T.nat(2))
       ),
@@ -1495,9 +1463,9 @@ run(
         "put existing",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.add(map, Nat.compare, 0, "0");
-          Map.add(map, Nat.compare, 0, "Zero");
-          Map.get(map, Nat.compare, 0)
+          map.add(0, "0");
+          map.add(0, "Zero");
+          map.get(0)
         },
         M.equals(T.optional(T.textTestable, ?"Zero"))
       )
@@ -1514,14 +1482,14 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            Map.add(map, Nat.compare, index, Nat.toText(index))
+            map.add(index, Nat.toText(index))
           };
-          let pureMap = Map.toPure(map, Nat.compare);
+          let pureMap = map.toPure();
           for (index in Nat.range(0, numberOfEntries)) {
-            assert (PureMap.get(pureMap, Nat.compare, index) == ?Nat.toText(index))
+            assert (pureMap.get(index) == ?Nat.toText(index))
           };
-          PureMap.assertValid(pureMap, Nat.compare);
-          PureMap.size(pureMap)
+          pureMap.assertValid();
+          pureMap.size
         },
         M.equals(T.nat(numberOfEntries))
       ),
@@ -1530,14 +1498,14 @@ run(
         do {
           var pureMap = PureMap.empty<Nat, Text>();
           for (index in Nat.range(0, numberOfEntries)) {
-            pureMap := PureMap.add(pureMap, Nat.compare, index, Nat.toText(index))
+            pureMap := pureMap.add(index, Nat.toText(index))
           };
-          let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
+          let map = Map.fromPure<Nat, Text>(pureMap);
           for (index in Nat.range(0, numberOfEntries)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          map.assertValid();
+          map.size()
         },
         M.equals(T.nat(numberOfEntries))
       )
@@ -1552,11 +1520,11 @@ Test.suite(
       "Simple",
       func() {
         let map = Map.empty<Nat, Text>();
-        Map.add(map, Nat.compare, 1, "1");
-        Map.add(map, Nat.compare, 2, "2");
-        Map.add(map, Nat.compare, 4, "4");
+        map.add(1, "1");
+        map.add(2, "2");
+        map.add(4, "4");
         func check(from : Nat, expected : [(Nat, Text)]) {
-          let actual = Iter.toArray(Map.entriesFrom(map, Nat.compare, from));
+          let actual = Iter.toArray(map.entriesFrom(from));
           Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
         };
         check(0, [(1, "1"), (2, "2"), (4, "4")]);
@@ -1573,10 +1541,10 @@ Test.suite(
         let map = Map.empty<Nat, Text>();
         let n = 100;
         for (i in Nat.rangeBy(1, n, 2)) {
-          Map.add(map, Nat.compare, i, Nat.toText(i));
+          map.add(i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(Map.entriesFrom(map, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(Map.entries(map), func(k, v) = k < j));
+            let actual = Iter.toArray(map.entriesFrom(j));
+            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(map.entries(), func(k, v) = k < j));
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }
@@ -1592,11 +1560,11 @@ Test.suite(
       "Simple",
       func() {
         let map = Map.empty<Nat, Text>();
-        Map.add(map, Nat.compare, 1, "1");
-        Map.add(map, Nat.compare, 2, "2");
-        Map.add(map, Nat.compare, 4, "4");
+        map.add(1, "1");
+        map.add(2, "2");
+        map.add(4, "4");
         func check(from : Nat, expected : [(Nat, Text)]) {
-          let actual = Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, from));
+          let actual = Iter.toArray(map.reverseEntriesFrom(from));
           Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
         };
         check(0, []);
@@ -1613,10 +1581,10 @@ Test.suite(
         let map = Map.empty<Nat, Text>();
         let n = 100;
         for (i in Nat.rangeBy(1, n, 2)) {
-          Map.add(map, Nat.compare, i, Nat.toText(i));
+          map.add(i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(Map.reverseEntries(map), func(k, v) = k > j));
+            let actual = Iter.toArray(map.reverseEntriesFrom(j));
+            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(map.reverseEntries(), func(k, v) = k > j));
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -35,7 +35,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           map.add(0, "0");
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -44,7 +44,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert map.insert(0, "0");
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array(entryTestable, [(0, "0")]))
       ),
@@ -53,7 +53,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           map.remove(0);
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -62,7 +62,7 @@ run(
         do {
           let map = Map.empty<Nat, Text>();
           assert (not map.delete(0));
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -95,12 +95,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Map.empty<Nat, Text>().entries()).toArray(),
+        Map.empty<Nat, Text>().entries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "iterate backward",
-        (Map.empty<Nat, Text>().reverseEntries()).toArray(),
+        Map.empty<Nat, Text>().reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
@@ -173,12 +173,12 @@ run(
       ),
       test(
         "iterate keys",
-        (Map.empty<Nat, Text>().keys()).toArray(),
+        Map.empty<Nat, Text>().keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate values",
-        (Map.empty<Nat, Text>().values()).toArray(),
+        Map.empty<Nat, Text>().values().toArray(),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
@@ -334,7 +334,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.add(0, "1");
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -343,7 +343,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.add(1, "1");
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -352,7 +352,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (not map.insert(0, "1"));
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "1")]))
       ),
@@ -361,7 +361,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert map.insert(1, "1");
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0"), (1, "1")]))
       ),
@@ -370,7 +370,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.remove(0);
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -379,7 +379,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           map.remove(1);
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -388,7 +388,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (map.delete(0));
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
@@ -397,7 +397,7 @@ run(
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
           assert (not map.delete(1));
-          (map.entries()).toArray()
+          map.entries().toArray()
         },
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
@@ -441,12 +441,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Map.singleton<Nat, Text>(0, "0").entries()).toArray(),
+        Map.singleton<Nat, Text>(0, "0").entries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
         "iterate backward",
-        (Map.singleton<Nat, Text>(0, "0").reverseEntries()).toArray(),
+        Map.singleton<Nat, Text>(0, "0").reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, [(0, "0")]))
       ),
       test(
@@ -569,12 +569,12 @@ run(
       ),
       test(
         "iterate keys",
-        (Map.singleton<Nat, Text>(0, "0").keys()).toArray(),
+        Map.singleton<Nat, Text>(0, "0").keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate values",
-        (Map.singleton<Nat, Text>(0, "0").values()).toArray(),
+        Map.singleton<Nat, Text>(0, "0").values().toArray(),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
@@ -823,7 +823,7 @@ run(
           let original = smallMap();
           let copy = smallMap();
           let clone = original.clone();
-          let keys = (original.keys()).toArray();
+          let keys = original.keys().toArray();
           for (key in keys.vals()) {
             original.add(key, "X")
           };
@@ -836,7 +836,7 @@ run(
       ),
       test(
         "iterate forward",
-        (smallMap().entries()).toArray(),
+        smallMap().entries().toArray(),
         M.equals(
           T.array<(Nat, Text)>(
             entryTestable,
@@ -846,7 +846,7 @@ run(
       ),
       test(
         "iterate backward",
-        (smallMap().reverseEntries()).toArray(),
+        smallMap().reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) }))))
       ),
       test(
@@ -983,12 +983,12 @@ run(
       ),
       test(
         "iterate keys",
-        (smallMap().keys()).toArray(),
+        smallMap().keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "iterate values",
-        (smallMap().values()).toArray(),
+        smallMap().values().toArray(),
         M.equals(T.array<Text>(T.textTestable, Array.tabulate<Text>(smallSize, func(index) { Nat.toText(index) })))
       ),
       test(

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -605,7 +605,8 @@ run(
         "filter",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = input.filter<Nat, Text>(func(key, value) {
+          let output = input.filter<Nat, Text>(
+            func(key, value) {
               assert (key == 0);
               assert (value == "0");
               true
@@ -636,7 +637,8 @@ run(
         "filter map",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = input.filterMap<Nat, Text, Int>(func(key, value) {
+          let output = input.filterMap<Nat, Text, Int>(
+            func(key, value) {
               assert (key == 0);
               assert (value == "0");
               ?+key
@@ -1024,7 +1026,8 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = input.filter<Nat, Text>(func(key, value) {
+          let output = input.filter<Nat, Text>(
+            func(key, value) {
               key % 2 == 0
             }
           );
@@ -1062,7 +1065,8 @@ run(
         "filter map",
         do {
           let input = smallMap();
-          let output = input.filterMap<Nat, Text, Int>(func(key, value) {
+          let output = input.filterMap<Nat, Text, Int>(
+            func(key, value) {
               if (key % 2 == 0) {
                 ?+key
               } else {

--- a/test/PriorityQueue.test.mo
+++ b/test/PriorityQueue.test.mo
@@ -35,7 +35,7 @@ suite(
       "push",
       func() {
         let priorityQueue = PriorityQueue.empty<Nat>();
-        PriorityQueue.push(priorityQueue, Nat.compare, 42);
+        priorityQueue.push(42);
         expect.nat(PriorityQueue.size(priorityQueue)).equal(1);
         let top = PriorityQueue.peek(priorityQueue);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(?42)
@@ -56,7 +56,7 @@ suite(
       "pop",
       func() {
         let priorityQueue = PriorityQueue.empty<Nat>();
-        let top = PriorityQueue.pop(priorityQueue, Nat.compare);
+        let top = priorityQueue.pop();
         expect.bool(PriorityQueue.isEmpty(priorityQueue)).equal(true);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(null)
       }
@@ -94,7 +94,7 @@ suite(
       "push smaller",
       func() {
         let priorityQueue = PriorityQueue.singleton<Nat>(42);
-        PriorityQueue.push(priorityQueue, Nat.compare, 41);
+        priorityQueue.push(41);
         expect.nat(PriorityQueue.size(priorityQueue)).equal(2);
         let top = PriorityQueue.peek(priorityQueue);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(?42)
@@ -105,7 +105,7 @@ suite(
       "push equal",
       func() {
         let priorityQueue = PriorityQueue.singleton<Nat>(42);
-        PriorityQueue.push(priorityQueue, Nat.compare, 42);
+        priorityQueue.push(42);
         expect.nat(PriorityQueue.size(priorityQueue)).equal(2);
         let top = PriorityQueue.peek(priorityQueue);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(?42)
@@ -116,7 +116,7 @@ suite(
       "push larger",
       func() {
         let priorityQueue = PriorityQueue.singleton<Nat>(42);
-        PriorityQueue.push(priorityQueue, Nat.compare, 43);
+        priorityQueue.push(43);
         expect.nat(PriorityQueue.size(priorityQueue)).equal(2);
         let top = PriorityQueue.peek(priorityQueue);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(?43)
@@ -137,7 +137,7 @@ suite(
       "pop",
       func() {
         let priorityQueue = PriorityQueue.singleton<Nat>(42);
-        let top = PriorityQueue.pop(priorityQueue, Nat.compare);
+        let top = priorityQueue.pop();
         expect.bool(PriorityQueue.isEmpty(priorityQueue)).equal(true);
         expect.option<Nat>(top, Nat.toText, Nat.equal).equal(?42)
       }
@@ -557,15 +557,15 @@ suite(
       func() {
         let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5, 9, 2, 6].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(8);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?9);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?6);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?4);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?3);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?2);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?1);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?1);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(null)
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?9);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?6);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?5);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?4);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?3);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?2);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?1);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?1);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(null)
       }
     );
 
@@ -574,10 +574,10 @@ suite(
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 5, 5].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(3);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
-        expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(null)
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?5);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?5);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(?5);
+        expect.option<Nat>(pq.pop(), Nat.toText, Nat.equal).equal(null)
       }
     )
   }
@@ -610,8 +610,8 @@ suite(
       func() {
         let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
         let copy = PriorityQueue.clone(original);
-        ignore PriorityQueue.pop(copy, Nat.compare);
-        ignore PriorityQueue.pop(copy, Nat.compare);
+        ignore copy.pop();
+        ignore copy.pop();
         expect.nat(PriorityQueue.size(copy)).equal(1);
         expect.nat(PriorityQueue.size(original)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(original), Nat.toText, Nat.equal).equal(?10)
@@ -639,7 +639,7 @@ suite(
       "empty queue",
       func() {
         let pq = PriorityQueue.empty<Nat>();
-        let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        let vals = Iter.toArray(pq.values());
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([])
       }
     );
@@ -648,7 +648,7 @@ suite(
       "singleton",
       func() {
         let pq = PriorityQueue.singleton<Nat>(42);
-        let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        let vals = Iter.toArray(pq.values());
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([42])
       }
     );
@@ -657,7 +657,7 @@ suite(
       "yields elements in descending priority order",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        let vals = Iter.toArray(pq.values());
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([10, 5, 3])
       }
     );
@@ -666,7 +666,7 @@ suite(
       "does not modify the original queue",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        ignore Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        ignore Iter.toArray(pq.values());
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?10)
       }
@@ -676,7 +676,7 @@ suite(
       "with duplicates",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5].values(), Nat.compare);
-        let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        let vals = Iter.toArray(pq.values());
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([5, 4, 3, 1, 1])
       }
     );
@@ -685,8 +685,8 @@ suite(
       "can be called multiple times",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([2, 7, 1].values(), Nat.compare);
-        let vals1 = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
-        let vals2 = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
+        let vals1 = Iter.toArray(pq.values());
+        let vals2 = Iter.toArray(pq.values());
         expect.array<Nat>(vals1, Nat.toText, Nat.equal).equal([7, 2, 1]);
         expect.array<Nat>(vals2, Nat.toText, Nat.equal).equal([7, 2, 1])
       }

--- a/test/PriorityQueue.test.mo
+++ b/test/PriorityQueue.test.mo
@@ -639,7 +639,7 @@ suite(
       "empty queue",
       func() {
         let pq = PriorityQueue.empty<Nat>();
-        let vals = Iter.toArray(pq.values());
+        let vals = (pq.values()).toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([])
       }
     );
@@ -648,7 +648,7 @@ suite(
       "singleton",
       func() {
         let pq = PriorityQueue.singleton<Nat>(42);
-        let vals = Iter.toArray(pq.values());
+        let vals = (pq.values()).toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([42])
       }
     );
@@ -657,7 +657,7 @@ suite(
       "yields elements in descending priority order",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        let vals = Iter.toArray(pq.values());
+        let vals = (pq.values()).toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([10, 5, 3])
       }
     );
@@ -666,7 +666,7 @@ suite(
       "does not modify the original queue",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        ignore Iter.toArray(pq.values());
+        ignore (pq.values()).toArray();
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?10)
       }
@@ -676,7 +676,7 @@ suite(
       "with duplicates",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5].values(), Nat.compare);
-        let vals = Iter.toArray(pq.values());
+        let vals = (pq.values()).toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([5, 4, 3, 1, 1])
       }
     );
@@ -685,8 +685,8 @@ suite(
       "can be called multiple times",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([2, 7, 1].values(), Nat.compare);
-        let vals1 = Iter.toArray(pq.values());
-        let vals2 = Iter.toArray(pq.values());
+        let vals1 = (pq.values()).toArray();
+        let vals2 = (pq.values()).toArray();
         expect.array<Nat>(vals1, Nat.toText, Nat.equal).equal([7, 2, 1]);
         expect.array<Nat>(vals2, Nat.toText, Nat.equal).equal([7, 2, 1])
       }

--- a/test/PriorityQueue.test.mo
+++ b/test/PriorityQueue.test.mo
@@ -639,7 +639,7 @@ suite(
       "empty queue",
       func() {
         let pq = PriorityQueue.empty<Nat>();
-        let vals = (pq.values()).toArray();
+        let vals = pq.values().toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([])
       }
     );
@@ -648,7 +648,7 @@ suite(
       "singleton",
       func() {
         let pq = PriorityQueue.singleton<Nat>(42);
-        let vals = (pq.values()).toArray();
+        let vals = pq.values().toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([42])
       }
     );
@@ -657,7 +657,7 @@ suite(
       "yields elements in descending priority order",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        let vals = (pq.values()).toArray();
+        let vals = pq.values().toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([10, 5, 3])
       }
     );
@@ -666,7 +666,7 @@ suite(
       "does not modify the original queue",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
-        ignore (pq.values()).toArray();
+        ignore pq.values().toArray();
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?10)
       }
@@ -676,7 +676,7 @@ suite(
       "with duplicates",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5].values(), Nat.compare);
-        let vals = (pq.values()).toArray();
+        let vals = pq.values().toArray();
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([5, 4, 3, 1, 1])
       }
     );
@@ -685,8 +685,8 @@ suite(
       "can be called multiple times",
       func() {
         let pq = PriorityQueue.fromIter<Nat>([2, 7, 1].values(), Nat.compare);
-        let vals1 = (pq.values()).toArray();
-        let vals2 = (pq.values()).toArray();
+        let vals1 = pq.values().toArray();
+        let vals2 = pq.values().toArray();
         expect.array<Nat>(vals1, Nat.toText, Nat.equal).equal([7, 2, 1]);
         expect.array<Nat>(vals2, Nat.toText, Nat.equal).equal([7, 2, 1])
       }

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -83,7 +83,7 @@ suite(
     test(
       "values",
       func() {
-        assert (Queue.values(Queue.empty<Nat>())).toArray() == []
+        assert (Queue.empty<Nat>().values()).toArray() == []
       }
     );
 
@@ -197,7 +197,7 @@ suite(
     test(
       "vals",
       func() {
-        assert (Queue.values(Queue.singleton<Nat>(0))).toArray() == [0]
+        assert (Queue.singleton<Nat>(0).values()).toArray() == [0]
       }
     );
 
@@ -255,7 +255,7 @@ suite(
         Queue.pushFront(queue, 1);
         Queue.pushFront(queue, 2);
         Queue.pushFront(queue, 3);
-        assert (Queue.values(queue)).toArray() == [3, 2, 1]
+        assert (queue.values()).toArray() == [3, 2, 1]
       }
     );
 
@@ -266,7 +266,7 @@ suite(
         Queue.pushBack(queue, 1);
         Queue.pushBack(queue, 2);
         Queue.pushBack(queue, 3);
-        assert (Queue.values(queue)).toArray() == [1, 2, 3]
+        assert (queue.values()).toArray() == [1, 2, 3]
       }
     );
 
@@ -277,7 +277,7 @@ suite(
         Queue.pushFront(queue, 2);
         Queue.pushBack(queue, 3);
         Queue.pushFront(queue, 1);
-        assert (Queue.values(queue)).toArray() == [1, 2, 3]
+        assert (queue.values()).toArray() == [1, 2, 3]
       }
     )
   }
@@ -342,7 +342,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
         let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
-        assert (Queue.values(mapped)).toArray() == ["1", "2", "3"]
+        assert (mapped.values()).toArray() == ["1", "2", "3"]
       }
     );
 
@@ -351,7 +351,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
         let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
-        assert (Queue.values(filtered)).toArray() == [2, 4]
+        assert (filtered.values()).toArray() == [2, 4]
       }
     );
 
@@ -363,7 +363,7 @@ suite(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
         );
-        assert (Queue.values(result)).toArray() == ["2", "4"]
+        assert (result.values()).toArray() == ["2", "4"]
       }
     );
 
@@ -442,7 +442,7 @@ suite(
       func() {
         let queue = Queue.singleton<Nat>(1);
         let pureQueue = Queue.toPure(queue);
-        assert (PureQueue.values(pureQueue)).toArray() == [1]
+        assert (pureQueue.values()).toArray() == [1]
       }
     );
 
@@ -451,7 +451,7 @@ suite(
       func() {
         let pureQueue = PureQueue.pushBack(PureQueue.empty(), 1);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert (Queue.values(queue)).toArray() == [1]
+        assert (queue.values()).toArray() == [1]
       }
     );
 
@@ -460,7 +460,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
         let pureQueue = Queue.toPure(queue);
-        assert (PureQueue.values(pureQueue)).toArray() == [1, 2, 3]
+        assert (pureQueue.values()).toArray() == [1, 2, 3]
       }
     );
 
@@ -472,7 +472,7 @@ suite(
         pureQueue := PureQueue.pushBack(pureQueue, 2);
         pureQueue := PureQueue.pushBack(pureQueue, 3);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert (Queue.values(queue)).toArray() == [1, 2, 3]
+        assert (queue.values()).toArray() == [1, 2, 3]
       }
     );
 
@@ -482,7 +482,7 @@ suite(
         let original = Queue.fromIter<Nat>([1, 2, 3].vals());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
-        assert (Queue.values(roundTrip)).toArray() == [1, 2, 3]
+        assert (roundTrip.values()).toArray() == [1, 2, 3]
       }
     );
 
@@ -495,7 +495,7 @@ suite(
         original := PureQueue.pushBack(original, 3);
         let mutableQueue = Queue.fromPure<Nat>(original);
         let roundTrip = Queue.toPure(mutableQueue);
-        assert (PureQueue.values(roundTrip)).toArray() == [1, 2, 3]
+        assert (roundTrip.values()).toArray() == [1, 2, 3]
       }
     )
   }
@@ -590,7 +590,7 @@ suite(
           Queue.pushBack(queue, number)
         };
         var counter = 0;
-        for (number in Queue.values(queue)) {
+        for (number in queue.values()) {
           assert number == counter;
           counter += 1
         };
@@ -599,7 +599,7 @@ suite(
           assert Queue.popFront(queue) == ?number
         };
         counter := numberOfSteps / 2;
-        for (number in Queue.values(queue)) {
+        for (number in queue.values()) {
           assert number == counter;
           counter += 1
         };

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -289,7 +289,7 @@ suite(
     test(
       "pop front",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let results = [
           Queue.popFront(queue),
           Queue.popFront(queue),
@@ -304,7 +304,7 @@ suite(
     test(
       "pop back",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let results = [
           Queue.popBack(queue),
           Queue.popBack(queue),
@@ -319,7 +319,7 @@ suite(
     test(
       "mixed pop",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let results = [
           Queue.popFront(queue),
           Queue.popBack(queue),
@@ -340,7 +340,7 @@ suite(
     test(
       "map",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
         assert (mapped.values()).toArray() == ["1", "2", "3"]
       }
@@ -349,7 +349,7 @@ suite(
     test(
       "filter",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
         assert (filtered.values()).toArray() == [2, 4]
       }
@@ -358,7 +358,7 @@ suite(
     test(
       "filter map",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let result = Queue.filterMap<Nat, Text>(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
@@ -370,7 +370,7 @@ suite(
     test(
       "for each",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         var sum = 0;
         Queue.forEach<Nat>(queue, func n { sum += n });
         assert sum == 6
@@ -385,7 +385,7 @@ suite(
     test(
       "all true",
       func() {
-        let queue = Queue.fromIter<Nat>([2, 4, 6].vals());
+        let queue = Queue.fromIter<Nat>([2, 4, 6].values());
         assert Queue.all<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -393,7 +393,7 @@ suite(
     test(
       "all false",
       func() {
-        let queue = Queue.fromIter<Nat>([2, 3, 4].vals());
+        let queue = Queue.fromIter<Nat>([2, 3, 4].values());
         assert not Queue.all<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -401,7 +401,7 @@ suite(
     test(
       "any true",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         assert Queue.any<Nat>(queue, func n = n % 2 == 0)
       }
     );
@@ -409,7 +409,7 @@ suite(
     test(
       "any false",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 3, 5].vals());
+        let queue = Queue.fromIter<Nat>([1, 3, 5].values());
         assert not Queue.any<Nat>(queue, func n = n % 2 == 0)
       }
     )
@@ -458,7 +458,7 @@ suite(
     test(
       "multiple elements to pure",
       func() {
-        let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(queue);
         assert (pureQueue.values()).toArray() == [1, 2, 3]
       }
@@ -479,7 +479,7 @@ suite(
     test(
       "round trip mutable to pure to mutable",
       func() {
-        let original = Queue.fromIter<Nat>([1, 2, 3].vals());
+        let original = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
         assert (roundTrip.values()).toArray() == [1, 2, 3]

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -83,7 +83,7 @@ suite(
     test(
       "values",
       func() {
-        assert (Queue.empty<Nat>().values()).toArray() == []
+        assert Queue.empty<Nat>().values().toArray() == []
       }
     );
 
@@ -197,7 +197,7 @@ suite(
     test(
       "vals",
       func() {
-        assert (Queue.singleton<Nat>(0).values()).toArray() == [0]
+        assert Queue.singleton<Nat>(0).values().toArray() == [0]
       }
     );
 
@@ -255,7 +255,7 @@ suite(
         Queue.pushFront(queue, 1);
         Queue.pushFront(queue, 2);
         Queue.pushFront(queue, 3);
-        assert (queue.values()).toArray() == [3, 2, 1]
+        assert queue.values().toArray() == [3, 2, 1]
       }
     );
 
@@ -266,7 +266,7 @@ suite(
         Queue.pushBack(queue, 1);
         Queue.pushBack(queue, 2);
         Queue.pushBack(queue, 3);
-        assert (queue.values()).toArray() == [1, 2, 3]
+        assert queue.values().toArray() == [1, 2, 3]
       }
     );
 
@@ -277,7 +277,7 @@ suite(
         Queue.pushFront(queue, 2);
         Queue.pushBack(queue, 3);
         Queue.pushFront(queue, 1);
-        assert (queue.values()).toArray() == [1, 2, 3]
+        assert queue.values().toArray() == [1, 2, 3]
       }
     )
   }
@@ -342,7 +342,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
-        assert (mapped.values()).toArray() == ["1", "2", "3"]
+        assert mapped.values().toArray() == ["1", "2", "3"]
       }
     );
 
@@ -351,7 +351,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
-        assert (filtered.values()).toArray() == [2, 4]
+        assert filtered.values().toArray() == [2, 4]
       }
     );
 
@@ -363,7 +363,7 @@ suite(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
         );
-        assert (result.values()).toArray() == ["2", "4"]
+        assert result.values().toArray() == ["2", "4"]
       }
     );
 
@@ -442,7 +442,7 @@ suite(
       func() {
         let queue = Queue.singleton<Nat>(1);
         let pureQueue = Queue.toPure(queue);
-        assert (pureQueue.values()).toArray() == [1]
+        assert pureQueue.values().toArray() == [1]
       }
     );
 
@@ -451,7 +451,7 @@ suite(
       func() {
         let pureQueue = PureQueue.pushBack(PureQueue.empty(), 1);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert (queue.values()).toArray() == [1]
+        assert queue.values().toArray() == [1]
       }
     );
 
@@ -460,7 +460,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(queue);
-        assert (pureQueue.values()).toArray() == [1, 2, 3]
+        assert pureQueue.values().toArray() == [1, 2, 3]
       }
     );
 
@@ -472,7 +472,7 @@ suite(
         pureQueue := PureQueue.pushBack(pureQueue, 2);
         pureQueue := PureQueue.pushBack(pureQueue, 3);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert (queue.values()).toArray() == [1, 2, 3]
+        assert queue.values().toArray() == [1, 2, 3]
       }
     );
 
@@ -482,7 +482,7 @@ suite(
         let original = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
-        assert (roundTrip.values()).toArray() == [1, 2, 3]
+        assert roundTrip.values().toArray() == [1, 2, 3]
       }
     );
 
@@ -495,7 +495,7 @@ suite(
         original := PureQueue.pushBack(original, 3);
         let mutableQueue = Queue.fromPure<Nat>(original);
         let roundTrip = Queue.toPure(mutableQueue);
-        assert (roundTrip.values()).toArray() == [1, 2, 3]
+        assert roundTrip.values().toArray() == [1, 2, 3]
       }
     )
   }

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -83,7 +83,7 @@ suite(
     test(
       "values",
       func() {
-        assert Queue.empty<Nat>().values().toArray() == []
+        assert Queue.empty<Nat>().toArray() == []
       }
     );
 
@@ -197,7 +197,7 @@ suite(
     test(
       "vals",
       func() {
-        assert Queue.singleton<Nat>(0).values().toArray() == [0]
+        assert Queue.singleton<Nat>(0).toArray() == [0]
       }
     );
 
@@ -255,7 +255,7 @@ suite(
         Queue.pushFront(queue, 1);
         Queue.pushFront(queue, 2);
         Queue.pushFront(queue, 3);
-        assert queue.values().toArray() == [3, 2, 1]
+        assert queue.toArray() == [3, 2, 1]
       }
     );
 
@@ -266,7 +266,7 @@ suite(
         Queue.pushBack(queue, 1);
         Queue.pushBack(queue, 2);
         Queue.pushBack(queue, 3);
-        assert queue.values().toArray() == [1, 2, 3]
+        assert queue.toArray() == [1, 2, 3]
       }
     );
 
@@ -277,7 +277,7 @@ suite(
         Queue.pushFront(queue, 2);
         Queue.pushBack(queue, 3);
         Queue.pushFront(queue, 1);
-        assert queue.values().toArray() == [1, 2, 3]
+        assert queue.toArray() == [1, 2, 3]
       }
     )
   }
@@ -342,7 +342,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
-        assert mapped.values().toArray() == ["1", "2", "3"]
+        assert mapped.toArray() == ["1", "2", "3"]
       }
     );
 
@@ -351,7 +351,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
         let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
-        assert filtered.values().toArray() == [2, 4]
+        assert filtered.toArray() == [2, 4]
       }
     );
 
@@ -363,7 +363,7 @@ suite(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
         );
-        assert result.values().toArray() == ["2", "4"]
+        assert result.toArray() == ["2", "4"]
       }
     );
 
@@ -442,7 +442,7 @@ suite(
       func() {
         let queue = Queue.singleton<Nat>(1);
         let pureQueue = Queue.toPure(queue);
-        assert pureQueue.values().toArray() == [1]
+        assert pureQueue.toArray() == [1]
       }
     );
 
@@ -451,7 +451,7 @@ suite(
       func() {
         let pureQueue = PureQueue.pushBack(PureQueue.empty(), 1);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert queue.values().toArray() == [1]
+        assert queue.toArray() == [1]
       }
     );
 
@@ -460,7 +460,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(queue);
-        assert pureQueue.values().toArray() == [1, 2, 3]
+        assert pureQueue.toArray() == [1, 2, 3]
       }
     );
 
@@ -472,7 +472,7 @@ suite(
         pureQueue := PureQueue.pushBack(pureQueue, 2);
         pureQueue := PureQueue.pushBack(pureQueue, 3);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert queue.values().toArray() == [1, 2, 3]
+        assert queue.toArray() == [1, 2, 3]
       }
     );
 
@@ -482,7 +482,7 @@ suite(
         let original = Queue.fromIter<Nat>([1, 2, 3].values());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
-        assert roundTrip.values().toArray() == [1, 2, 3]
+        assert roundTrip.toArray() == [1, 2, 3]
       }
     );
 
@@ -495,7 +495,7 @@ suite(
         original := PureQueue.pushBack(original, 3);
         let mutableQueue = Queue.fromPure<Nat>(original);
         let roundTrip = Queue.toPure(mutableQueue);
-        assert roundTrip.values().toArray() == [1, 2, 3]
+        assert roundTrip.toArray() == [1, 2, 3]
       }
     )
   }

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -83,7 +83,7 @@ suite(
     test(
       "values",
       func() {
-        assert Iter.toArray(Queue.values(Queue.empty<Nat>())) == []
+        assert (Queue.values(Queue.empty<Nat>())).toArray() == []
       }
     );
 
@@ -197,7 +197,7 @@ suite(
     test(
       "vals",
       func() {
-        assert Iter.toArray(Queue.values(Queue.singleton<Nat>(0))) == [0]
+        assert (Queue.values(Queue.singleton<Nat>(0))).toArray() == [0]
       }
     );
 
@@ -255,7 +255,7 @@ suite(
         Queue.pushFront(queue, 1);
         Queue.pushFront(queue, 2);
         Queue.pushFront(queue, 3);
-        assert Iter.toArray(Queue.values(queue)) == [3, 2, 1]
+        assert (Queue.values(queue)).toArray() == [3, 2, 1]
       }
     );
 
@@ -266,7 +266,7 @@ suite(
         Queue.pushBack(queue, 1);
         Queue.pushBack(queue, 2);
         Queue.pushBack(queue, 3);
-        assert Iter.toArray(Queue.values(queue)) == [1, 2, 3]
+        assert (Queue.values(queue)).toArray() == [1, 2, 3]
       }
     );
 
@@ -277,7 +277,7 @@ suite(
         Queue.pushFront(queue, 2);
         Queue.pushBack(queue, 3);
         Queue.pushFront(queue, 1);
-        assert Iter.toArray(Queue.values(queue)) == [1, 2, 3]
+        assert (Queue.values(queue)).toArray() == [1, 2, 3]
       }
     )
   }
@@ -342,7 +342,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
         let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
-        assert Iter.toArray(Queue.values(mapped)) == ["1", "2", "3"]
+        assert (Queue.values(mapped)).toArray() == ["1", "2", "3"]
       }
     );
 
@@ -351,7 +351,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
         let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
-        assert Iter.toArray(Queue.values(filtered)) == [2, 4]
+        assert (Queue.values(filtered)).toArray() == [2, 4]
       }
     );
 
@@ -363,7 +363,7 @@ suite(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
         );
-        assert Iter.toArray(Queue.values(result)) == ["2", "4"]
+        assert (Queue.values(result)).toArray() == ["2", "4"]
       }
     );
 
@@ -442,7 +442,7 @@ suite(
       func() {
         let queue = Queue.singleton<Nat>(1);
         let pureQueue = Queue.toPure(queue);
-        assert Iter.toArray(PureQueue.values(pureQueue)) == [1]
+        assert (PureQueue.values(pureQueue)).toArray() == [1]
       }
     );
 
@@ -451,7 +451,7 @@ suite(
       func() {
         let pureQueue = PureQueue.pushBack(PureQueue.empty(), 1);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert Iter.toArray(Queue.values(queue)) == [1]
+        assert (Queue.values(queue)).toArray() == [1]
       }
     );
 
@@ -460,7 +460,7 @@ suite(
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
         let pureQueue = Queue.toPure(queue);
-        assert Iter.toArray(PureQueue.values(pureQueue)) == [1, 2, 3]
+        assert (PureQueue.values(pureQueue)).toArray() == [1, 2, 3]
       }
     );
 
@@ -472,7 +472,7 @@ suite(
         pureQueue := PureQueue.pushBack(pureQueue, 2);
         pureQueue := PureQueue.pushBack(pureQueue, 3);
         let queue = Queue.fromPure<Nat>(pureQueue);
-        assert Iter.toArray(Queue.values(queue)) == [1, 2, 3]
+        assert (Queue.values(queue)).toArray() == [1, 2, 3]
       }
     );
 
@@ -482,7 +482,7 @@ suite(
         let original = Queue.fromIter<Nat>([1, 2, 3].vals());
         let pureQueue = Queue.toPure(original);
         let roundTrip = Queue.fromPure<Nat>(pureQueue);
-        assert Iter.toArray(Queue.values(roundTrip)) == [1, 2, 3]
+        assert (Queue.values(roundTrip)).toArray() == [1, 2, 3]
       }
     );
 
@@ -495,7 +495,7 @@ suite(
         original := PureQueue.pushBack(original, 3);
         let mutableQueue = Queue.fromPure<Nat>(original);
         let roundTrip = Queue.toPure(mutableQueue);
-        assert Iter.toArray(PureQueue.values(roundTrip)) == [1, 2, 3]
+        assert (PureQueue.values(roundTrip)).toArray() == [1, 2, 3]
       }
     )
   }

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -31,7 +31,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.add(0);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -40,7 +40,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert set.insert(0);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -49,7 +49,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.remove(0);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -58,7 +58,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert (not set.delete(0));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -333,7 +333,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(0);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -342,7 +342,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(1);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -351,7 +351,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.insert(0));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -360,7 +360,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert set.insert(1);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -369,7 +369,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(0);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -378,7 +378,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(1);
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -387,7 +387,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (set.delete(0));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -396,7 +396,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.delete(1));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -748,7 +748,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(2);
           let union = set1.union(set2);
-          (union.values()).toArray()
+          union.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -763,7 +763,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let union = set1.union(set2);
-          (union.values()).toArray()
+          union.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -778,7 +778,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          (intersection.values()).toArray()
+          intersection.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -793,7 +793,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          (intersection.values()).toArray()
+          intersection.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -808,7 +808,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -823,7 +823,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -839,7 +839,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -857,7 +857,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = setOfSets.flatten();
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -944,7 +944,7 @@ run(
           let original = smallSet();
           let copy = smallSet();
           let clone = original.clone();
-          let keys = (original.values()).toArray();
+          let keys = original.values().toArray();
           for (key in keys.vals()) {
             original.remove(key)
           };
@@ -1261,7 +1261,7 @@ run(
           let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let union = Set.union(set1, set2, Int.compare);
-          (union.values()).toArray()
+          union.values().toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1283,7 +1283,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           Set.add(set2, Int.compare, 1);
           let intersection = Set.intersection(set1, set2, Int.compare);
-          (intersection.values()).toArray()
+          intersection.values().toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1301,7 +1301,7 @@ run(
           set2.remove(1);
           set2.remove(2);
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -1317,7 +1317,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1340,7 +1340,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
           let combined = Set.flatten(setOfSets, Int.compare);
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1560,7 +1560,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let union = set1.union(set2);
-          (union.values()).toArray()
+          union.values().toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1570,7 +1570,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let union = set1.union(set2);
-          (union.values()).toArray()
+          union.values().toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1640,7 +1640,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let intersection = set1.intersection(set2);
-          (intersection.values()).toArray()
+          intersection.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 3]))
       ),
@@ -1660,7 +1660,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1680,7 +1680,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1690,7 +1690,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let difference = set1.difference(set2);
-          (difference.values()).toArray()
+          difference.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1710,7 +1710,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           set1.addAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1720,7 +1720,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           set1.addAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1730,7 +1730,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           set1.addAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1740,7 +1740,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           set1.addAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1758,7 +1758,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1776,7 +1776,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n % 2 == 0 }));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 4]))
       ),
@@ -1785,7 +1785,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4, 5]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n > 2 and n < 5 }));
-          (set.values()).toArray()
+          set.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [3, 4]))
       ),
@@ -1805,7 +1805,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.deleteAll(set2.values()));
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1835,7 +1835,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (not (set1.deleteAll(set2.values())));
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1845,7 +1845,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.deleteAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1856,7 +1856,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.insertAll(set2.values()));
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1886,7 +1886,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (set1.insertAll(set2.values()));
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1896,7 +1896,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.insertAll(set2.values());
-          (set1.values()).toArray()
+          set1.values().toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -84,12 +84,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.values(Set.empty<Nat>())).toArray(),
+        (Set.empty<Nat>().values()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate backward",
-        (Set.reverseValues(Set.empty<Nat>())).toArray(),
+        (Set.empty<Nat>().reverseValues()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
@@ -426,12 +426,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.values(Set.singleton<Nat>(0))).toArray(),
+        (Set.singleton<Nat>(0).values()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backward",
-        (Set.reverseValues(Set.singleton<Nat>(0))).toArray(),
+        (Set.singleton<Nat>(0).reverseValues()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -514,12 +514,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.values(Set.singleton<Nat>(0))).toArray(),
+        (Set.singleton<Nat>(0).values()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backwards",
-        (Set.reverseValues(Set.singleton<Nat>(0))).toArray(),
+        (Set.singleton<Nat>(0).reverseValues()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -957,7 +957,7 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.values(smallSet())).toArray(),
+        (smallSet().values()).toArray(),
         M.equals(
           T.array<Nat>(
             T.natTestable,
@@ -967,7 +967,7 @@ run(
       ),
       test(
         "iterate backward",
-        (Set.reverseValues(smallSet())).toArray(),
+        (smallSet().reverseValues()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.reverse(Array.tabulate<Nat>(smallSize, func(index) { index }))))
       ),
       test(
@@ -1046,12 +1046,12 @@ run(
       ),
       test(
         "forward iteration",
-        (Set.values(smallSet())).toArray(),
+        (smallSet().values()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "backwards iteration",
-        (Set.reverseValues(smallSet())).toArray(),
+        (smallSet().reverseValues()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { smallSize - 1 - index : Nat })))
       ),
       test(
@@ -1528,7 +1528,7 @@ run(
             set.add(index)
           };
           var index = numberOfElements;
-          for (element in Set.reverseValues(set)) {
+          for (element in set.reverseValues()) {
             index -= 1;
             assert (element == index)
           };
@@ -1975,7 +1975,7 @@ Test.suite(
           set.add(i);
           for (j in Nat.range(0, i + 2)) {
             let actual = (set.reverseValuesFrom(j)).toArray();
-            let expected = (Iter.dropWhile<(Nat)>(Set.reverseValues(set), func(k) = k > j)).toArray();
+            let expected = (Iter.dropWhile<(Nat)>(set.reverseValues(), func(k) = k > j)).toArray();
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -945,10 +945,10 @@ run(
           let copy = smallSet();
           let clone = original.clone();
           let keys = original.values().toArray();
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             original.remove(key)
           };
-          for (key in keys.vals()) {
+          for (key in keys.values()) {
             assert clone.contains(key) == copy.contains(key)
           };
           clone.size()

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -31,7 +31,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.add(0);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -40,7 +40,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert set.insert(0);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -49,7 +49,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.remove(0);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -58,7 +58,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert (not set.delete(0));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -84,7 +84,7 @@ run(
       ),
       test(
         "iterate forward",
-        Set.empty<Nat>().values().toArray(),
+        Set.empty<Nat>().toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
@@ -333,7 +333,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(0);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -342,7 +342,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(1);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -351,7 +351,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.insert(0));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -360,7 +360,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert set.insert(1);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -369,7 +369,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(0);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -378,7 +378,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(1);
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -387,7 +387,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (set.delete(0));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -396,7 +396,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.delete(1));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -426,7 +426,7 @@ run(
       ),
       test(
         "iterate forward",
-        Set.singleton<Nat>(0).values().toArray(),
+        Set.singleton<Nat>(0).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -514,7 +514,7 @@ run(
       ),
       test(
         "iterate forward",
-        Set.singleton<Nat>(0).values().toArray(),
+        Set.singleton<Nat>(0).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -748,7 +748,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(2);
           let union = set1.union(set2);
-          union.values().toArray()
+          union.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -763,7 +763,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let union = set1.union(set2);
-          union.values().toArray()
+          union.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -778,7 +778,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          intersection.values().toArray()
+          intersection.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -793,7 +793,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          intersection.values().toArray()
+          intersection.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -808,7 +808,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -823,7 +823,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -839,7 +839,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          combined.values().toArray()
+          combined.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -857,7 +857,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = setOfSets.flatten();
-          combined.values().toArray()
+          combined.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -944,7 +944,7 @@ run(
           let original = smallSet();
           let copy = smallSet();
           let clone = original.clone();
-          let keys = original.values().toArray();
+          let keys = original.toArray();
           for (key in keys.values()) {
             original.remove(key)
           };
@@ -957,7 +957,7 @@ run(
       ),
       test(
         "iterate forward",
-        smallSet().values().toArray(),
+        smallSet().toArray(),
         M.equals(
           T.array<Nat>(
             T.natTestable,
@@ -1046,7 +1046,7 @@ run(
       ),
       test(
         "forward iteration",
-        smallSet().values().toArray(),
+        smallSet().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
@@ -1261,7 +1261,7 @@ run(
           let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let union = Set.union(set1, set2, Int.compare);
-          union.values().toArray()
+          union.toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1283,7 +1283,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           Set.add(set2, Int.compare, 1);
           let intersection = Set.intersection(set1, set2, Int.compare);
-          intersection.values().toArray()
+          intersection.toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1301,7 +1301,7 @@ run(
           set2.remove(1);
           set2.remove(2);
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -1317,7 +1317,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
-          combined.values().toArray()
+          combined.toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1340,7 +1340,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
           let combined = Set.flatten(setOfSets, Int.compare);
-          combined.values().toArray()
+          combined.toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1560,7 +1560,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let union = set1.union(set2);
-          union.values().toArray()
+          union.toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1570,7 +1570,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let union = set1.union(set2);
-          union.values().toArray()
+          union.toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1640,7 +1640,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let intersection = set1.intersection(set2);
-          intersection.values().toArray()
+          intersection.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 3]))
       ),
@@ -1660,7 +1660,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1680,7 +1680,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1690,7 +1690,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let difference = set1.difference(set2);
-          difference.values().toArray()
+          difference.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1710,7 +1710,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           set1.addAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1720,7 +1720,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           set1.addAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1730,7 +1730,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           set1.addAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1740,7 +1740,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           set1.addAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1758,7 +1758,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1776,7 +1776,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n % 2 == 0 }));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 4]))
       ),
@@ -1785,7 +1785,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4, 5]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n > 2 and n < 5 }));
-          set.values().toArray()
+          set.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [3, 4]))
       ),
@@ -1805,7 +1805,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.deleteAll(set2.values()));
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1835,7 +1835,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (not (set1.deleteAll(set2.values())));
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1845,7 +1845,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.deleteAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1856,7 +1856,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.insertAll(set2.values()));
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1886,7 +1886,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (set1.insertAll(set2.values()));
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1896,7 +1896,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.insertAll(set2.values());
-          set1.values().toArray()
+          set1.toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -31,7 +31,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.add(0);
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -40,7 +40,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert set.insert(0);
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -49,7 +49,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.remove(0);
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -58,7 +58,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert (not set.delete(0));
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -66,10 +66,10 @@ run(
         "clone no alias",
         do {
           let original = Set.empty<Nat>();
-          let clone = Set.clone(original);
-          Set.add(original, Nat.compare, 0);
-          assert Set.size(original) == 1;
-          Set.size(clone)
+          let clone = original.clone();
+          original.add(0);
+          assert original.size() == 1;
+          clone.size()
         },
         M.equals(T.nat(0))
       ),
@@ -77,8 +77,8 @@ run(
         "clone",
         do {
           let original = Set.empty<Nat>();
-          let clone = Set.clone(original);
-          Set.size(clone)
+          let clone = original.clone();
+          clone.size()
         },
         M.equals(T.nat(0))
       ),
@@ -96,7 +96,7 @@ run(
         "contains present",
         do {
           let set = Set.empty<Nat>();
-          Set.add(set, Nat.compare, 0);
+          set.add(0);
           set.contains(0)
         },
         M.equals(T.bool(true))
@@ -113,8 +113,8 @@ run(
         "clear",
         do {
           let set = Set.empty<Nat>();
-          Set.clear(set);
-          Set.isEmpty(set)
+          set.clear();
+          set.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -147,7 +147,7 @@ run(
         "from iterator",
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([]));
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -161,7 +161,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -174,7 +174,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -187,7 +187,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -200,7 +200,7 @@ run(
               Runtime.trap("test failed")
             }
           );
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(0))
       ),
@@ -280,7 +280,7 @@ run(
         "is sub-set",
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([]), Nat.compare);
-          let set2 = Set.clone(set1);
+          let set2 = set1.clone();
           set1.isSubset(set2)
         },
         M.equals(T.bool(true))
@@ -289,10 +289,10 @@ run(
         "join",
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([]), Nat.compare);
-          let set2 = Set.clone(set1);
-          let set3 = Set.clone(set2);
+          let set2 = set1.clone();
+          let set3 = set2.clone();
           let combined = Set.join(Iter.fromArray([set1, set2, set3]));
-          Set.size(combined)
+          combined.size()
         },
         M.equals(T.nat(0))
       ),
@@ -300,12 +300,12 @@ run(
         "flatten",
         do {
           let subSet1 = Set.fromIter(Iter.fromArray<Nat>([]), Nat.compare);
-          let subSet2 = Set.clone(subSet1);
-          let subSet3 = Set.clone(subSet2);
+          let subSet2 = subSet1.clone();
+          let subSet3 = subSet2.clone();
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = Set.flatten(setOfSets);
-          Set.size(combined)
+          combined.size()
         },
         M.equals(T.nat(0))
       ),
@@ -332,8 +332,8 @@ run(
         "add singleton old",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.add(set, Nat.compare, 0);
-          Iter.toArray(Set.values(set))
+          set.add(0);
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -341,8 +341,8 @@ run(
         "add singleton new",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.add(set, Nat.compare, 1);
-          Iter.toArray(Set.values(set))
+          set.add(1);
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -350,8 +350,8 @@ run(
         "insert singleton old",
         do {
           let set = Set.singleton<Nat>(0);
-          assert (not Set.insert(set, Nat.compare, 0));
-          Iter.toArray(Set.values(set))
+          assert (not set.insert(0));
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -359,8 +359,8 @@ run(
         "insert singleton new",
         do {
           let set = Set.singleton<Nat>(0);
-          assert Set.insert(set, Nat.compare, 1);
-          Iter.toArray(Set.values(set))
+          assert set.insert(1);
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -368,8 +368,8 @@ run(
         "remove singleton old",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.remove(set, Nat.compare, 0);
-          Iter.toArray(Set.values(set))
+          set.remove(0);
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -377,8 +377,8 @@ run(
         "remove singleton new",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.remove(set, Nat.compare, 1);
-          Iter.toArray(Set.values(set))
+          set.remove(1);
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -386,8 +386,8 @@ run(
         "delete singleton old",
         do {
           let set = Set.singleton<Nat>(0);
-          assert (Set.delete(set, Nat.compare, 0));
-          Iter.toArray(Set.values(set))
+          assert (set.delete(0));
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -395,8 +395,8 @@ run(
         "delete singleton new",
         do {
           let set = Set.singleton<Nat>(0);
-          assert (not Set.delete(set, Nat.compare, 1));
-          Iter.toArray(Set.values(set))
+          assert (not set.delete(1));
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -404,9 +404,9 @@ run(
         "clone",
         do {
           let original = Set.singleton<Nat>(0);
-          let clone = Set.clone(original);
-          assert (Set.equal(original, clone, Nat.compare));
-          Set.size(clone)
+          let clone = original.clone();
+          assert (original.equal(clone));
+          clone.size()
         },
         M.equals(T.nat(1))
       ),
@@ -414,13 +414,13 @@ run(
         "clone no alias",
         do {
           let original = Set.singleton<Nat>(0);
-          assert Set.size(original) == 1;
-          let clone = Set.clone(original);
-          Set.remove(original, Nat.compare, 0);
-          assert Set.size(original) == 0;
-          assert not Set.contains(original, Nat.compare, 0);
-          assert Set.contains(clone, Nat.compare, 0);
-          Set.size(clone)
+          assert original.size() == 1;
+          let clone = original.clone();
+          original.remove(0);
+          assert original.size() == 0;
+          assert not original.contains(0);
+          assert clone.contains(0);
+          clone.size()
         },
         M.equals(T.nat(1))
       ),
@@ -438,7 +438,7 @@ run(
         "contains present key",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.contains(set, Nat.compare, 0)
+          set.contains(0)
         },
         M.equals(T.bool(true))
       ),
@@ -446,7 +446,7 @@ run(
         "contains absent key",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.contains(set, Nat.compare, 1)
+          set.contains(1)
         },
         M.equals(T.bool(false))
       ),
@@ -454,9 +454,9 @@ run(
         "add duplicate",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.add(set, Nat.compare, 0);
-          assert (Set.contains(set, Nat.compare, 0));
-          Set.size(set)
+          set.add(0);
+          assert (set.contains(0));
+          set.size()
         },
         M.equals(T.nat(1))
       ),
@@ -464,8 +464,8 @@ run(
         "remove",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.remove(set, Nat.compare, 0);
-          Set.size(set)
+          set.remove(0);
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -473,8 +473,8 @@ run(
         "clear",
         do {
           let set = Set.singleton<Nat>(0);
-          Set.clear(set);
-          Set.isEmpty(set)
+          set.clear();
+          set.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -483,7 +483,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(0);
-          Set.equal(set1, set2, Nat.compare)
+          set1.equal(set2)
         },
         M.equals(T.bool(true))
       ),
@@ -492,7 +492,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          Set.equal(set1, set2, Nat.compare)
+          set1.equal(set2)
         },
         M.equals(T.bool(false))
       ),
@@ -526,9 +526,9 @@ run(
         "from iterator",
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([0]), Nat.compare);
-          assert (Set.contains(set, Nat.compare, 0));
+          assert (set.contains(0));
           assert (Set.equal(set, Set.singleton<Nat>(0), Nat.compare));
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(1))
       ),
@@ -542,7 +542,7 @@ run(
               assert (number == 0)
             }
           );
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(1))
       ),
@@ -558,8 +558,8 @@ run(
               true
             }
           );
-          assert (Set.equal(input, output, Nat.compare));
-          Set.size(output)
+          assert (input.equal(output));
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -576,7 +576,7 @@ run(
             }
           );
           assert (Set.contains(output, Int.compare, 0));
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -593,7 +593,7 @@ run(
             }
           );
           assert (Set.contains(output, Int.compare, 0));
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(1))
       ),
@@ -690,7 +690,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          assert (Set.compare(set1, set2, Nat.compare) == #less);
+          assert (set1.compare(set2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -700,7 +700,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(0);
-          assert (Set.compare(set1, set2, Nat.compare) == #equal);
+          assert (set1.compare(set2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -710,7 +710,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(0);
-          assert (Set.compare(set1, set2, Nat.compare) == #greater);
+          assert (set1.compare(set2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -720,7 +720,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(0);
-          Set.isSubset(set1, set2, Nat.compare)
+          set1.isSubset(set2)
         },
         M.equals(T.bool(true))
       ),
@@ -729,7 +729,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          Set.isSubset(set1, set2, Nat.compare)
+          set1.isSubset(set2)
         },
         M.equals(T.bool(false))
       ),
@@ -738,7 +738,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([0, 1, 2]), Nat.compare);
-          Set.isSubset(set1, set2, Nat.compare)
+          set1.isSubset(set2)
         },
         M.equals(T.bool(true))
       ),
@@ -747,8 +747,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(2);
-          let union = Set.union(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(union))
+          let union = set1.union(set2);
+          Iter.toArray(union.values())
         },
         M.equals(
           T.array<Nat>(
@@ -762,8 +762,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
-          let union = Set.union(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(union))
+          let union = set1.union(set2);
+          Iter.toArray(union.values())
         },
         M.equals(
           T.array<Nat>(
@@ -777,8 +777,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(intersection))
+          let intersection = set1.intersection(set2);
+          Iter.toArray(intersection.values())
         },
         M.equals(
           T.array<Nat>(
@@ -792,8 +792,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(intersection))
+          let intersection = set1.intersection(set2);
+          Iter.toArray(intersection.values())
         },
         M.equals(
           T.array<Nat>(
@@ -807,8 +807,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(
           T.array<Nat>(
@@ -822,8 +822,8 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(
           T.array<Nat>(
@@ -839,7 +839,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          Iter.toArray(Set.values(combined))
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Nat>(
@@ -855,9 +855,9 @@ run(
           let subSet2 = Set.singleton<Nat>(1);
           let subSet3 = Set.singleton<Nat>(2);
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
-          let combined = Set.flatten(setOfSets, Nat.compare);
-          Iter.toArray(Set.values(combined))
+          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
+          let combined = setOfSets.flatten();
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Nat>(
@@ -875,7 +875,7 @@ let smallSize = 100;
 func smallSet() : Set.Set<Nat> {
   let set = Set.empty<Nat>();
   for (index in Nat.range(0, smallSize)) {
-    Set.add(set, Nat.compare, index)
+    set.add(index)
   };
   set
 };
@@ -893,8 +893,8 @@ run(
         "size after clone",
         do {
           let set1 = smallSet();
-          let set2 = Set.clone(set1);
-          Set.size(set1) == Set.size(set2)
+          let set2 = set1.clone();
+          set1.size() == set2.size()
         },
         M.equals(T.bool(true))
       ),
@@ -902,10 +902,10 @@ run(
         "size after adding elements",
         do {
           let set = Set.empty<Nat>();
-          Set.add(set, Nat.compare, 1);
-          Set.add(set, Nat.compare, 2);
-          Set.add(set, Nat.compare, 3);
-          Set.size(set)
+          set.add(1);
+          set.add(2);
+          set.add(3);
+          set.size()
         },
         M.equals(T.nat(3))
       ),
@@ -913,13 +913,13 @@ run(
         "size after adding and removing elements",
         do {
           let set = Set.empty<Nat>();
-          Set.add(set, Nat.compare, 1);
-          Set.add(set, Nat.compare, 2);
-          Set.add(set, Nat.compare, 3);
-          Set.remove(set, Nat.compare, 1);
-          Set.remove(set, Nat.compare, 2);
-          Set.remove(set, Nat.compare, 3);
-          Set.size(set)
+          set.add(1);
+          set.add(2);
+          set.add(3);
+          set.remove(1);
+          set.remove(2);
+          set.remove(3);
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -932,9 +932,9 @@ run(
         "clone",
         do {
           let original = smallSet();
-          let clone = Set.clone(original);
-          assert (Set.equal(original, clone, Nat.compare));
-          Set.size(clone)
+          let clone = original.clone();
+          assert (original.equal(clone));
+          clone.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -943,15 +943,15 @@ run(
         do {
           let original = smallSet();
           let copy = smallSet();
-          let clone = Set.clone(original);
-          let keys = Iter.toArray(Set.values(original));
+          let clone = original.clone();
+          let keys = Iter.toArray(original.values());
           for (key in keys.vals()) {
-            Set.remove(original, Nat.compare, key)
+            original.remove(key)
           };
           for (key in keys.vals()) {
-            assert Set.contains(clone, Nat.compare, key) == Set.contains(copy, Nat.compare, key)
+            assert clone.contains(key) == copy.contains(key)
           };
-          Set.size(clone)
+          clone.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -975,7 +975,7 @@ run(
         do {
           let set = smallSet();
           for (index in Nat.range(0, smallSize)) {
-            assert (Set.contains(set, Nat.compare, index))
+            assert (set.contains(index))
           };
           true
         },
@@ -985,7 +985,7 @@ run(
         "contains absent",
         do {
           let set = smallSet();
-          Set.contains(set, Nat.compare, smallSize)
+          set.contains(smallSize)
         },
         M.equals(T.bool(false))
       ),
@@ -994,9 +994,9 @@ run(
         do {
           let set = smallSet();
           for (index in Nat.range(0, smallSize)) {
-            Set.remove(set, Nat.compare, index)
+            set.remove(index)
           };
-          Set.isEmpty(set)
+          set.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -1004,8 +1004,8 @@ run(
         "clear",
         do {
           let set = smallSet();
-          Set.clear(set);
-          Set.isEmpty(set)
+          set.clear();
+          set.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -1014,7 +1014,7 @@ run(
         do {
           let set1 = smallSet();
           let set2 = smallSet();
-          Set.equal(set1, set2, Nat.compare)
+          set1.equal(set2)
         },
         M.equals(T.bool(true))
       ),
@@ -1023,8 +1023,8 @@ run(
         do {
           let set1 = smallSet();
           let set2 = smallSet();
-          Set.remove(set2, Nat.compare, smallSize - 1 : Nat);
-          Set.equal(set1, set2, Nat.compare)
+          set2.remove(smallSize - 1 : Nat);
+          set1.equal(set2)
         },
         M.equals(T.bool(false))
       ),
@@ -1060,10 +1060,10 @@ run(
           let array = Array.tabulate<Nat>(smallSize, func(index) { index });
           let set = Set.fromIter<Nat>(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
-            assert (Set.contains(set, Nat.compare, index))
+            assert (set.contains(index))
           };
           assert (Set.equal(set, smallSet(), Nat.compare));
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1079,7 +1079,7 @@ run(
               index += 1
             }
           );
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1095,14 +1095,14 @@ run(
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            let present = Set.contains(output, Nat.compare, index);
+            let present = output.contains(index);
             if (index % 2 == 0) {
               assert (present)
             } else {
               assert (not present)
             }
           };
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1120,7 +1120,7 @@ run(
           for (index in Nat.range(0, smallSize)) {
             assert (Set.contains(output, Int.compare, index))
           };
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1147,7 +1147,7 @@ run(
               assert (not present)
             }
           };
-          Set.size(output)
+          output.size()
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1227,9 +1227,9 @@ run(
         "compare less key",
         do {
           let set1 = smallSet();
-          Set.remove(set1, Nat.compare, smallSize - 1 : Nat);
+          set1.remove(smallSize - 1 : Nat);
           let set2 = smallSet();
-          assert (Set.compare(set1, set2, Nat.compare) == #less);
+          assert (set1.compare(set2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -1239,7 +1239,7 @@ run(
         do {
           let set1 = smallSet();
           let set2 = smallSet();
-          assert (Set.compare(set1, set2, Nat.compare) == #equal);
+          assert (set1.compare(set2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -1249,8 +1249,8 @@ run(
         do {
           let set1 = smallSet();
           let set2 = smallSet();
-          Set.remove(set2, Nat.compare, smallSize - 1 : Nat);
-          assert (Set.compare(set1, set2, Nat.compare) == #greater);
+          set2.remove(smallSize - 1 : Nat);
+          assert (set1.compare(set2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -1261,7 +1261,7 @@ run(
           let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let union = Set.union(set1, set2, Int.compare);
-          Iter.toArray(Set.values(union))
+          Iter.toArray(union.values())
         },
         M.equals(
           T.array<Int>(
@@ -1283,7 +1283,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           Set.add(set2, Int.compare, 1);
           let intersection = Set.intersection(set1, set2, Int.compare);
-          Iter.toArray(Set.values(intersection))
+          Iter.toArray(intersection.values())
         },
         M.equals(
           T.array<Int>(
@@ -1297,11 +1297,11 @@ run(
         do {
           let set1 = smallSet();
           let set2 = smallSet();
-          Set.remove(set2, Nat.compare, 0);
-          Set.remove(set2, Nat.compare, 1);
-          Set.remove(set2, Nat.compare, 2);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          set2.remove(0);
+          set2.remove(1);
+          set2.remove(2);
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(
           T.array<Nat>(
@@ -1317,7 +1317,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
-          Iter.toArray(Set.values(combined))
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Int>(
@@ -1340,7 +1340,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
           let combined = Set.flatten(setOfSets, Int.compare);
-          Iter.toArray(Set.values(combined))
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Int>(
@@ -1385,16 +1385,16 @@ run(
         do {
           let set = Set.empty<Nat>();
           for (index in Nat.range(0, numberOfElements)) {
-            Set.add(set, Nat.compare, index);
-            assert (Set.size(set) == index + 1);
-            assert (Set.contains(set, Nat.compare, index))
+            set.add(index);
+            assert (set.size() == index + 1);
+            assert (set.contains(index))
           };
           for (index in Nat.range(0, numberOfElements)) {
-            assert (Set.contains(set, Nat.compare, index))
+            assert (set.contains(index))
           };
-          assert (not Set.contains(set, Nat.compare, numberOfElements));
-          Set.assertValid(set, Nat.compare);
-          Set.size(set)
+          assert (not set.contains(numberOfElements));
+          set.assertValid();
+          set.size()
         },
         M.equals(T.nat(numberOfElements))
       ),
@@ -1403,19 +1403,19 @@ run(
         do {
           let set = Set.empty<Nat>();
           for (index in Nat.range(0, numberOfElements)) {
-            assert (Set.insert(set, Nat.compare, index));
-            assert (Set.size(set) == index + 1);
-            assert (Set.contains(set, Nat.compare, index))
+            assert (set.insert(index));
+            assert (set.size() == index + 1);
+            assert (set.contains(index))
           };
           for (index in Nat.range(0, numberOfElements)) {
-            assert (not (Set.insert(set, Nat.compare, index)))
+            assert (not (set.insert(index)))
           };
           for (index in Nat.range(0, numberOfElements)) {
-            assert (Set.contains(set, Nat.compare, index))
+            assert (set.contains(index))
           };
-          assert (not Set.contains(set, Nat.compare, numberOfElements));
-          Set.assertValid(set, Nat.compare);
-          Set.size(set)
+          assert (not set.contains(numberOfElements));
+          set.assertValid();
+          set.size()
         },
         M.equals(T.nat(numberOfElements))
       ),
@@ -1426,14 +1426,14 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            if (not Set.contains(set, Nat.compare, element)) {
-              Set.add(set, Nat.compare, element)
+            if (not set.contains(element)) {
+              set.add(element)
             }
           };
           random.reset();
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            assert (Set.contains(set, Nat.compare, element))
+            assert (set.contains(element))
           };
           true
         },
@@ -1446,27 +1446,27 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            if (not Set.contains(set, Nat.compare, element)) {
-              Set.add(set, Nat.compare, element)
+            if (not set.contains(element)) {
+              set.add(element)
             }
           };
-          assert (Set.size(set) > 0);
+          assert (set.size() > 0);
           random.reset();
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            assert (Set.contains(set, Nat.compare, element))
+            assert (set.contains(element))
           };
           random.reset();
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            if (Set.contains(set, Nat.compare, element)) {
-              Set.remove(set, Nat.compare, element);
-              assert (not Set.contains(set, Nat.compare, element))
+            if (set.contains(element)) {
+              set.remove(element);
+              assert (not set.contains(element))
             };
-            assert (not Set.contains(set, Nat.compare, element))
+            assert (not set.contains(element))
           };
-          Set.assertValid(set, Nat.compare);
-          Set.size(set)
+          set.assertValid();
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1478,29 +1478,29 @@ run(
           let random = Random(randomSeed);
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            if (not Set.contains(set, Nat.compare, element)) {
-              Set.add(set, Nat.compare, element)
+            if (not set.contains(element)) {
+              set.add(element)
             }
           };
-          assert (Set.size(set) > 0);
+          assert (set.size() > 0);
           random.reset();
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            assert (Set.contains(set, Nat.compare, element))
+            assert (set.contains(element))
           };
           random.reset();
           for (index in Nat.range(0, numberOfElements)) {
             let element = random.next();
-            if (Set.contains(set, Nat.compare, element)) {
-              assert Set.delete(set, Nat.compare, element);
-              assert (not Set.contains(set, Nat.compare, element))
+            if (set.contains(element)) {
+              assert set.delete(element);
+              assert (not set.contains(element))
             } else {
-              assert (not Set.delete(set, Nat.compare, element))
+              assert (not set.delete(element))
             };
-            assert (not Set.contains(set, Nat.compare, element))
+            assert (not set.contains(element))
           };
-          Set.assertValid(set, Nat.compare);
-          Set.size(set)
+          set.assertValid();
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1509,10 +1509,10 @@ run(
         do {
           let set = Set.empty<Nat>();
           for (index in Nat.range(0, numberOfElements)) {
-            Set.add(set, Nat.compare, index)
+            set.add(index)
           };
           var index = 0;
-          for (element in Set.values(set)) {
+          for (element in set.values()) {
             assert (element == index);
             index += 1
           };
@@ -1525,7 +1525,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           for (index in Nat.range(0, numberOfElements)) {
-            Set.add(set, Nat.compare, index)
+            set.add(index)
           };
           var index = numberOfElements;
           for (element in Set.reverseValues(set)) {
@@ -1549,8 +1549,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          let union = Set.union(set1, set2, Nat.compare);
-          Set.size(union)
+          let union = set1.union(set2);
+          union.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1559,8 +1559,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let union = Set.union(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(union))
+          let union = set1.union(set2);
+          Iter.toArray(union.values())
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1569,8 +1569,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          let union = Set.union(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(union))
+          let union = set1.union(set2);
+          Iter.toArray(union.values())
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1579,8 +1579,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          let union = Set.union(set1, set2, Nat.compare);
-          Set.size(union)
+          let union = set1.union(set2);
+          union.size()
         },
         M.equals(T.nat(6))
       ),
@@ -1589,8 +1589,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          let union = Set.union(set1, set2, Nat.compare);
-          Set.size(union)
+          let union = set1.union(set2);
+          union.size()
         },
         M.equals(T.nat(4))
       ),
@@ -1599,8 +1599,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Set.size(intersection)
+          let intersection = set1.intersection(set2);
+          intersection.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1609,8 +1609,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Set.size(intersection)
+          let intersection = set1.intersection(set2);
+          intersection.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1619,8 +1619,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Set.size(intersection)
+          let intersection = set1.intersection(set2);
+          intersection.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1629,8 +1629,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Set.size(intersection)
+          let intersection = set1.intersection(set2);
+          intersection.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1639,8 +1639,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          let intersection = Set.intersection(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(intersection))
+          let intersection = set1.intersection(set2);
+          Iter.toArray(intersection.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 3]))
       ),
@@ -1649,8 +1649,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Set.size(difference)
+          let difference = set1.difference(set2);
+          difference.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1659,8 +1659,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1669,8 +1669,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Set.size(difference)
+          let difference = set1.difference(set2);
+          difference.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1679,8 +1679,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1689,8 +1689,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          let difference = Set.difference(set1, set2, Nat.compare);
-          Iter.toArray(Set.values(difference))
+          let difference = set1.difference(set2);
+          Iter.toArray(difference.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1699,8 +1699,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          Set.addAll(set1, Nat.compare, Set.values(set2));
-          Set.size(set1)
+          set1.addAll(set2.values());
+          set1.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1709,8 +1709,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          Set.addAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          set1.addAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1719,8 +1719,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          Set.addAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          set1.addAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1729,8 +1729,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          Set.addAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          set1.addAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1739,8 +1739,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          Set.addAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          set1.addAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1749,7 +1749,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1758,7 +1758,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1767,7 +1767,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { false }));
-          Set.size(set)
+          set.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1776,7 +1776,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n % 2 == 0 }));
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 4]))
       ),
@@ -1785,7 +1785,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4, 5]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n > 2 and n < 5 }));
-          Iter.toArray(Set.values(set))
+          Iter.toArray(set.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [3, 4]))
       ),
@@ -1794,8 +1794,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          assert (not Set.deleteAll(set1, Nat.compare, Set.values(set2)));
-          Set.size(set1)
+          assert (not set1.deleteAll(set2.values()));
+          set1.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1804,8 +1804,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          assert (not Set.deleteAll(set1, Nat.compare, Set.values(set2)));
-          Iter.toArray(Set.values(set1))
+          assert (not set1.deleteAll(set2.values()));
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1814,8 +1814,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          assert (Set.deleteAll(set1, Nat.compare, Set.values(set2)));
-          Set.size(set1)
+          assert (set1.deleteAll(set2.values()));
+          set1.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1824,8 +1824,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          assert (not (Set.deleteAll(set1, Nat.compare, Set.values(set2))));
-          Set.size(set1)
+          assert (not (set1.deleteAll(set2.values())));
+          set1.size()
         },
         M.equals(T.nat(0))
       ),
@@ -1834,8 +1834,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          assert (not (Set.deleteAll(set1, Nat.compare, Set.values(set2))));
-          Iter.toArray(Set.values(set1))
+          assert (not (set1.deleteAll(set2.values())));
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1844,8 +1844,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          assert Set.deleteAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          assert set1.deleteAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1855,8 +1855,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
-          assert (not Set.insertAll(set1, Nat.compare, Set.values(set2)));
-          Iter.toArray(Set.values(set1))
+          assert (not set1.insertAll(set2.values()));
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1865,8 +1865,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          assert (not Set.insertAll(set1, Nat.compare, Set.values(set2)));
-          Set.size(set1)
+          assert (not set1.insertAll(set2.values()));
+          set1.size()
         },
         M.equals(T.nat(3))
       ),
@@ -1875,8 +1875,8 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          assert (Set.insertAll(set1, Nat.compare, Set.values(set2)));
-          Set.size(set1)
+          assert (set1.insertAll(set2.values()));
+          set1.size()
         },
         M.equals(T.nat(3))
       ),
@@ -1885,8 +1885,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
-          assert (Set.insertAll(set1, Nat.compare, Set.values(set2)));
-          Iter.toArray(Set.values(set1))
+          assert (set1.insertAll(set2.values()));
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1895,8 +1895,8 @@ run(
         do {
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
-          assert Set.insertAll(set1, Nat.compare, Set.values(set2));
-          Iter.toArray(Set.values(set1))
+          assert set1.insertAll(set2.values());
+          Iter.toArray(set1.values())
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1912,11 +1912,11 @@ Test.suite(
       "Simple",
       func() {
         let set = Set.empty<Nat>();
-        Set.add(set, Nat.compare, 1);
-        Set.add(set, Nat.compare, 2);
-        Set.add(set, Nat.compare, 4);
+        set.add(1);
+        set.add(2);
+        set.add(4);
         func check(from : Nat, expected : [Nat]) {
-          let actual = Iter.toArray(Set.valuesFrom(set, Nat.compare, from));
+          let actual = Iter.toArray(set.valuesFrom(from));
           Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
         };
         check(0, [1, 2, 4]);
@@ -1932,10 +1932,10 @@ Test.suite(
         let set = Set.empty<Nat>();
         let n = 100;
         for (i in Nat.rangeBy(1, n, 2)) {
-          Set.add(set, Nat.compare, i);
+          set.add(i);
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(Set.valuesFrom(set, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(Set.values(set), func(k) = k < j));
+            let actual = Iter.toArray(set.valuesFrom(j));
+            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(set.values(), func(k) = k < j));
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }
@@ -1951,11 +1951,11 @@ Test.suite(
       "Simple",
       func() {
         let set = Set.empty<Nat>();
-        Set.add(set, Nat.compare, 1);
-        Set.add(set, Nat.compare, 2);
-        Set.add(set, Nat.compare, 4);
+        set.add(1);
+        set.add(2);
+        set.add(4);
         func check(from : Nat, expected : [Nat]) {
-          let actual = Iter.toArray(Set.reverseValuesFrom(set, Nat.compare, from));
+          let actual = Iter.toArray(set.reverseValuesFrom(from));
           Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
         };
         check(0, []);
@@ -1972,9 +1972,9 @@ Test.suite(
         let set = Set.empty<Nat>();
         let n = 100;
         for (i in Nat.rangeBy(1, n, 2)) {
-          Set.add(set, Nat.compare, i);
+          set.add(i);
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(Set.reverseValuesFrom(set, Nat.compare, j));
+            let actual = Iter.toArray(set.reverseValuesFrom(j));
             let expected = Iter.toArray(Iter.dropWhile<(Nat)>(Set.reverseValues(set), func(k) = k > j));
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -84,12 +84,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.empty<Nat>().values()).toArray(),
+        Set.empty<Nat>().values().toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate backward",
-        (Set.empty<Nat>().reverseValues()).toArray(),
+        Set.empty<Nat>().reverseValues().toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
@@ -426,12 +426,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.singleton<Nat>(0).values()).toArray(),
+        Set.singleton<Nat>(0).values().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backward",
-        (Set.singleton<Nat>(0).reverseValues()).toArray(),
+        Set.singleton<Nat>(0).reverseValues().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -514,12 +514,12 @@ run(
       ),
       test(
         "iterate forward",
-        (Set.singleton<Nat>(0).values()).toArray(),
+        Set.singleton<Nat>(0).values().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backwards",
-        (Set.singleton<Nat>(0).reverseValues()).toArray(),
+        Set.singleton<Nat>(0).reverseValues().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -957,7 +957,7 @@ run(
       ),
       test(
         "iterate forward",
-        (smallSet().values()).toArray(),
+        smallSet().values().toArray(),
         M.equals(
           T.array<Nat>(
             T.natTestable,
@@ -967,7 +967,7 @@ run(
       ),
       test(
         "iterate backward",
-        (smallSet().reverseValues()).toArray(),
+        smallSet().reverseValues().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.reverse(Array.tabulate<Nat>(smallSize, func(index) { index }))))
       ),
       test(
@@ -1046,12 +1046,12 @@ run(
       ),
       test(
         "forward iteration",
-        (smallSet().values()).toArray(),
+        smallSet().values().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "backwards iteration",
-        (smallSet().reverseValues()).toArray(),
+        smallSet().reverseValues().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { smallSize - 1 - index : Nat })))
       ),
       test(

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -31,7 +31,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.add(0);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -40,7 +40,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert set.insert(0);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -49,7 +49,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           set.remove(0);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -58,7 +58,7 @@ run(
         do {
           let set = Set.empty<Nat>();
           assert (not set.delete(0));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -84,12 +84,12 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Set.values(Set.empty<Nat>())),
+        (Set.values(Set.empty<Nat>())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Set.reverseValues(Set.empty<Nat>())),
+        (Set.reverseValues(Set.empty<Nat>())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
@@ -333,7 +333,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(0);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -342,7 +342,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.add(1);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -351,7 +351,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.insert(0));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -360,7 +360,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert set.insert(1);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0, 1]))
       ),
@@ -369,7 +369,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(0);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -378,7 +378,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           set.remove(1);
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -387,7 +387,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (set.delete(0));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
@@ -396,7 +396,7 @@ run(
         do {
           let set = Set.singleton<Nat>(0);
           assert (not set.delete(1));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
@@ -426,12 +426,12 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Set.values(Set.singleton<Nat>(0))),
+        (Set.values(Set.singleton<Nat>(0))).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backward",
-        Iter.toArray(Set.reverseValues(Set.singleton<Nat>(0))),
+        (Set.reverseValues(Set.singleton<Nat>(0))).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -514,12 +514,12 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Set.values(Set.singleton<Nat>(0))),
+        (Set.values(Set.singleton<Nat>(0))).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "iterate backwards",
-        Iter.toArray(Set.reverseValues(Set.singleton<Nat>(0))),
+        (Set.reverseValues(Set.singleton<Nat>(0))).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
@@ -748,7 +748,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(2);
           let union = set1.union(set2);
-          Iter.toArray(union.values())
+          (union.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -763,7 +763,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let union = set1.union(set2);
-          Iter.toArray(union.values())
+          (union.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -778,7 +778,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          Iter.toArray(intersection.values())
+          (intersection.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -793,7 +793,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let intersection = set1.intersection(set2);
-          Iter.toArray(intersection.values())
+          (intersection.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -808,7 +808,7 @@ run(
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -823,7 +823,7 @@ run(
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -839,7 +839,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -857,7 +857,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = setOfSets.flatten();
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -944,7 +944,7 @@ run(
           let original = smallSet();
           let copy = smallSet();
           let clone = original.clone();
-          let keys = Iter.toArray(original.values());
+          let keys = (original.values()).toArray();
           for (key in keys.vals()) {
             original.remove(key)
           };
@@ -957,7 +957,7 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Set.values(smallSet())),
+        (Set.values(smallSet())).toArray(),
         M.equals(
           T.array<Nat>(
             T.natTestable,
@@ -967,7 +967,7 @@ run(
       ),
       test(
         "iterate backward",
-        Iter.toArray(Set.reverseValues(smallSet())),
+        (Set.reverseValues(smallSet())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.reverse(Array.tabulate<Nat>(smallSize, func(index) { index }))))
       ),
       test(
@@ -1046,12 +1046,12 @@ run(
       ),
       test(
         "forward iteration",
-        Iter.toArray(Set.values(smallSet())),
+        (Set.values(smallSet())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "backwards iteration",
-        Iter.toArray(Set.reverseValues(smallSet())),
+        (Set.reverseValues(smallSet())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { smallSize - 1 - index : Nat })))
       ),
       test(
@@ -1261,7 +1261,7 @@ run(
           let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let union = Set.union(set1, set2, Int.compare);
-          Iter.toArray(union.values())
+          (union.values()).toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1283,7 +1283,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           Set.add(set2, Int.compare, 1);
           let intersection = Set.intersection(set1, set2, Int.compare);
-          Iter.toArray(intersection.values())
+          (intersection.values()).toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1301,7 +1301,7 @@ run(
           set2.remove(1);
           set2.remove(2);
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -1317,7 +1317,7 @@ run(
           let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
           let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1340,7 +1340,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
           let combined = Set.flatten(setOfSets, Int.compare);
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Int>(
@@ -1560,7 +1560,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let union = set1.union(set2);
-          Iter.toArray(union.values())
+          (union.values()).toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1570,7 +1570,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let union = set1.union(set2);
-          Iter.toArray(union.values())
+          (union.values()).toArray()
         },
         M.equals(T.array(T.natTestable, [1, 2, 3]))
       ),
@@ -1640,7 +1640,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let intersection = set1.intersection(set2);
-          Iter.toArray(intersection.values())
+          (intersection.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 3]))
       ),
@@ -1660,7 +1660,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1680,7 +1680,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1690,7 +1690,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           let difference = set1.difference(set2);
-          Iter.toArray(difference.values())
+          (difference.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1710,7 +1710,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           set1.addAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1720,7 +1720,7 @@ run(
           let set1 = Set.empty<Nat>();
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           set1.addAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1730,7 +1730,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           set1.addAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1740,7 +1740,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           set1.addAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1758,7 +1758,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1776,7 +1776,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n % 2 == 0 }));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [2, 4]))
       ),
@@ -1785,7 +1785,7 @@ run(
         do {
           let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4, 5]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n > 2 and n < 5 }));
-          Iter.toArray(set.values())
+          (set.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [3, 4]))
       ),
@@ -1805,7 +1805,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.deleteAll(set2.values()));
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1835,7 +1835,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (not (set1.deleteAll(set2.values())));
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1845,7 +1845,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.deleteAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1]))
       ),
@@ -1856,7 +1856,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not set1.insertAll(set2.values()));
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
@@ -1886,7 +1886,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
           assert (set1.insertAll(set2.values()));
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4, 5, 6]))
       ),
@@ -1896,7 +1896,7 @@ run(
           let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
           let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
           assert set1.insertAll(set2.values());
-          Iter.toArray(set1.values())
+          (set1.values()).toArray()
         },
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3, 4]))
       ),
@@ -1916,7 +1916,7 @@ Test.suite(
         set.add(2);
         set.add(4);
         func check(from : Nat, expected : [Nat]) {
-          let actual = Iter.toArray(set.valuesFrom(from));
+          let actual = (set.valuesFrom(from)).toArray();
           Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
         };
         check(0, [1, 2, 4]);
@@ -1934,8 +1934,8 @@ Test.suite(
         for (i in Nat.rangeBy(1, n, 2)) {
           set.add(i);
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(set.valuesFrom(j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(set.values(), func(k) = k < j));
+            let actual = (set.valuesFrom(j)).toArray();
+            let expected = (Iter.dropWhile<(Nat)>(set.values(), func(k) = k < j)).toArray();
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }
@@ -1955,7 +1955,7 @@ Test.suite(
         set.add(2);
         set.add(4);
         func check(from : Nat, expected : [Nat]) {
-          let actual = Iter.toArray(set.reverseValuesFrom(from));
+          let actual = (set.reverseValuesFrom(from)).toArray();
           Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
         };
         check(0, []);
@@ -1974,8 +1974,8 @@ Test.suite(
         for (i in Nat.rangeBy(1, n, 2)) {
           set.add(i);
           for (j in Nat.range(0, i + 2)) {
-            let actual = Iter.toArray(set.reverseValuesFrom(j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(Set.reverseValues(set), func(k) = k > j));
+            let actual = (set.reverseValuesFrom(j)).toArray();
+            let expected = (Iter.dropWhile<(Nat)>(Set.reverseValues(set), func(k) = k > j)).toArray();
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -146,7 +146,7 @@ suite(
       "values iterates in LIFO order",
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
-        expect.array(s.values().toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
+        expect.array(s.toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
   }
@@ -160,7 +160,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.reverse(s);
-        expect.array(s.values().toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
+        expect.array(s.toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
     );
 
@@ -169,7 +169,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
-        expect.array(mapped.values().toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
+        expect.array(mapped.toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
     );
 
@@ -178,7 +178,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
-        expect.array(evens.values().toArray(), Nat.toText, Nat.equal).equal([4, 2])
+        expect.array(evens.toArray(), Nat.toText, Nat.equal).equal([4, 2])
       }
     );
 
@@ -192,7 +192,7 @@ suite(
             if (x % 2 == 0) { ?(x * 2) } else { null }
           }
         );
-        expect.array(evenDoubled.values().toArray(), Nat.toText, Nat.equal).equal([8, 4])
+        expect.array(evenDoubled.toArray(), Nat.toText, Nat.equal).equal([8, 4])
       }
     )
   }

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -105,7 +105,7 @@ suite(
     test(
       "clear empties stack",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.clear(s);
         expect.bool(Stack.isEmpty(s)).isTrue()
       }
@@ -114,7 +114,7 @@ suite(
     test(
       "clone creates independent copy",
       func() {
-        let original = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let original = Stack.fromIter<Nat>([1, 2, 3].values());
         let copy = Stack.clone(original);
         ignore Stack.pop(original);
         expect.bool(Stack.size(copy) == 3 and Stack.peek(copy) == ?3).isTrue()
@@ -129,7 +129,7 @@ suite(
     test(
       "contains finds element",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.contains(s, Nat.equal, 2)).isTrue()
       }
     );
@@ -137,7 +137,7 @@ suite(
     test(
       "get retrieves correct element",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.get(s, 1) == ?2).isTrue()
       }
     );
@@ -145,7 +145,7 @@ suite(
     test(
       "values iterates in LIFO order",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
@@ -158,7 +158,7 @@ suite(
     test(
       "reverse changes order",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.reverse(s);
         expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
@@ -167,7 +167,7 @@ suite(
     test(
       "map transforms elements",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
         expect.array((mapped.values()).toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
@@ -176,7 +176,7 @@ suite(
     test(
       "filter keeps matching elements",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
         expect.array((evens.values()).toArray(), Nat.toText, Nat.equal).equal([4, 2])
       }
@@ -185,7 +185,7 @@ suite(
     test(
       "filterMap combines map and filter",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evenDoubled = Stack.filterMap<Nat, Nat>(
           s,
           func(x) {
@@ -204,7 +204,7 @@ suite(
     test(
       "all true when all match",
       func() {
-        let s = Stack.fromIter<Nat>([2, 4, 6].vals());
+        let s = Stack.fromIter<Nat>([2, 4, 6].values());
         expect.bool(Stack.all<Nat>(s, func(x) { x % 2 == 0 })).isTrue()
       }
     );
@@ -212,7 +212,7 @@ suite(
     test(
       "all false when any doesn't match",
       func() {
-        let s = Stack.fromIter<Nat>([2, 3, 4].vals());
+        let s = Stack.fromIter<Nat>([2, 3, 4].values());
         expect.bool(Stack.all<Nat>(s, func(x) { x % 2 == 0 })).isFalse()
       }
     );
@@ -220,7 +220,7 @@ suite(
     test(
       "any true when one matches",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.any<Nat>(s, func(x) { x % 2 == 0 })).isTrue()
       }
     );
@@ -228,7 +228,7 @@ suite(
     test(
       "any false when none match",
       func() {
-        let s = Stack.fromIter<Nat>([1, 3, 5].vals());
+        let s = Stack.fromIter<Nat>([1, 3, 5].values());
         expect.bool(Stack.any<Nat>(s, func(x) { x % 2 == 0 })).isFalse()
       }
     )
@@ -241,8 +241,8 @@ suite(
     test(
       "equal returns true for identical stacks",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2, 3].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2, 3].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.equal(s1, s2, Nat.equal)).isTrue()
       }
     );
@@ -250,8 +250,8 @@ suite(
     test(
       "equal returns false for different stacks",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2, 3].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 4].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2, 3].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 4].values());
         expect.bool(Stack.equal(s1, s2, Nat.equal)).isFalse()
       }
     );
@@ -259,8 +259,8 @@ suite(
     test(
       "compare orders correctly",
       func() {
-        let s1 = Stack.fromIter<Nat>([1, 2].vals());
-        let s2 = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s1 = Stack.fromIter<Nat>([1, 2].values());
+        let s2 = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.bool(Stack.compare(s1, s2, Nat.compare) == #less).isTrue()
       }
     )
@@ -273,7 +273,7 @@ suite(
     test(
       "toText formats correctly",
       func() {
-        let s = Stack.fromIter<Nat>([1, 2, 3].vals());
+        let s = Stack.fromIter<Nat>([1, 2, 3].values());
         expect.text(Stack.toText(s, Nat.toText)).equal("Stack[3, 2, 1]")
       }
     )

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -146,7 +146,7 @@ suite(
       "values iterates in LIFO order",
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
-        expect.array(Iter.toArray(Stack.values(s)), Nat.toText, Nat.equal).equal([3, 2, 1])
+        expect.array((Stack.values(s)).toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
   }
@@ -160,7 +160,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
         Stack.reverse(s);
-        expect.array(Iter.toArray(Stack.values(s)), Nat.toText, Nat.equal).equal([1, 2, 3])
+        expect.array((Stack.values(s)).toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
     );
 
@@ -169,7 +169,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
-        expect.array(Iter.toArray(Stack.values(mapped)), Nat.toText, Nat.equal).equal([4, 3, 2])
+        expect.array((Stack.values(mapped)).toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
     );
 
@@ -178,7 +178,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
         let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
-        expect.array(Iter.toArray(Stack.values(evens)), Nat.toText, Nat.equal).equal([4, 2])
+        expect.array((Stack.values(evens)).toArray(), Nat.toText, Nat.equal).equal([4, 2])
       }
     );
 
@@ -192,7 +192,7 @@ suite(
             if (x % 2 == 0) { ?(x * 2) } else { null }
           }
         );
-        expect.array(Iter.toArray(Stack.values(evenDoubled)), Nat.toText, Nat.equal).equal([8, 4])
+        expect.array((Stack.values(evenDoubled)).toArray(), Nat.toText, Nat.equal).equal([8, 4])
       }
     )
   }

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -146,7 +146,7 @@ suite(
       "values iterates in LIFO order",
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
-        expect.array((Stack.values(s)).toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
+        expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
   }
@@ -160,7 +160,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
         Stack.reverse(s);
-        expect.array((Stack.values(s)).toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
+        expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
     );
 
@@ -169,7 +169,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].vals());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
-        expect.array((Stack.values(mapped)).toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
+        expect.array((mapped.values()).toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
     );
 
@@ -178,7 +178,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
         let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
-        expect.array((Stack.values(evens)).toArray(), Nat.toText, Nat.equal).equal([4, 2])
+        expect.array((evens.values()).toArray(), Nat.toText, Nat.equal).equal([4, 2])
       }
     );
 
@@ -192,7 +192,7 @@ suite(
             if (x % 2 == 0) { ?(x * 2) } else { null }
           }
         );
-        expect.array((Stack.values(evenDoubled)).toArray(), Nat.toText, Nat.equal).equal([8, 4])
+        expect.array((evenDoubled.values()).toArray(), Nat.toText, Nat.equal).equal([8, 4])
       }
     )
   }
@@ -378,7 +378,7 @@ suite(
         var sum = 0;
         var count = 0;
 
-        for (value in Stack.values(s)) {
+        for (value in s.values()) {
           sum += value;
           count += 1
         };

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -146,7 +146,7 @@ suite(
       "values iterates in LIFO order",
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
-        expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
+        expect.array(s.values().toArray(), Nat.toText, Nat.equal).equal([3, 2, 1])
       }
     )
   }
@@ -160,7 +160,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
         Stack.reverse(s);
-        expect.array((s.values()).toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
+        expect.array(s.values().toArray(), Nat.toText, Nat.equal).equal([1, 2, 3])
       }
     );
 
@@ -169,7 +169,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3].values());
         let mapped = Stack.map<Nat, Nat>(s, func(x) { x + 1 });
-        expect.array((mapped.values()).toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
+        expect.array(mapped.values().toArray(), Nat.toText, Nat.equal).equal([4, 3, 2])
       }
     );
 
@@ -178,7 +178,7 @@ suite(
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3, 4].values());
         let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
-        expect.array((evens.values()).toArray(), Nat.toText, Nat.equal).equal([4, 2])
+        expect.array(evens.values().toArray(), Nat.toText, Nat.equal).equal([4, 2])
       }
     );
 
@@ -192,7 +192,7 @@ suite(
             if (x % 2 == 0) { ?(x * 2) } else { null }
           }
         );
-        expect.array((evenDoubled.values()).toArray(), Nat.toText, Nat.equal).equal([8, 4])
+        expect.array(evenDoubled.values().toArray(), Nat.toText, Nat.equal).equal([8, 4])
       }
     )
   }

--- a/test/Text.test.mo
+++ b/test/Text.test.mo
@@ -30,7 +30,7 @@ func optTextT(ot : ?Text) : T.TestableItem<?Text> = T.optional(T.textTestable, o
 
 // TODO: generalize and move to Iter.mo
 func iterT(c : [Char]) : T.TestableItem<Iter.Iter<Char>> = {
-  item = c.vals();
+  item = c.values();
   display = Text.fromIter; // not this will only print the remainder of cs1 below
   equals = func(cs1 : Iter.Iter<Char>, cs2 : Iter.Iter<Char>) : Bool {
     loop {
@@ -45,7 +45,7 @@ func iterT(c : [Char]) : T.TestableItem<Iter.Iter<Char>> = {
 
 // TODO: generalize and move to Iter.mo
 func textIterT(c : [Text]) : T.TestableItem<Iter.Iter<Text>> = {
-  item = c.vals();
+  item = c.values();
   display = func(ts : Iter.Iter<Text>) : Text { Text.join(ts, ",") };
   // not this will only print the remainder of cs1 below
   equals = func(ts1 : Iter.Iter<Text>, ts2 : Iter.Iter<Text>) : Bool {
@@ -143,7 +143,7 @@ run(
         let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-2",
-          Text.toIter(Text.join(Array.map(a, Char.toText).vals(), "")),
+          Text.toIter(Text.join(Array.map(a, Char.toText).values(), "")),
           M.equals(iterT a)
         )
       }
@@ -157,25 +157,25 @@ run(
     [
       test(
         "fromIter-0",
-        Text.fromIter(([].vals())),
+        Text.fromIter(([].values())),
         M.equals(T.text(""))
       ),
       test(
         "fromIter-1",
-        Text.fromIter((['a'].vals())),
+        Text.fromIter((['a'].values())),
         M.equals(T.text "a")
       ),
       test(
         "fromIter-2",
-        Text.fromIter((['a', 'b', 'c'].vals())),
+        Text.fromIter((['a', 'b', 'c'].values())),
         M.equals(T.text "abc")
       ),
       do {
         let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-3",
-          Text.fromIter(a.vals()),
-          M.equals(T.text(Text.join(Array.map(a, Char.toText).vals(), "")))
+          Text.fromIter(a.values()),
+          M.equals(T.text(Text.join(Array.map(a, Char.toText).values(), "")))
         )
       }
     ]
@@ -264,35 +264,35 @@ run(
     [
       test(
         "join-0",
-        Text.join(["", ""].vals(), ""),
+        Text.join(["", ""].values(), ""),
         M.equals(T.text(""))
       ),
       test(
         "join-1",
-        Text.join(["", "b"].vals(), ""),
+        Text.join(["", "b"].values(), ""),
         M.equals(T.text "b")
       ),
       test(
         "join-2",
-        Text.join(["a", "bb", "ccc", "dddd"].vals(), ""),
+        Text.join(["a", "bb", "ccc", "dddd"].values(), ""),
         M.equals(T.text "abbcccdddd")
       ),
       do {
         let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
-          Text.join(Array.map(a, Char.toText).vals(), ""),
-          M.equals(T.text(Text.fromIter(a.vals())))
+          Text.join(Array.map(a, Char.toText).values(), ""),
+          M.equals(T.text(Text.fromIter(a.values())))
         )
       },
       test(
         "join-4",
-        Text.join([].vals(), ""),
+        Text.join([].values(), ""),
         M.equals(T.text "")
       ),
       test(
         "join-5",
-        Text.join(["aaa"].vals(), ""),
+        Text.join(["aaa"].values(), ""),
         M.equals(T.text "aaa")
       )
     ]
@@ -305,35 +305,35 @@ run(
     [
       test(
         "join-0",
-        Text.join(["", ""].vals(), ","),
+        Text.join(["", ""].values(), ","),
         M.equals(T.text(","))
       ),
       test(
         "join-1",
-        Text.join(["", "b"].vals(), ","),
+        Text.join(["", "b"].values(), ","),
         M.equals(T.text ",b")
       ),
       test(
         "join-2",
-        Text.join(["a", "bb", "ccc", "dddd"].vals(), ","),
+        Text.join(["a", "bb", "ccc", "dddd"].values(), ","),
         M.equals(T.text "a,bb,ccc,dddd")
       ),
       do {
         let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
-          Text.join(Array.map(a, Char.toText).vals(), ""),
-          M.equals(T.text(Text.fromIter(a.vals())))
+          Text.join(Array.map(a, Char.toText).values(), ""),
+          M.equals(T.text(Text.fromIter(a.values())))
         )
       },
       test(
         "join-4",
-        Text.join([].vals(), ","),
+        Text.join([].values(), ","),
         M.equals(T.text "")
       ),
       test(
         "join-5",
-        Text.join(["aaa"].vals(), ","),
+        Text.join(["aaa"].values(), ","),
         M.equals(T.text "aaa")
       )
     ]
@@ -376,7 +376,7 @@ run(
       ),
       do {
         let a = Array.tabulate<Text>(1000, func _ = "abc");
-        let t = Text.join(a.vals(), ";");
+        let t = Text.join(a.values(), ";");
         test(
           "split-char-large",
           Text.split(t, #char ';'),
@@ -385,7 +385,7 @@ run(
       },
       do {
         let a = Array.tabulate<Text>(100000, func _ = "abc");
-        let t = Text.join(a.vals(), ";");
+        let t = Text.join(a.values(), ";");
         test(
           "split-char-very-large",
           Text.split(t, #char ';'),
@@ -434,7 +434,7 @@ do {
         ),
         do {
           let a = Array.tabulate<Text>(1000, func _ = "abc");
-          let t = Text.join(a.vals(), ";");
+          let t = Text.join(a.values(), ";");
           test(
             "split-pred-large",
             Text.split(t, pat),
@@ -443,7 +443,7 @@ do {
         },
         do {
           let a = Array.tabulate<Text>(10000, func _ = "abc");
-          let t = Text.join(a.vals(), ";");
+          let t = Text.join(a.values(), ";");
           test(
             "split-pred-very-large",
             Text.split(t, pat),
@@ -493,7 +493,7 @@ do {
         ),
         do {
           let a = Array.tabulate<Text>(1000, func _ = "abc");
-          let t = Text.join(a.vals(), "PAT");
+          let t = Text.join(a.values(), "PAT");
           test(
             "split-pat-large",
             Text.split(t, pat),
@@ -502,7 +502,7 @@ do {
         },
         do {
           let a = Array.tabulate<Text>(10000, func _ = "abc");
-          let t = Text.join(a.vals(), "PAT");
+          let t = Text.join(a.values(), "PAT");
           test(
             "split-pat-very-large",
             Text.split(t, pat),
@@ -550,7 +550,7 @@ run(
       ),
       do {
         let a = Array.tabulate<Text>(1000, func _ = "abc");
-        let t = Text.join(a.vals(), ";;");
+        let t = Text.join(a.values(), ";;");
         test(
           "tokens-char-large",
           Text.tokens(t, #char ';'),
@@ -559,7 +559,7 @@ run(
       },
       do {
         let a = Array.tabulate<Text>(100000, func _ = "abc");
-        let t = Text.join(a.vals(), ";;");
+        let t = Text.join(a.values(), ";;");
         test(
           "tokens-char-very-large",
           Text.tokens(t, #char ';'),

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -330,19 +330,19 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "flatMap",
-      VarArray.flatMap<Int, Int>([var 0, 1, 2], func x = [x, -x].vals()),
+      VarArray.flatMap<Int, Int>([var 0, 1, 2], func x = [x, -x].values()),
       M.equals(varArray<Int>(T.intTestable, [var 0, 0, 1, -1, 2, -2]))
     ),
     Suite.test(
       "flatMap empty",
-      VarArray.flatMap<Int, Int>([var], func x = [x, -x].vals()),
+      VarArray.flatMap<Int, Int>([var], func x = [x, -x].values()),
       M.equals(varArray<Int>(T.intTestable, [var]))
     ),
     Suite.test(
       "flatMap mix",
       VarArray.flatMap<Nat, Nat>(
         [var 1, 2, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -350,7 +350,7 @@ let suite = Suite.suite(
       "flatMap mix empty right",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -358,7 +358,7 @@ let suite = Suite.suite(
       "flatMap mix empties right",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3, 0, 0, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -366,7 +366,7 @@ let suite = Suite.suite(
       "flatMap mix empty left",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -374,7 +374,7 @@ let suite = Suite.suite(
       "flatMap mix empties left",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 0, 0, 1, 2, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -382,7 +382,7 @@ let suite = Suite.suite(
       "flatMap mix empties middle",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 1, 2, 0, 0, 0, 1, 2, 3],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var 0, 0, 1, 0, 0, 1, 0, 1, 2]))
     ),
@@ -390,7 +390,7 @@ let suite = Suite.suite(
       "flatMap mix empties",
       VarArray.flatMap<Nat, Nat>(
         [var 0, 0, 0],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var]))
     ),
@@ -398,7 +398,7 @@ let suite = Suite.suite(
       "flatMap mix empty",
       VarArray.flatMap<Nat, Nat>(
         [var],
-        func n = VarArray.tabulate<Nat>(n, func i = i).vals()
+        func n = VarArray.tabulate<Nat>(n, func i = i).values()
       ),
       M.equals(varArray<Nat>(T.natTestable, [var]))
     ),

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -743,53 +743,53 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "binarySearch found",
-      VarArray.binarySearch<Nat>([var 1, 3, 5, 7, 9, 11], Nat.compare, 5) == #found(2),
+      ([var 1, 3, 5, 7, 9, 11]).binarySearch<Nat>(5) == #found(2),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch not found",
-      VarArray.binarySearch<Nat>([var 1, 3, 5, 7, 9, 11], Nat.compare, 6) == #insertionIndex(3),
+      ([var 1, 3, 5, 7, 9, 11]).binarySearch<Nat>(6) == #insertionIndex(3),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch first element",
       do {
-        VarArray.binarySearch<Nat>([var 1, 3, 5, 7, 9, 11], Nat.compare, 1) == #found(0)
+        ([var 1, 3, 5, 7, 9, 11]).binarySearch<Nat>(1) == #found(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch last element",
       do {
-        VarArray.binarySearch<Nat>([var 1, 3, 5, 7, 9, 11], Nat.compare, 11) == #found(5)
+        ([var 1, 3, 5, 7, 9, 11]).binarySearch<Nat>(11) == #found(5)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch empty array",
       do {
-        VarArray.binarySearch<Nat>([var], Nat.compare, 5) == #insertionIndex(0)
+        ([var]).binarySearch<Nat>(5) == #insertionIndex(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch single element found",
       do {
-        VarArray.binarySearch<Nat>([var 42], Nat.compare, 42) == #found(0)
+        ([var 42]).binarySearch<Nat>(42) == #found(0)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch single element not found",
       do {
-        VarArray.binarySearch<Nat>([var 42], Nat.compare, 43) == #insertionIndex(1)
+        ([var 42]).binarySearch<Nat>(43) == #insertionIndex(1)
       },
       M.equals(T.bool(true))
     ),
     Suite.test(
       "binarySearch duplicates",
       do {
-        let result = VarArray.binarySearch<Nat>([var 1, 2, 2, 2, 3], Nat.compare, 2);
+        let result = ([var 1, 2, 2, 2, 3]).binarySearch<Nat>(2);
         switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }
@@ -799,32 +799,32 @@ let suite = Suite.suite(
     ),
     Suite.test(
       "isSorted empty array",
-      VarArray.isSorted<Nat>([var], Nat.compare),
+      ([var]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted single element",
-      VarArray.isSorted<Nat>([var 42], Nat.compare),
+      ([var 42]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted already sorted",
-      VarArray.isSorted<Nat>([var 1, 2, 3, 4, 5], Nat.compare),
+      ([var 1, 2, 3, 4, 5]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted with duplicates",
-      VarArray.isSorted<Nat>([var 1, 2, 2, 3, 3, 3], Nat.compare),
+      ([var 1, 2, 2, 3, 3, 3]).isSorted<Nat>(),
       M.equals(T.bool(true))
     ),
     Suite.test(
       "isSorted not sorted",
-      VarArray.isSorted<Nat>([var 1, 3, 2, 4, 5], Nat.compare),
+      ([var 1, 3, 2, 4, 5]).isSorted<Nat>(),
       M.equals(T.bool(false))
     ),
     Suite.test(
       "isSorted reverse sorted",
-      VarArray.isSorted<Nat>([var 5, 4, 3, 2, 1], Nat.compare),
+      ([var 5, 4, 3, 2, 1]).isSorted<Nat>(),
       M.equals(T.bool(false))
     )
   ]

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -1663,7 +1663,7 @@ Test.suite(
   "join",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputIter = Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x));
+      let inputIter = Iter.map<[Nat], List<Nat>>(input.values(), func x = List.fromArray(x));
       let result = List.join(inputIter);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };
@@ -1677,7 +1677,7 @@ Test.suite(
   "flatten",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputList = List.fromIter(Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x)));
+      let inputList = List.fromIter(Iter.map<[Nat], List<Nat>>(input.values(), func x = List.fromArray(x)));
       let result = List.flatten(inputList);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };

--- a/test/pure/Map.prop.test.mo
+++ b/test/pure/Map.prop.test.mo
@@ -19,11 +19,11 @@ let entryTestable = T.tuple2Testable(T.natTestable, T.textTestable);
 
 class MapMatcher(expected : Map.Map<Nat, Text>) : M.Matcher<Map.Map<Nat, Text>> {
   public func describeMismatch(actual : Map.Map<Nat, Text>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(Map.entries(actual))) # " should be " # debug_show (Iter.toArray(Map.entries(expected))))
+    Debug.print(debug_show ((Map.entries(actual)).toArray()) # " should be " # debug_show ((Map.entries(expected)).toArray()))
   };
 
   public func matches(actual : Map.Map<Nat, Text>) : Bool {
-    Iter.toArray(Map.entries(actual)) == Iter.toArray(Map.entries(expected))
+    (Map.entries(actual)).toArray() == (Map.entries(expected)).toArray()
   }
 };
 
@@ -75,7 +75,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
         label stop for (map in mapGen(map_samples, size, range)) {
           if (not f(map)) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n m: " # debug_show (Iter.toArray(Map.entries(map)));
+            error_msg #= "\n m: " # debug_show ((Map.entries(map)).toArray());
             break stop
           }
         };
@@ -94,7 +94,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             let key = Random.nextNat(range);
             if (not f(map, key)) {
               error_msg #= "Property \"" # name # "\" failed";
-              error_msg #= "\n m: " # debug_show (Iter.toArray(Map.entries(map)));
+              error_msg #= "\n m: " # debug_show ((Map.entries(map)).toArray());
               error_msg #= "\n k: " # debug_show (key);
               break stop
             }
@@ -290,8 +290,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "Array.fromIter(entries(m)) == Array.fromIter(reverseEntries(m)).reverse()",
               func(m) {
-                let a = Iter.toArray(Map.entries(m));
-                let b = Array.reverse(Iter.toArray(Map.reverseEntries(m)));
+                let a = (Map.entries(m)).toArray();
+                let b = Array.reverse((Map.reverseEntries(m)).toArray());
                 M.equals(T.array<(Nat, Text)>(entryTestable, a)).matches(b)
               }
             )

--- a/test/pure/Map.prop.test.mo
+++ b/test/pure/Map.prop.test.mo
@@ -19,11 +19,11 @@ let entryTestable = T.tuple2Testable(T.natTestable, T.textTestable);
 
 class MapMatcher(expected : Map.Map<Nat, Text>) : M.Matcher<Map.Map<Nat, Text>> {
   public func describeMismatch(actual : Map.Map<Nat, Text>, _description : M.Description) {
-    Debug.print(debug_show ((Map.entries(actual)).toArray()) # " should be " # debug_show ((Map.entries(expected)).toArray()))
+    Debug.print(debug_show (actual.entries().toArray()) # " should be " # debug_show (expected.entries().toArray()))
   };
 
   public func matches(actual : Map.Map<Nat, Text>) : Bool {
-    (Map.entries(actual)).toArray() == (Map.entries(expected)).toArray()
+    actual.entries().toArray() == expected.entries().toArray()
   }
 };
 
@@ -75,7 +75,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
         label stop for (map in mapGen(map_samples, size, range)) {
           if (not f(map)) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n m: " # debug_show ((Map.entries(map)).toArray());
+            error_msg #= "\n m: " # debug_show (map.entries().toArray());
             break stop
           }
         };
@@ -94,7 +94,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             let key = Random.nextNat(range);
             if (not f(map, key)) {
               error_msg #= "Property \"" # name # "\" failed";
-              error_msg #= "\n m: " # debug_show ((Map.entries(map)).toArray());
+              error_msg #= "\n m: " # debug_show (map.entries().toArray());
               error_msg #= "\n k: " # debug_show (key);
               break stop
             }
@@ -267,21 +267,21 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "fromIter(entries(m), c) == m",
               func(m) {
-                MapMatcher(m).matches(Map.fromIter(Map.entries(m), c))
+                MapMatcher(m).matches(Map.fromIter(m.entries(), c))
               }
             ),
             prop(
               "fromIter(entriesRev(m)) == m",
               func(m) {
-                MapMatcher(m).matches(Map.fromIter(Map.reverseEntries(m), c))
+                MapMatcher(m).matches(Map.fromIter(m.reverseEntries(), c))
               }
             ),
             prop(
               "entries(m) = zip(key(m), values(m))",
               func(m) {
-                let k = Map.keys(m);
-                let v = Map.values(m);
-                for (e in Map.entries(m)) {
+                let k = m.keys();
+                let v = m.values();
+                for (e in m.entries()) {
                   if (?e.0 != k.next() or ?e.1 != v.next()) return false
                 };
                 return true
@@ -290,8 +290,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "Array.fromIter(entries(m)) == Array.fromIter(reverseEntries(m)).reverse()",
               func(m) {
-                let a = (Map.entries(m)).toArray();
-                let b = Array.reverse((Map.reverseEntries(m)).toArray());
+                let a = m.entries().toArray();
+                let b = Array.reverse(m.reverseEntries().toArray());
                 M.equals(T.array<(Nat, Text)>(entryTestable, a)).matches(b)
               }
             )
@@ -350,14 +350,14 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "foldLeft as entries()",
               func(m) {
-                let it = Map.entries(m);
+                let it = m.entries();
                 Map.foldLeft<Nat, Text, Bool>(m, true, func(acc, k, v) { acc and it.next() == ?(k, v) })
               }
             ),
             prop(
               "foldRight as reverseEntries()",
               func(m) {
-                let it = Map.reverseEntries(m);
+                let it = m.reverseEntries();
                 Map.foldRight<Nat, Text, Bool>(m, true, func(k, v, acc) { acc and it.next() == ?(k, v) })
               }
             )

--- a/test/pure/Map.prop.test.mo
+++ b/test/pure/Map.prop.test.mo
@@ -59,7 +59,7 @@ func mapGen(samples_number : Nat, size : Nat, range : (Nat, Nat)) : Iter.Iter<Ma
       if (n > samples_number) {
         null
       } else {
-        ?Map.fromIter(Random.nextEntries(range, size).vals(), c)
+        ?Map.fromIter(Random.nextEntries(range, size).values(), c)
       }
     }
   }

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -18,11 +18,11 @@ let entryTestable = T.tuple2Testable(T.natTestable, T.textTestable);
 
 class MapMatcher(expected : [(Nat, Text)]) : M.Matcher<Map.Map<Nat, Text>> {
   public func describeMismatch(actual : Map.Map<Nat, Text>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(actual.entries())) # " should be " # debug_show (expected))
+    Debug.print(debug_show ((actual.entries()).toArray()) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Map.Map<Nat, Text>) : Bool {
-    Iter.toArray(actual.entries()) == expected
+    (actual.entries()).toArray() == expected
   }
 };
 
@@ -99,22 +99,22 @@ run(
       ),
       test(
         "entries",
-        Iter.toArray(buildTestMap().entries()),
+        (buildTestMap().entries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "reverseEntries",
-        Iter.toArray(buildTestMap().reverseEntries()),
+        (buildTestMap().reverseEntries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "keys",
-        Iter.toArray(buildTestMap().keys()),
+        (buildTestMap().keys()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "vals",
-        Iter.toArray(buildTestMap().values()),
+        (buildTestMap().values()).toArray(),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
@@ -280,22 +280,22 @@ run(
       ),
       test(
         "entries",
-        Iter.toArray(buildTestMap().entries()),
+        (buildTestMap().entries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "reverseEntries",
-        Iter.toArray(buildTestMap().reverseEntries()),
+        (buildTestMap().reverseEntries()).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "keys",
-        Iter.toArray(buildTestMap().keys()),
+        (buildTestMap().keys()).toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "values",
-        Iter.toArray(buildTestMap().values()),
+        (buildTestMap().values()).toArray(),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
@@ -510,22 +510,22 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   ),
   test(
     "entries",
-    Iter.toArray(buildTestMap().entries()),
+    (buildTestMap().entries()).toArray(),
     M.equals(T.array<(Nat, Text)>(entryTestable, expected))
   ),
   test(
     "reverserEntries",
-    Iter.toArray(buildTestMap().reverseEntries()),
+    (buildTestMap().reverseEntries()).toArray(),
     M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(expected)))
   ),
   test(
     "keys",
-    Iter.toArray(buildTestMap().keys()),
+    (buildTestMap().keys()).toArray(),
     M.equals(T.array<Nat>(T.natTestable, [0, 1, 2]))
   ),
   test(
     "values",
-    Iter.toArray(buildTestMap().values()),
+    (buildTestMap().values()).toArray(),
     M.equals(T.array<Text>(T.textTestable, ["0", "1", "2"]))
   ),
   test(
@@ -793,7 +793,7 @@ run(
       ),
       test(
         "iterate forward",
-        Iter.toArray(Map.entries(smallMap())),
+        (Map.entries(smallMap())).toArray(),
         M.equals(
           T.array<(Nat, Text)>(
             entryTestable,
@@ -803,7 +803,7 @@ run(
       ),
       test(
         "iterate backward",
-        Iter.toArray(Map.reverseEntries(smallMap())),
+        (Map.reverseEntries(smallMap())).toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) }))))
       ),
       test(
@@ -933,12 +933,12 @@ run(
       ),
       test(
         "iterate keys",
-        Iter.toArray(Map.keys(smallMap())),
+        (Map.keys(smallMap())).toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "iterate values",
-        Iter.toArray(Map.values(smallMap())),
+        (Map.values(smallMap())).toArray(),
         M.equals(T.array<Text>(T.textTestable, Array.tabulate<Text>(smallSize, func(index) { Nat.toText(index) })))
       ),
       test(

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -124,37 +124,37 @@ run(
       ),
       test(
         "get absent",
-        Map.get(buildTestMap(), Nat.compare, 0),
+        buildTestMap().get(0),
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
       test(
         "containsKey absent",
-        Map.containsKey(buildTestMap(), Nat.compare, 0),
+        buildTestMap().containsKey(0),
         M.equals(T.bool(false))
       ),
       test(
         "maxEntry",
-        Map.maxEntry(buildTestMap()),
+        buildTestMap().maxEntry(),
         M.equals(T.optional(entryTestable, null : ?(Nat, Text)))
       ),
       test(
         "minEntry",
-        Map.minEntry(buildTestMap()),
+        buildTestMap().minEntry(),
         M.equals(T.optional(entryTestable, null : ?(Nat, Text)))
       ),
       test(
         "take absent",
-        Map.take(buildTestMap(), Nat.compare, 0).1,
+        buildTestMap().take(0).1,
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
       test(
         "replace absent/no value",
-        Map.swap(buildTestMap(), Nat.compare, 0, "Test").1,
+        buildTestMap().swap(0, "Test").1,
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
       test(
         "replace absent/key appeared",
-        Map.swap(buildTestMap(), Nat.compare, 0, "Test").0,
+        buildTestMap().swap(0, "Test").0,
         MapMatcher([(0, "Test")])
       ),
       test(
@@ -184,7 +184,7 @@ run(
       ),
       test(
         "empty map filter",
-        Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(0, multiplyKeyAndConcat)),
+        buildTestMap().filterMap(ifKeyLessThan(0, multiplyKeyAndConcat)),
         MapMatcher([])
       ),
       test(
@@ -305,27 +305,27 @@ run(
       ),
       test(
         "get",
-        Map.get(buildTestMap(), Nat.compare, 0),
+        buildTestMap().get(0),
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
       test(
         "containsKey",
-        Map.containsKey(buildTestMap(), Nat.compare, 0),
+        buildTestMap().containsKey(0),
         M.equals(T.bool(true))
       ),
       test(
         "maxEntry",
-        Map.maxEntry(buildTestMap()),
+        buildTestMap().maxEntry(),
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
       test(
         "minEntry",
-        Map.minEntry(buildTestMap()),
+        buildTestMap().minEntry(),
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
       test(
         "swap function result",
-        Map.swap(buildTestMap(), Nat.compare, 0, "TEST").1,
+        buildTestMap().swap(0, "TEST").1,
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
       test(
@@ -338,7 +338,7 @@ run(
       ),
       test(
         "take function result",
-        Map.take(buildTestMap(), Nat.compare, 0).1,
+        buildTestMap().take(0).1,
         M.equals(T.optional(T.textTestable, ?"0"))
       ),
       test(
@@ -378,12 +378,12 @@ run(
       ),
       test(
         "filter map/filter all",
-        Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(0, multiplyKeyAndConcat)),
+        buildTestMap().filterMap(ifKeyLessThan(0, multiplyKeyAndConcat)),
         MapMatcher([])
       ),
       test(
         "filter map/no filter",
-        Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(1, multiplyKeyAndConcat)),
+        buildTestMap().filterMap(ifKeyLessThan(1, multiplyKeyAndConcat)),
         MapMatcher([(0, "00")])
       ),
       test(
@@ -544,17 +544,17 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   ),
   test(
     "containsKey",
-    Array.tabulate<Bool>(4, func(k : Nat) = (Map.containsKey(buildTestMap(), Nat.compare, k))),
+    Array.tabulate<Bool>(4, func(k : Nat) = (buildTestMap().containsKey(k))),
     M.equals(T.array<Bool>(T.boolTestable, [true, true, true, false]))
   ),
   test(
     "maxEntry",
-    Map.maxEntry(buildTestMap()),
+    buildTestMap().maxEntry(),
     M.equals(T.optional(entryTestable, ?(2, "2")))
   ),
   test(
     "minEntry",
-    Map.minEntry(buildTestMap()),
+    buildTestMap().minEntry(),
     M.equals(T.optional(entryTestable, ?(0, "0")))
   ),
   test(
@@ -589,17 +589,17 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   ),
   test(
     "filter map/filter all",
-    Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(0, multiplyKeyAndConcat)),
+    buildTestMap().filterMap(ifKeyLessThan(0, multiplyKeyAndConcat)),
     MapMatcher([])
   ),
   test(
     "filter map/filter one",
-    Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(1, multiplyKeyAndConcat)),
+    buildTestMap().filterMap(ifKeyLessThan(1, multiplyKeyAndConcat)),
     MapMatcher([(0, "00")])
   ),
   test(
     "filter map/no filter",
-    Map.filterMap(buildTestMap(), Nat.compare, ifKeyLessThan(3, multiplyKeyAndConcat)),
+    buildTestMap().filterMap(ifKeyLessThan(3, multiplyKeyAndConcat)),
     MapMatcher([(0, "00"), (1, "21"), (2, "42")])
   ),
   test(
@@ -949,7 +949,7 @@ run(
           for (index in Nat.range(0, smallSize)) {
             assert (map.get(index) == ?Nat.toText(index))
           };
-          assert (Map.equal(map, smallMap(), Nat.compare, Text.equal));
+          assert (map.equal(smallMap()));
           map.size
         },
         M.equals(T.nat(smallSize))
@@ -1111,7 +1111,7 @@ run(
       test(
         "compare less key",
         do {
-          let (map1, result1) = Map.delete(smallMap(), Nat.compare, smallSize - 1 : Nat);
+          let (map1, result1) = smallMap().delete(smallSize - 1 : Nat);
           assert result1;
           let map2 = smallMap();
           assert (map1.compare(map2) == #less);
@@ -1123,7 +1123,7 @@ run(
         "compare less value",
         do {
           let map1 = smallMap();
-          let (map2, _) = Map.swap(smallMap(), Nat.compare, smallSize - 1 : Nat, "Last");
+          let (map2, _) = smallMap().swap(smallSize - 1 : Nat, "Last");
           assert (map1.compare(map2) == #less);
           true
         },
@@ -1143,7 +1143,7 @@ run(
         "compare greater key",
         do {
           let map1 = smallMap();
-          let (map2, result2) = Map.delete(smallMap(), Nat.compare, smallSize - 1 : Nat);
+          let (map2, result2) = smallMap().delete(smallSize - 1 : Nat);
           assert result2;
           assert (map1.compare(map2) == #greater);
           true
@@ -1153,7 +1153,7 @@ run(
       test(
         "compare greater value",
         do {
-          let (map1, _) = Map.swap(smallMap(), Nat.compare, smallSize - 1 : Nat, "Last");
+          let (map1, _) = smallMap().swap(smallSize - 1 : Nat, "Last");
           let map2 = smallMap();
           assert (map1.compare(map2) == #greater);
           true

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -18,11 +18,11 @@ let entryTestable = T.tuple2Testable(T.natTestable, T.textTestable);
 
 class MapMatcher(expected : [(Nat, Text)]) : M.Matcher<Map.Map<Nat, Text>> {
   public func describeMismatch(actual : Map.Map<Nat, Text>, _description : M.Description) {
-    Debug.print(debug_show ((actual.entries()).toArray()) # " should be " # debug_show (expected))
+    Debug.print(debug_show (actual.entries().toArray()) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Map.Map<Nat, Text>) : Bool {
-    (actual.entries()).toArray() == expected
+    actual.entries().toArray() == expected
   }
 };
 
@@ -99,22 +99,22 @@ run(
       ),
       test(
         "entries",
-        (buildTestMap().entries()).toArray(),
+        buildTestMap().entries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "reverseEntries",
-        (buildTestMap().reverseEntries()).toArray(),
+        buildTestMap().reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "keys",
-        (buildTestMap().keys()).toArray(),
+        buildTestMap().keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "vals",
-        (buildTestMap().values()).toArray(),
+        buildTestMap().values().toArray(),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
@@ -280,22 +280,22 @@ run(
       ),
       test(
         "entries",
-        (buildTestMap().entries()).toArray(),
+        buildTestMap().entries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "reverseEntries",
-        (buildTestMap().reverseEntries()).toArray(),
+        buildTestMap().reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "keys",
-        (buildTestMap().keys()).toArray(),
+        buildTestMap().keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "values",
-        (buildTestMap().values()).toArray(),
+        buildTestMap().values().toArray(),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
@@ -510,22 +510,22 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   ),
   test(
     "entries",
-    (buildTestMap().entries()).toArray(),
+    buildTestMap().entries().toArray(),
     M.equals(T.array<(Nat, Text)>(entryTestable, expected))
   ),
   test(
     "reverserEntries",
-    (buildTestMap().reverseEntries()).toArray(),
+    buildTestMap().reverseEntries().toArray(),
     M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(expected)))
   ),
   test(
     "keys",
-    (buildTestMap().keys()).toArray(),
+    buildTestMap().keys().toArray(),
     M.equals(T.array<Nat>(T.natTestable, [0, 1, 2]))
   ),
   test(
     "values",
-    (buildTestMap().values()).toArray(),
+    buildTestMap().values().toArray(),
     M.equals(T.array<Text>(T.textTestable, ["0", "1", "2"]))
   ),
   test(
@@ -793,7 +793,7 @@ run(
       ),
       test(
         "iterate forward",
-        (Map.entries(smallMap())).toArray(),
+        (smallMap()).entries().toArray(),
         M.equals(
           T.array<(Nat, Text)>(
             entryTestable,
@@ -803,7 +803,7 @@ run(
       ),
       test(
         "iterate backward",
-        (Map.reverseEntries(smallMap())).toArray(),
+        (smallMap()).reverseEntries().toArray(),
         M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) }))))
       ),
       test(
@@ -933,12 +933,12 @@ run(
       ),
       test(
         "iterate keys",
-        (Map.keys(smallMap())).toArray(),
+        (smallMap()).keys().toArray(),
         M.equals(T.array<Nat>(T.natTestable, Array.tabulate<Nat>(smallSize, func(index) { index })))
       ),
       test(
         "iterate values",
-        (Map.values(smallMap())).toArray(),
+        (smallMap()).values().toArray(),
         M.equals(T.array<Text>(T.textTestable, Array.tabulate<Text>(smallSize, func(index) { Nat.toText(index) })))
       ),
       test(

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -219,7 +219,8 @@ run(
         "filter",
         do {
           let input = Map.empty<Nat, Text>();
-          let output = input.filter<Nat, Text>(func(_, _) {
+          let output = input.filter<Nat, Text>(
+            func(_, _) {
               Runtime.trap("test failed")
             }
           );
@@ -419,7 +420,8 @@ run(
         "filter",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = input.filter<Nat, Text>(func(key, value) {
+          let output = input.filter<Nat, Text>(
+            func(key, value) {
               assert (key == 0);
               assert (value == "0");
               true
@@ -647,7 +649,8 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
     "filter",
     do {
       let input = buildTestMap();
-      let output = input.filter<Nat, Text>(func(key, value) {
+      let output = input.filter<Nat, Text>(
+        func(key, value) {
           key % 2 == 0
         }
       );
@@ -974,7 +977,8 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = input.filter<Nat, Text>(func(key, value) {
+          let output = input.filter<Nat, Text>(
+            func(key, value) {
               key % 2 == 0
             }
           );

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -18,35 +18,35 @@ let entryTestable = T.tuple2Testable(T.natTestable, T.textTestable);
 
 class MapMatcher(expected : [(Nat, Text)]) : M.Matcher<Map.Map<Nat, Text>> {
   public func describeMismatch(actual : Map.Map<Nat, Text>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(Map.entries(actual))) # " should be " # debug_show (expected))
+    Debug.print(debug_show (Iter.toArray(actual.entries())) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Map.Map<Nat, Text>) : Bool {
-    Iter.toArray(Map.entries(actual)) == expected
+    Iter.toArray(actual.entries()) == expected
   }
 };
 
-func checkMap(m : Map.Map<Nat, Text>) { Map.assertValid(m, Nat.compare) };
+func checkMap(m : Map.Map<Nat, Text>) { m.assertValid() };
 
 func insert(rbTree : Map.Map<Nat, Text>, key : Nat) : Map.Map<Nat, Text> {
-  let updatedTree = Map.add(rbTree, Nat.compare, key, debug_show (key));
+  let updatedTree = rbTree.add(key, debug_show (key));
   checkMap(updatedTree);
   updatedTree
 };
 
 func getAll(rbTree : Map.Map<Nat, Text>, keys : [Nat]) {
   for (key in keys.vals()) {
-    let value = Map.get(rbTree, Nat.compare, key);
+    let value = rbTree.get(key);
     assert (value == ?debug_show (key))
   }
 };
 
 func clear(initialRbMap : Map.Map<Nat, Text>) : Map.Map<Nat, Text> {
   var rbMap = initialRbMap;
-  for ((key, value) in Map.entries(initialRbMap)) {
+  for ((key, value) in initialRbMap.entries()) {
     // stable iteration
     assert (value == debug_show (key));
-    let (newMap, result) = Map.take(rbMap, Nat.compare, key);
+    let (newMap, result) = rbMap.take(key);
     rbMap := newMap;
     assert (result == ?debug_show (key));
     checkMap(rbMap)
@@ -94,27 +94,27 @@ run(
     [
       test(
         "size",
-        Map.size(buildTestMap()),
+        buildTestMap().size,
         M.equals(T.nat(0))
       ),
       test(
         "entries",
-        Iter.toArray(Map.entries(buildTestMap())),
+        Iter.toArray(buildTestMap().entries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "reverseEntries",
-        Iter.toArray(Map.reverseEntries(buildTestMap())),
+        Iter.toArray(buildTestMap().reverseEntries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, []))
       ),
       test(
         "keys",
-        Iter.toArray(Map.keys(buildTestMap())),
+        Iter.toArray(buildTestMap().keys()),
         M.equals(T.array<Nat>(T.natTestable, []))
       ),
       test(
         "vals",
-        Iter.toArray(Map.values(buildTestMap())),
+        Iter.toArray(buildTestMap().values()),
         M.equals(T.array<Text>(T.textTestable, []))
       ),
       test(
@@ -206,13 +206,12 @@ run(
         "for each",
         do {
           let map = Map.empty<Nat, Text>();
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(_, _) {
               assert false
             }
           );
-          Map.size(map)
+          map.size
         },
         M.equals(T.nat(0))
       ),
@@ -220,14 +219,11 @@ run(
         "filter",
         do {
           let input = Map.empty<Nat, Text>();
-          let output = Map.filter<Nat, Text>(
-            input,
-            Nat.compare,
-            func(_, _) {
+          let output = input.filter<Nat, Text>(func(_, _) {
               Runtime.trap("test failed")
             }
           );
-          Map.size(output)
+          output.size
         },
         M.equals(T.nat(0))
       ),
@@ -236,7 +232,7 @@ run(
         do {
           let map1 = Map.empty<Nat, Text>();
           let map2 = Map.empty<Nat, Text>();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -246,7 +242,7 @@ run(
         do {
           let map1 = Map.empty<Nat, Text>();
           let map2 = Map.empty<Nat, Text>();
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          map1.equal(map2)
         },
         M.equals(T.bool(true))
       ),
@@ -271,35 +267,35 @@ run(
         "singleton valid",
         do {
           let map = Map.singleton(0, "Zero");
-          Map.assertValid(map, Nat.compare);
-          Map.size(map)
+          map.assertValid();
+          map.size
         },
         M.equals(T.nat(1))
       ),
 
       test(
         "size",
-        Map.size(buildTestMap()),
+        buildTestMap().size,
         M.equals(T.nat(1))
       ),
       test(
         "entries",
-        Iter.toArray(Map.entries(buildTestMap())),
+        Iter.toArray(buildTestMap().entries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "reverseEntries",
-        Iter.toArray(Map.reverseEntries(buildTestMap())),
+        Iter.toArray(buildTestMap().reverseEntries()),
         M.equals(T.array<(Nat, Text)>(entryTestable, expected))
       ),
       test(
         "keys",
-        Iter.toArray(Map.keys(buildTestMap())),
+        Iter.toArray(buildTestMap().keys()),
         M.equals(T.array<Nat>(T.natTestable, [0]))
       ),
       test(
         "values",
-        Iter.toArray(Map.values(buildTestMap())),
+        Iter.toArray(buildTestMap().values()),
         M.equals(T.array<Text>(T.textTestable, ["0"]))
       ),
       test(
@@ -336,7 +332,7 @@ run(
         "swap map result",
         do {
           let rbMap = buildTestMap();
-          Map.swap(rbMap, Nat.compare, 0, "TEST").0
+          rbMap.swap(0, "TEST").0
         },
         MapMatcher([(0, "TEST")])
       ),
@@ -349,7 +345,7 @@ run(
         "take map result",
         do {
           var rbMap = buildTestMap();
-          rbMap := Map.take(rbMap, Nat.compare, 0).0;
+          rbMap := rbMap.take(0).0;
           checkMap(rbMap);
           rbMap
         },
@@ -409,14 +405,13 @@ run(
         "for each",
         do {
           let map = Map.singleton<Nat, Text>(0, "0");
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(key, value) {
               assert (key == 0);
               assert (value == "0")
             }
           );
-          Map.size(map)
+          map.size
         },
         M.equals(T.nat(1))
       ),
@@ -424,17 +419,14 @@ run(
         "filter",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filter<Nat, Text>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filter<Nat, Text>(func(key, value) {
               assert (key == 0);
               assert (value == "0");
               true
             }
           );
-          assert (Map.equal(input, output, Nat.compare, Text.equal));
-          Map.size(output)
+          assert (input.equal(output));
+          output.size
         },
         M.equals(T.nat(1))
       ),
@@ -453,7 +445,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(1, "1");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -463,7 +455,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(0, "Zero");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -473,7 +465,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "0");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -483,7 +475,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(1, "1");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -493,7 +485,7 @@ run(
         do {
           let map1 = Map.singleton<Nat, Text>(0, "Zero");
           let map2 = Map.singleton<Nat, Text>(0, "0");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -508,7 +500,7 @@ expected := expectedEntries([0, 1, 2]);
 func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   test(
     "size",
-    Map.size(buildTestMap()),
+    buildTestMap().size,
     M.equals(T.nat(3))
   ),
   test(
@@ -518,22 +510,22 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
   ),
   test(
     "entries",
-    Iter.toArray(Map.entries(buildTestMap())),
+    Iter.toArray(buildTestMap().entries()),
     M.equals(T.array<(Nat, Text)>(entryTestable, expected))
   ),
   test(
     "reverserEntries",
-    Iter.toArray(Map.reverseEntries(buildTestMap())),
+    Iter.toArray(buildTestMap().reverseEntries()),
     M.equals(T.array<(Nat, Text)>(entryTestable, Array.reverse(expected)))
   ),
   test(
     "keys",
-    Iter.toArray(Map.keys(buildTestMap())),
+    Iter.toArray(buildTestMap().keys()),
     M.equals(T.array<Nat>(T.natTestable, [0, 1, 2]))
   ),
   test(
     "values",
-    Iter.toArray(Map.values(buildTestMap())),
+    Iter.toArray(buildTestMap().values()),
     M.equals(T.array<Text>(T.textTestable, ["0", "1", "2"]))
   ),
   test(
@@ -640,15 +632,14 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
     do {
       let map = buildTestMap();
       var index = 0;
-      Map.forEach<Nat, Text>(
-        map,
+      map.forEach(
         func(key, value) {
           assert (key == index);
           assert (value == Nat.toText(index));
           index += 1
         }
       );
-      Map.size(map)
+      map.size
     },
     M.equals(T.nat(3))
   ),
@@ -656,24 +647,21 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
     "filter",
     do {
       let input = buildTestMap();
-      let output = Map.filter<Nat, Text>(
-        input,
-        Nat.compare,
-        func(key, value) {
+      let output = input.filter<Nat, Text>(func(key, value) {
           key % 2 == 0
         }
       );
-      for (index in Nat.range(0, Map.size(input))) {
-        let present = Map.containsKey(output, Nat.compare, index);
+      for (index in Nat.range(0, input.size)) {
+        let present = output.containsKey(index);
         if (index % 2 == 0) {
           assert (present);
-          assert (Map.get(output, Nat.compare, index) == ?Nat.toText(index))
+          assert (output.get(index) == ?Nat.toText(index))
         } else {
           assert (not present);
-          assert (Map.get(output, Nat.compare, index) == null)
+          assert (output.get(index) == null)
         }
       };
-      Map.size(output)
+      output.size
     },
     M.equals(T.nat((3 + 1) / 2))
   )
@@ -735,9 +723,9 @@ run(
         "repeated put",
         do {
           var rbMap = buildTestMap();
-          assert (Map.get(rbMap, Nat.compare, 1) == ?"1");
-          rbMap := Map.add(rbMap, Nat.compare, 1, "TEST-1");
-          Map.get(rbMap, Nat.compare, 1)
+          assert (rbMap.get(1) == ?"1");
+          rbMap := rbMap.add(1, "TEST-1");
+          rbMap.get(1)
         },
         M.equals(T.optional(T.textTestable, ?"TEST-1"))
       ),
@@ -745,9 +733,9 @@ run(
         "repeated swap",
         do {
           let rbMap0 = buildTestMap();
-          let (rbMap1, firstResult) = Map.swap(rbMap0, Nat.compare, 1, "TEST-1");
+          let (rbMap1, firstResult) = rbMap0.swap(1, "TEST-1");
           assert (firstResult == ?"1");
-          let (rbMap2, secondResult) = Map.swap(rbMap1, Nat.compare, 1, "1");
+          let (rbMap2, secondResult) = rbMap1.swap(1, "1");
           assert (secondResult == ?"TEST-1");
           rbMap2
         },
@@ -757,10 +745,10 @@ run(
         "repeated take",
         do {
           var rbMap0 = buildTestMap();
-          let (rbMap1, result) = Map.take(rbMap0, Nat.compare, 1);
+          let (rbMap1, result) = rbMap0.take(1);
           assert (result == ?"1");
           checkMap(rbMap1);
-          Map.take(rbMap1, Nat.compare, 1).1
+          rbMap1.take(1).1
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -768,9 +756,9 @@ run(
         "repeated delete",
         do {
           let map = buildTestMap();
-          let (map1, result1) = Map.delete(map, Nat.compare, 1);
+          let (map1, result1) = map.delete(1);
           assert result1;
-          let (map2, result2) = Map.delete(map1, Nat.compare, 1);
+          let (map2, result2) = map1.delete(1);
           assert not result2;
           map2
         },
@@ -784,7 +772,7 @@ let smallSize = 100;
 func smallMap() : Map.Map<Nat, Text> {
   var map = Map.empty<Nat, Text>();
   for (index in Nat.range(0, smallSize)) {
-    map := Map.add(map, Nat.compare, index, Nat.toText(index))
+    map := map.add(index, Nat.toText(index))
   };
   map
 };
@@ -823,7 +811,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.containsKey(map, Nat.compare, index))
+            assert (map.containsKey(index))
           };
           true
         },
@@ -833,7 +821,7 @@ run(
         "contains absent key",
         do {
           let map = smallMap();
-          Map.containsKey(map, Nat.compare, smallSize)
+          map.containsKey(smallSize)
         },
         M.equals(T.bool(false))
       ),
@@ -842,7 +830,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
           true
         },
@@ -852,7 +840,7 @@ run(
         "get absent",
         do {
           let map = smallMap();
-          Map.get(map, Nat.compare, smallSize)
+          map.get(smallSize)
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -861,7 +849,7 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.swap(map, Nat.compare, index, Nat.toText(index) # "!").1 == ?Nat.toText(index))
+            assert (map.swap(index, Nat.toText(index) # "!").1 == ?Nat.toText(index))
           };
           true
         },
@@ -871,7 +859,7 @@ run(
         "update absent",
         do {
           let map = smallMap();
-          Map.swap(map, Nat.compare, smallSize, Nat.toText(smallSize)).1
+          map.swap(smallSize, Nat.toText(smallSize)).1
         },
         M.equals(T.optional(T.textTestable, null : ?Text))
       ),
@@ -880,9 +868,9 @@ run(
         do {
           let map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.replace(map, Nat.compare, index, Nat.toText(index) # "!").1 == ?Nat.toText(index))
+            assert (map.replace(index, Nat.toText(index) # "!").1 == ?Nat.toText(index))
           };
-          Map.size(map)
+          map.size
         },
         M.equals(T.nat(smallSize))
       ),
@@ -890,9 +878,9 @@ run(
         "replace if exists absent",
         do {
           let map0 = smallMap();
-          let (map1, ov) = Map.replace(map0, Nat.compare, smallSize, Nat.toText(smallSize));
+          let (map1, ov) = map0.replace(smallSize, Nat.toText(smallSize));
           assert (ov == null);
-          Map.size(map1)
+          map1.size
         },
         M.equals(T.nat(smallSize))
       ),
@@ -901,11 +889,11 @@ run(
         do {
           var map = smallMap();
           for (index in Nat.range(0, smallSize)) {
-            let (map1, changed) = Map.delete(map, Nat.compare, index);
+            let (map1, changed) = map.delete(index);
             assert changed;
             map := map1
           };
-          Map.isEmpty(map)
+          map.isEmpty()
         },
         M.equals(T.bool(true))
       ),
@@ -914,7 +902,7 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          map1.equal(map2)
         },
         M.equals(T.bool(true))
       ),
@@ -922,8 +910,8 @@ run(
         "not equal",
         do {
           let map1 = smallMap();
-          let (map2, _) = Map.delete(map1, Nat.compare, smallSize - 1 : Nat);
-          Map.equal(map1, map2, Nat.compare, Text.equal)
+          let (map2, _) = map1.delete(smallSize - 1 : Nat);
+          map1.equal(map2)
         },
         M.equals(T.bool(false))
       ),
@@ -931,7 +919,7 @@ run(
         "maximum entry",
         do {
           let map = smallMap();
-          Map.maxEntry(map)
+          map.maxEntry()
         },
         M.equals(T.optional(entryTestable, ?(smallSize - 1 : Nat, Nat.toText(smallSize - 1))))
       ),
@@ -939,7 +927,7 @@ run(
         "minimum entry",
         do {
           let map = smallMap();
-          Map.minEntry(map)
+          map.minEntry()
         },
         M.equals(T.optional(entryTestable, ?(0, "0")))
       ),
@@ -959,10 +947,10 @@ run(
           let array = Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) });
           let map = Map.fromIter<Nat, Text>(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
+            assert (map.get(index) == ?Nat.toText(index))
           };
           assert (Map.equal(map, smallMap(), Nat.compare, Text.equal));
-          Map.size(map)
+          map.size
         },
         M.equals(T.nat(smallSize))
       ),
@@ -971,15 +959,14 @@ run(
         do {
           let map = smallMap();
           var index = 0;
-          Map.forEach<Nat, Text>(
-            map,
+          map.forEach(
             func(key, value) {
               assert (key == index);
               assert (value == Nat.toText(index));
               index += 1
             }
           );
-          Map.size(map)
+          map.size
         },
         M.equals(T.nat(smallSize))
       ),
@@ -987,24 +974,21 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = Map.filter<Nat, Text>(
-            input,
-            Nat.compare,
-            func(key, value) {
+          let output = input.filter<Nat, Text>(func(key, value) {
               key % 2 == 0
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            let present = Map.containsKey(output, Nat.compare, index);
+            let present = output.containsKey(index);
             if (index % 2 == 0) {
               assert (present);
-              assert (Map.get(output, Nat.compare, index) == ?Nat.toText(index))
+              assert (output.get(index) == ?Nat.toText(index))
             } else {
               assert (not present);
-              assert (Map.get(output, Nat.compare, index) == null)
+              assert (output.get(index) == null)
             }
           };
-          Map.size(output)
+          output.size
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1019,9 +1003,9 @@ run(
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            assert (Map.get(output, Nat.compare, index) == ?index)
+            assert (output.get(index) == ?index)
           };
-          Map.size(output)
+          output.size
         },
         M.equals(T.nat(smallSize))
       ),
@@ -1041,16 +1025,16 @@ run(
             }
           );
           for (index in Nat.range(0, smallSize)) {
-            let present = Map.containsKey(output, Nat.compare, index);
+            let present = output.containsKey(index);
             if (index % 2 == 0) {
               assert (present);
-              assert (Map.get(output, Nat.compare, index) == ?+index)
+              assert (output.get(index) == ?+index)
             } else {
               assert (not present);
-              assert (Map.get(output, Nat.compare, index) == null)
+              assert (output.get(index) == null)
             }
           };
-          Map.size(output)
+          output.size
         },
         M.equals(T.nat((smallSize + 1) / 2))
       ),
@@ -1086,8 +1070,7 @@ run(
         "all",
         do {
           let map = smallMap();
-          Map.all<Nat, Text>(
-            map,
+          map.all<Nat, Text>(
             func(key, value) {
               key < smallSize
             }
@@ -1099,8 +1082,7 @@ run(
         "any",
         do {
           let map = smallMap();
-          Map.any<Nat, Text>(
-            map,
+          map.any<Nat, Text>(
             func(key, value) {
               key == (smallSize - 1 : Nat)
             }
@@ -1112,7 +1094,7 @@ run(
         "to text",
         do {
           let map = smallMap();
-          Map.toText<Nat, Text>(map, Nat.toText, func(value) { value })
+          map.toText()
         },
         do {
           var text = "PureMap{";
@@ -1132,7 +1114,7 @@ run(
           let (map1, result1) = Map.delete(smallMap(), Nat.compare, smallSize - 1 : Nat);
           assert result1;
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -1142,7 +1124,7 @@ run(
         do {
           let map1 = smallMap();
           let (map2, _) = Map.swap(smallMap(), Nat.compare, smallSize - 1 : Nat, "Last");
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
+          assert (map1.compare(map2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -1152,7 +1134,7 @@ run(
         do {
           let map1 = smallMap();
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
+          assert (map1.compare(map2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -1163,7 +1145,7 @@ run(
           let map1 = smallMap();
           let (map2, result2) = Map.delete(smallMap(), Nat.compare, smallSize - 1 : Nat);
           assert result2;
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -1173,7 +1155,7 @@ run(
         do {
           let (map1, _) = Map.swap(smallMap(), Nat.compare, smallSize - 1 : Nat, "Last");
           let map2 = smallMap();
-          assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
+          assert (map1.compare(map2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -1190,9 +1172,9 @@ run(
         "add disjoint",
         do {
           var map = Map.empty<Nat, Text>();
-          map := Map.add(map, Nat.compare, 0, "0");
-          map := Map.add(map, Nat.compare, 1, "1");
-          Map.size(map)
+          map := map.add(0, "0");
+          map := map.add(1, "1");
+          map.size
         },
         M.equals(T.nat(2))
       ),
@@ -1200,9 +1182,9 @@ run(
         "put existing",
         do {
           var map = Map.empty<Nat, Text>();
-          map := Map.add(map, Nat.compare, 0, "0");
-          map := Map.add(map, Nat.compare, 0, "Zero");
-          Map.get(map, Nat.compare, 0)
+          map := map.add(0, "0");
+          map := map.add(0, "Zero");
+          map.get(0)
         },
         M.equals(T.optional(T.textTestable, ?"Zero"))
       )

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -35,7 +35,7 @@ func insert(rbTree : Map.Map<Nat, Text>, key : Nat) : Map.Map<Nat, Text> {
 };
 
 func getAll(rbTree : Map.Map<Nat, Text>, keys : [Nat]) {
-  for (key in keys.vals()) {
+  for (key in keys.values()) {
     let value = rbTree.get(key);
     assert (value == ?debug_show (key))
   }

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -384,7 +384,7 @@ suite(
   }
 );
 
-queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].vals()), func n = n < 3);
+queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].values()), func n = n < 3);
 
 suite(
   "filter invariants",

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -7,9 +7,9 @@ import Iter "../../src/Iter";
 import Prim "mo:prim";
 import { suite; test; expect } "mo:test";
 
-func iterateForward<T>(queue : Queue.Queue<T>) : Iter.Iter<T> = Queue.values(queue);
+func iterateForward<T>(queue : Queue.Queue<T>) : Iter.Iter<T> = queue.values();
 
-func iterateBackward<T>(queue : Queue.Queue<T>) : Iter.Iter<T> = Queue.values(Queue.reverse(queue));
+func iterateBackward<T>(queue : Queue.Queue<T>) : Iter.Iter<T> = Queue.reverse(queue).values();
 
 func frontToText(t : (Nat, Queue.Queue<Nat>)) : Text {
   "(" # Nat.toText(t.0) # ", " # Queue.toText(t.1, Nat.toText) # ")"

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -64,14 +64,14 @@ suite(
     test(
       "iterate forward",
       func() {
-        expect.array<Nat>(Iter.toArray(iterateForward(queue)), Nat.toText, Nat.equal).size(0)
+        expect.array<Nat>((iterateForward(queue)).toArray(), Nat.toText, Nat.equal).size(0)
       }
     );
 
     test(
       "iterate backward",
       func() {
-        expect.array(Iter.toArray(iterateBackward(queue)), Nat.toText, Nat.equal).size(0)
+        expect.array((iterateBackward(queue)).toArray(), Nat.toText, Nat.equal).size(0)
       }
     );
 
@@ -128,14 +128,14 @@ suite(
     test(
       "iterate forward",
       func() {
-        expect.array(Iter.toArray(iterateForward(queue)), Nat.toText, Nat.equal).equal([1])
+        expect.array((iterateForward(queue)).toArray(), Nat.toText, Nat.equal).equal([1])
       }
     );
 
     test(
       "iterate backward",
       func() {
-        expect.array(Iter.toArray(iterateBackward(queue)), Nat.toText, Nat.equal).equal([1])
+        expect.array((iterateBackward(queue)).toArray(), Nat.toText, Nat.equal).equal([1])
       }
     );
 
@@ -203,7 +203,7 @@ suite(
       "iterate forward",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -221,7 +221,7 @@ suite(
       "iterate backward",
       func() {
         expect.array(
-          Iter.toArray(iterateBackward(queue)),
+          (iterateBackward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -300,7 +300,7 @@ suite(
       "iterate forward",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -318,7 +318,7 @@ suite(
       "iterate backward",
       func() {
         expect.array(
-          Iter.toArray(iterateBackward(queue)),
+          (iterateBackward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -433,7 +433,7 @@ func randomPopulate(amount : Nat) : Queue.Queue<Nat> {
 };
 
 func isSorted(queue : Queue.Queue<Nat>) : Bool {
-  let array = Iter.toArray(iterateForward(queue));
+  let array = (iterateForward(queue)).toArray();
   let sorted = Array.sort(array, Nat.compare);
   Array.equal(array, sorted, Nat.equal)
 };
@@ -481,10 +481,10 @@ suite(
       "consistent iteration",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
-        ).equal(Array.reverse(Iter.toArray(iterateBackward(queue))))
+        ).equal(Array.reverse((iterateBackward(queue)).toArray()))
       }
     );
 

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -67,14 +67,14 @@ suite(
     test(
       "iterate forward",
       func() {
-        expect.array<Nat>(Iter.toArray(iterateForward(queue)), Nat.toText, Nat.equal).size(0)
+        expect.array<Nat>((iterateForward(queue)).toArray(), Nat.toText, Nat.equal).size(0)
       }
     );
 
     test(
       "iterate backward",
       func() {
-        expect.array(Iter.toArray(iterateBackward(queue)), Nat.toText, Nat.equal).size(0)
+        expect.array((iterateBackward(queue)).toArray(), Nat.toText, Nat.equal).size(0)
       }
     );
 
@@ -131,14 +131,14 @@ suite(
     test(
       "iterate forward",
       func() {
-        expect.array(Iter.toArray(iterateForward(queue)), Nat.toText, Nat.equal).equal([1])
+        expect.array((iterateForward(queue)).toArray(), Nat.toText, Nat.equal).equal([1])
       }
     );
 
     test(
       "iterate backward",
       func() {
-        expect.array(Iter.toArray(iterateBackward(queue)), Nat.toText, Nat.equal).equal([1])
+        expect.array((iterateBackward(queue)).toArray(), Nat.toText, Nat.equal).equal([1])
       }
     );
 
@@ -206,7 +206,7 @@ suite(
       "iterate forward",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -224,7 +224,7 @@ suite(
       "iterate backward",
       func() {
         expect.array(
-          Iter.toArray(iterateBackward(queue)),
+          (iterateBackward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -303,7 +303,7 @@ suite(
       "iterate forward",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -321,7 +321,7 @@ suite(
       "iterate backward",
       func() {
         expect.array(
-          Iter.toArray(iterateBackward(queue)),
+          (iterateBackward(queue)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal(
@@ -436,7 +436,7 @@ func randomPopulate(amount : Nat) : Queue<Nat> {
 };
 
 func isSorted(queue : Queue<Nat>) : Bool {
-  let array = Iter.toArray(iterateForward(queue));
+  let array = (iterateForward(queue)).toArray();
   let sorted = Array.sort(array, Nat.compare);
   Array.equal(array, sorted, Nat.equal)
 };
@@ -484,10 +484,10 @@ suite(
       "consistent iteration",
       func() {
         expect.array(
-          Iter.toArray(iterateForward(queue)),
+          (iterateForward(queue)).toArray(),
           Nat.toText,
           Nat.equal
-        ).equal(Array.reverse(Iter.toArray(iterateBackward(queue))))
+        ).equal(Array.reverse((iterateBackward(queue)).toArray()))
       }
     );
 
@@ -618,7 +618,7 @@ suite(
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
           );
           expect.array<Text>(
-            Iter.toArray(Queue.values(mapped)),
+            (Queue.values(mapped)).toArray(),
             func t = t,
             Text.equal
           ).equal(Array.filterMap<Nat, Text>(testElements, func n = if (n % 2 == 0) ?Nat.toText(n) else null))
@@ -737,7 +737,7 @@ suite(
           let q = Queue.fromIter(testElements.vals());
           let mapped = Queue.map<Nat, Nat>(q, func n = n * 2);
           expect.array(
-            Iter.toArray(Queue.values(mapped)),
+            (Queue.values(mapped)).toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.map<Nat, Nat>(testElements, func n = n * 2))
@@ -759,7 +759,7 @@ suite(
           let q = Queue.fromIter(testElements.vals());
           let reversed = Queue.reverse(q);
           expect.array(
-            Iter.toArray(Queue.values(reversed)),
+            (Queue.values(reversed)).toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.reverse(testElements))
@@ -866,7 +866,7 @@ suite(
         q := Queue.pushFront(q, 300);
         // Verify order is maintained
         expect.array(
-          Iter.toArray(Queue.values(q)),
+          (Queue.values(q)).toArray(),
           Nat.toText,
           Nat.equal
         ).equal([300, 4, 3, 2, 1, 0, 100, 101, 102, 103, 104, 200])
@@ -879,7 +879,7 @@ suite(
   "regression: stack overflow should not happen when iterating over large queues",
   func() {
     let queue = populateForward(1, 17_001);
-    let actual = Iter.toArray(iterateBackward(queue));
+    let actual = (iterateBackward(queue)).toArray();
     expect.array(
       actual,
       Nat.toText,

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -10,9 +10,9 @@ import Text "../../src/Text";
 
 type Queue<T> = Queue.Queue<T>;
 
-func iterateForward<T>(queue : Queue<T>) : Iter.Iter<T> = Queue.values(queue);
+func iterateForward<T>(queue : Queue<T>) : Iter.Iter<T> = queue.values();
 
-func iterateBackward<T>(queue : Queue<T>) : Iter.Iter<T> = Queue.values(Queue.reverse(queue));
+func iterateBackward<T>(queue : Queue<T>) : Iter.Iter<T> = Queue.reverse(queue).values();
 
 func frontToText(t : (Nat, Queue<Nat>)) : Text {
   "(" # Nat.toText(t.0) # ", " # Queue.toText(t.1, Nat.toText) # ")"
@@ -618,7 +618,7 @@ suite(
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
           );
           expect.array<Text>(
-            (Queue.values(mapped)).toArray(),
+            (mapped.values()).toArray(),
             func t = t,
             Text.equal
           ).equal(Array.filterMap<Nat, Text>(testElements, func n = if (n % 2 == 0) ?Nat.toText(n) else null))
@@ -737,7 +737,7 @@ suite(
           let q = Queue.fromIter(testElements.vals());
           let mapped = Queue.map<Nat, Nat>(q, func n = n * 2);
           expect.array(
-            (Queue.values(mapped)).toArray(),
+            (mapped.values()).toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.map<Nat, Nat>(testElements, func n = n * 2))
@@ -759,7 +759,7 @@ suite(
           let q = Queue.fromIter(testElements.vals());
           let reversed = Queue.reverse(q);
           expect.array(
-            (Queue.values(reversed)).toArray(),
+            (reversed.values()).toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.reverse(testElements))
@@ -866,7 +866,7 @@ suite(
         q := Queue.pushFront(q, 300);
         // Verify order is maintained
         expect.array(
-          (Queue.values(q)).toArray(),
+          (q.values()).toArray(),
           Nat.toText,
           Nat.equal
         ).equal([300, 4, 3, 2, 1, 0, 100, 101, 102, 103, 104, 200])

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -618,7 +618,7 @@ suite(
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
           );
           expect.array<Text>(
-            (mapped.values()).toArray(),
+            mapped.values().toArray(),
             func t = t,
             Text.equal
           ).equal(Array.filterMap<Nat, Text>(testElements, func n = if (n % 2 == 0) ?Nat.toText(n) else null))
@@ -737,7 +737,7 @@ suite(
           let q = Queue.fromIter(testElements.values());
           let mapped = Queue.map<Nat, Nat>(q, func n = n * 2);
           expect.array(
-            (mapped.values()).toArray(),
+            mapped.values().toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.map<Nat, Nat>(testElements, func n = n * 2))
@@ -759,7 +759,7 @@ suite(
           let q = Queue.fromIter(testElements.values());
           let reversed = Queue.reverse(q);
           expect.array(
-            (reversed.values()).toArray(),
+            reversed.values().toArray(),
             Nat.toText,
             Nat.equal
           ).equal(Array.reverse(testElements))
@@ -866,7 +866,7 @@ suite(
         q := Queue.pushFront(q, 300);
         // Verify order is maintained
         expect.array(
-          (q.values()).toArray(),
+          q.values().toArray(),
           Nat.toText,
           Nat.equal
         ).equal([300, 4, 3, 2, 1, 0, 100, 101, 102, 103, 104, 200])

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -387,7 +387,7 @@ suite(
   }
 );
 
-queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].vals()), func n = n < 3);
+queue := Queue.filter<Nat>(Queue.fromIter([1, 2, 3, 4, 5].values()), func n = n < 3);
 
 suite(
   "filter invariants",
@@ -595,7 +595,7 @@ suite(
       "all",
       func() {
         let testAll = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.bool(Queue.all<Nat>(q, func n = n > 0)).isTrue();
           expect.bool(Queue.all<Nat>(q, func n = n < 3)).isFalse()
         };
@@ -612,7 +612,7 @@ suite(
       "filterMap",
       func() {
         let testFilterMap = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let mapped = Queue.filterMap<Nat, Text>(
             q,
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
@@ -637,7 +637,7 @@ suite(
       "forEach",
       func() {
         let testForEach = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           var result = "";
           Queue.forEach<Nat>(
             q,
@@ -661,7 +661,7 @@ suite(
       "toText",
       func() {
         let testToText = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.text(Queue.toText(q, Nat.toText)).equal("RealTimeQueue" # Array.toText<Nat>(testElements, Nat.toText))
         };
         testToText([]);
@@ -678,7 +678,7 @@ suite(
       "size",
       func() {
         let testSize = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.nat(Queue.size(q)).equal(testElements.size())
         };
         testSize([]);
@@ -695,7 +695,7 @@ suite(
       "contains",
       func() {
         let testContains = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let alwaysThere = 1;
           let neverThere = 123;
           expect.bool(Queue.contains(q, Nat.equal, alwaysThere)).equal(Array.find<Nat>(testElements, func n = Nat.equal(n, alwaysThere)) != null);
@@ -715,7 +715,7 @@ suite(
       "any",
       func() {
         let testAny = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           expect.bool(Queue.any<Nat>(q, func n = n > 2)).equal(Array.any<Nat>(testElements, func n = n > 2));
           expect.bool(Queue.any<Nat>(q, func n = n > 3)).equal(Array.any<Nat>(testElements, func n = n > 3))
         };
@@ -734,7 +734,7 @@ suite(
       "map",
       func() {
         let testMap = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let mapped = Queue.map<Nat, Nat>(q, func n = n * 2);
           expect.array(
             (mapped.values()).toArray(),
@@ -756,7 +756,7 @@ suite(
       "reverse",
       func() {
         let testReverse = func(testElements : [Nat]) {
-          let q = Queue.fromIter(testElements.vals());
+          let q = Queue.fromIter(testElements.values());
           let reversed = Queue.reverse(q);
           expect.array(
             (reversed.values()).toArray(),
@@ -779,8 +779,8 @@ suite(
       "compare",
       func() {
         let testCompare = func(testElements1 : [Nat], testElements2 : [Nat]) {
-          let q1 = Queue.fromIter(testElements1.vals());
-          let q2 = Queue.fromIter(testElements2.vals());
+          let q1 = Queue.fromIter(testElements1.values());
+          let q2 = Queue.fromIter(testElements2.values());
           expect.bool(q1.compare(q2) == Array.compare<Nat>(testElements1, testElements2, Nat.compare)).isTrue()
         };
 
@@ -860,9 +860,9 @@ suite(
           q := Queue.pushBack(q, i + 100)
         };
         // Mixed operations
-        expect.option(Queue.popFront(q), frontToText, frontEqual).equal(?(4, Queue.fromIter([3, 2, 1, 0, 100, 101, 102, 103, 104].vals())));
+        expect.option(Queue.popFront(q), frontToText, frontEqual).equal(?(4, Queue.fromIter([3, 2, 1, 0, 100, 101, 102, 103, 104].values())));
         q := Queue.pushBack(q, 200);
-        expect.option(Queue.popBack(q), backToText, backEqual).equal(?(Queue.fromIter([4, 3, 2, 1, 0, 100, 101, 102, 103, 104].vals()), 200));
+        expect.option(Queue.popBack(q), backToText, backEqual).equal(?(Queue.fromIter([4, 3, 2, 1, 0, 100, 101, 102, 103, 104].values()), 200));
         q := Queue.pushFront(q, 300);
         // Verify order is maintained
         expect.array(

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -781,7 +781,7 @@ suite(
         let testCompare = func(testElements1 : [Nat], testElements2 : [Nat]) {
           let q1 = Queue.fromIter(testElements1.vals());
           let q2 = Queue.fromIter(testElements2.vals());
-          expect.bool(Queue.compare(q1, q2, Nat.compare) == Array.compare<Nat>(testElements1, testElements2, Nat.compare)).isTrue()
+          expect.bool(q1.compare(q2) == Array.compare<Nat>(testElements1, testElements2, Nat.compare)).isTrue()
         };
 
         testCompare([], []);

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -17,7 +17,7 @@ let c = Nat.compare;
 
 class SetMatcher(expected : Set.Set<Nat>) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(Set.values(actual))) # " should be " # debug_show (Iter.toArray(Set.values(expected))))
+    Debug.print(debug_show ((Set.values(actual)).toArray()) # " should be " # debug_show ((Set.values(expected)).toArray()))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
@@ -79,7 +79,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 1)) {
           if (not f(sets[0])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s: " # debug_show (Iter.toArray(Set.values(sets[0])));
+            error_msg #= "\n s: " # debug_show ((Set.values(sets[0])).toArray());
             break stop
           }
         };
@@ -98,8 +98,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 2)) {
           if (not f(sets[0], sets[1])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show (Iter.toArray(Set.values(sets[0])));
-            error_msg #= "\n s2: " # debug_show (Iter.toArray(Set.values(sets[1])));
+            error_msg #= "\n s1: " # debug_show ((Set.values(sets[0])).toArray());
+            error_msg #= "\n s2: " # debug_show ((Set.values(sets[1])).toArray());
             break stop
           }
         };
@@ -118,9 +118,9 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 3)) {
           if (not f(sets[0], sets[1], sets[2])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show (Iter.toArray(Set.values(sets[0])));
-            error_msg #= "\n s2: " # debug_show (Iter.toArray(Set.values(sets[1])));
-            error_msg #= "\n s3: " # debug_show (Iter.toArray(Set.values(sets[2])));
+            error_msg #= "\n s1: " # debug_show ((Set.values(sets[0])).toArray());
+            error_msg #= "\n s2: " # debug_show ((Set.values(sets[1])).toArray());
+            error_msg #= "\n s3: " # debug_show ((Set.values(sets[2])).toArray());
             break stop
           }
         };
@@ -140,7 +140,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             let key = Random.nextNat(range);
             if (not f(sets[0], key)) {
               error_msg #= "Property \"" # name # "\" failed";
-              error_msg #= "\n s: " # debug_show (Iter.toArray(Set.values(sets[0])));
+              error_msg #= "\n s: " # debug_show ((Set.values(sets[0])).toArray());
               error_msg #= "\n e: " # debug_show (key);
               break stop
             }
@@ -319,8 +319,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             prop(
               "toArray(values(s)).reverse() == toArray(reverseValues(s))",
               func(s) {
-                let a = Array.reverse(Iter.toArray(Set.values(s)));
-                let b = Iter.toArray(Set.reverseValues(s));
+                let a = Array.reverse((Set.values(s)).toArray());
+                let b = (Set.reverseValues(s)).toArray();
                 M.equals(T.array<Nat>(T.natTestable, a)).matches(b)
               }
             )

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -17,7 +17,7 @@ let c = Nat.compare;
 
 class SetMatcher(expected : Set.Set<Nat>) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show ((actual.values()).toArray()) # " should be " # debug_show ((expected.values()).toArray()))
+    Debug.print(debug_show (actual.values().toArray()) # " should be " # debug_show (expected.values().toArray()))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
@@ -79,7 +79,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 1)) {
           if (not f(sets[0])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s: " # debug_show ((sets[0].values()).toArray());
+            error_msg #= "\n s: " # debug_show (sets[0].values().toArray());
             break stop
           }
         };
@@ -98,8 +98,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 2)) {
           if (not f(sets[0], sets[1])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show ((sets[0].values()).toArray());
-            error_msg #= "\n s2: " # debug_show ((sets[1].values()).toArray());
+            error_msg #= "\n s1: " # debug_show (sets[0].values().toArray());
+            error_msg #= "\n s2: " # debug_show (sets[1].values().toArray());
             break stop
           }
         };
@@ -118,9 +118,9 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 3)) {
           if (not f(sets[0], sets[1], sets[2])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show ((sets[0].values()).toArray());
-            error_msg #= "\n s2: " # debug_show ((sets[1].values()).toArray());
-            error_msg #= "\n s3: " # debug_show ((sets[2].values()).toArray());
+            error_msg #= "\n s1: " # debug_show (sets[0].values().toArray());
+            error_msg #= "\n s2: " # debug_show (sets[1].values().toArray());
+            error_msg #= "\n s3: " # debug_show (sets[2].values().toArray());
             break stop
           }
         };
@@ -140,7 +140,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             let key = Random.nextNat(range);
             if (not f(sets[0], key)) {
               error_msg #= "Property \"" # name # "\" failed";
-              error_msg #= "\n s: " # debug_show ((sets[0].values()).toArray());
+              error_msg #= "\n s: " # debug_show (sets[0].values().toArray());
               error_msg #= "\n e: " # debug_show (key);
               break stop
             }
@@ -319,8 +319,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             prop(
               "toArray(values(s)).reverse() == toArray(reverseValues(s))",
               func(s) {
-                let a = Array.reverse((s.values()).toArray());
-                let b = (s.reverseValues()).toArray();
+                let a = Array.reverse(s.values().toArray());
+                let b = s.reverseValues().toArray();
                 M.equals(T.array<Nat>(T.natTestable, a)).matches(b)
               }
             )

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -60,7 +60,7 @@ func setGenN(samples_number : Nat, size : Nat, range : (Nat, Nat), chunkSize : N
         ?Array.tabulate<Set.Set<Nat>>(
           chunkSize,
           func _ = Set.fromIter(
-            Random.nextEntries(range, size).vals(),
+            Random.nextEntries(range, size).values(),
             c
           )
         )

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -17,7 +17,7 @@ let c = Nat.compare;
 
 class SetMatcher(expected : Set.Set<Nat>) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show ((Set.values(actual)).toArray()) # " should be " # debug_show ((Set.values(expected)).toArray()))
+    Debug.print(debug_show ((actual.values()).toArray()) # " should be " # debug_show ((expected.values()).toArray()))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
@@ -79,7 +79,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 1)) {
           if (not f(sets[0])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s: " # debug_show ((Set.values(sets[0])).toArray());
+            error_msg #= "\n s: " # debug_show ((sets[0].values()).toArray());
             break stop
           }
         };
@@ -98,8 +98,8 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 2)) {
           if (not f(sets[0], sets[1])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show ((Set.values(sets[0])).toArray());
-            error_msg #= "\n s2: " # debug_show ((Set.values(sets[1])).toArray());
+            error_msg #= "\n s1: " # debug_show ((sets[0].values()).toArray());
+            error_msg #= "\n s2: " # debug_show ((sets[1].values()).toArray());
             break stop
           }
         };
@@ -118,9 +118,9 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
         label stop for (sets in setGenN(set_samples, size, range, 3)) {
           if (not f(sets[0], sets[1], sets[2])) {
             error_msg := "Property \"" # name # "\" failed\n";
-            error_msg #= "\n s1: " # debug_show ((Set.values(sets[0])).toArray());
-            error_msg #= "\n s2: " # debug_show ((Set.values(sets[1])).toArray());
-            error_msg #= "\n s3: " # debug_show ((Set.values(sets[2])).toArray());
+            error_msg #= "\n s1: " # debug_show ((sets[0].values()).toArray());
+            error_msg #= "\n s2: " # debug_show ((sets[1].values()).toArray());
+            error_msg #= "\n s3: " # debug_show ((sets[2].values()).toArray());
             break stop
           }
         };
@@ -140,7 +140,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             let key = Random.nextNat(range);
             if (not f(sets[0], key)) {
               error_msg #= "Property \"" # name # "\" failed";
-              error_msg #= "\n s: " # debug_show ((Set.values(sets[0])).toArray());
+              error_msg #= "\n s: " # debug_show ((sets[0].values()).toArray());
               error_msg #= "\n e: " # debug_show (key);
               break stop
             }
@@ -199,14 +199,14 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             prop(
               "foldLeft as values()",
               func(m) {
-                let it = Set.values(m);
+                let it = m.values();
                 Set.foldLeft<Nat, Bool>(m, true, func(acc, v) { acc and it.next() == ?v })
               }
             ),
             prop(
               "foldRight as valsRev()",
               func(m) {
-                let it = Set.reverseValues(m);
+                let it = m.reverseValues();
                 Set.foldRight<Nat, Bool>(m, true, func(v, acc) { acc and it.next() == ?v })
               }
             )
@@ -307,20 +307,20 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             prop(
               "fromIter(values(s), c) == s",
               func(s) {
-                SetMatcher(s).matches(Set.fromIter(Set.values(s), c))
+                SetMatcher(s).matches(Set.fromIter(s.values(), c))
               }
             ),
             prop(
               "fromIter(reverseValue(s), c) == s",
               func(s) {
-                SetMatcher(s).matches(Set.fromIter(Set.reverseValues(s), c))
+                SetMatcher(s).matches(Set.fromIter(s.reverseValues(), c))
               }
             ),
             prop(
               "toArray(values(s)).reverse() == toArray(reverseValues(s))",
               func(s) {
-                let a = Array.reverse((Set.values(s)).toArray());
-                let b = (Set.reverseValues(s)).toArray();
+                let a = Array.reverse((s.values()).toArray());
+                let b = (s.reverseValues()).toArray();
                 M.equals(T.array<Nat>(T.natTestable, a)).matches(b)
               }
             )

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -124,7 +124,8 @@ run(
         "filter",
         do {
           let input = Set.empty<Nat>();
-          let output = input.filter<Nat>(func(_) {
+          let output = input.filter<Nat>(
+            func(_) {
               Runtime.trap("test failed")
             }
           );
@@ -254,7 +255,8 @@ run(
         "filter",
         do {
           let input = buildTestSet();
-          let output = input.filter<Nat>(func(number) {
+          let output = input.filter<Nat>(
+            func(number) {
               assert (number == 0);
               true
             }
@@ -465,7 +467,8 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
     "filter",
     do {
       let input = buildTestSet();
-      let output = input.filter<Nat>(func(number) {
+      let output = input.filter<Nat>(
+        func(number) {
           number % 2 == 0
         }
       );

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -79,12 +79,12 @@ run(
       ),
       test(
         "values",
-        (buildTestSet().values()).toArray(),
+        buildTestSet().values().toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
         "reverseValues",
-        (buildTestSet().reverseValues()).toArray(),
+        buildTestSet().reverseValues().toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
@@ -215,12 +215,12 @@ run(
       ),
       test(
         "values",
-        (buildTestSet().values()).toArray(),
+        buildTestSet().values().toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
         "reverseValues",
-        (buildTestSet().reverseValues()).toArray(),
+        buildTestSet().reverseValues().toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
@@ -401,12 +401,12 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   ),
   test(
     "values",
-    (buildTestSet().values()).toArray(),
+    buildTestSet().values().toArray(),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(
     "reverseValues",
-    Array.reverse((buildTestSet().reverseValues()).toArray()),
+    Array.reverse(buildTestSet().reverseValues().toArray()),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -18,11 +18,11 @@ let entryTestable = T.natTestable;
 
 class SetMatcher(expected : [Nat]) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show ((actual.values()).toArray()) # " should be " # debug_show (expected))
+    Debug.print(debug_show (actual.values().toArray()) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
-    (actual.values()).toArray() == expected
+    actual.values().toArray() == expected
   }
 };
 
@@ -351,7 +351,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -369,7 +369,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = setOfSets.flatten();
-          (combined.values()).toArray()
+          combined.values().toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -569,7 +569,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
       let set2 = buildTestSet().map<Nat, Int>(func(number) { -number });
       let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
       let combined = Set.join(Iter.fromArray([set1, set2, set3]));
-      (combined.values()).toArray()
+      combined.values().toArray()
     },
     do {
       let size = buildTestSet().size;
@@ -595,7 +595,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
       let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
       let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { first.compare(second) });
       let combined = Set.flatten(setOfSets, Int.compare);
-      (combined.values()).toArray()
+      combined.values().toArray()
     },
     do {
       let size = buildTestSet().size;

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -18,11 +18,11 @@ let entryTestable = T.natTestable;
 
 class SetMatcher(expected : [Nat]) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(actual.values())) # " should be " # debug_show (expected))
+    Debug.print(debug_show ((actual.values()).toArray()) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
-    Iter.toArray(actual.values()) == expected
+    (actual.values()).toArray() == expected
   }
 };
 
@@ -79,12 +79,12 @@ run(
       ),
       test(
         "values",
-        Iter.toArray(Set.values(buildTestSet())),
+        (Set.values(buildTestSet())).toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
         "reverseValues",
-        Iter.toArray(Set.reverseValues(buildTestSet())),
+        (Set.reverseValues(buildTestSet())).toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
@@ -214,12 +214,12 @@ run(
       ),
       test(
         "values",
-        Iter.toArray(Set.values(buildTestSet())),
+        (Set.values(buildTestSet())).toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
         "reverseValues",
-        Iter.toArray(Set.reverseValues(buildTestSet())),
+        (Set.reverseValues(buildTestSet())).toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
@@ -351,7 +351,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -369,7 +369,7 @@ run(
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
           let combined = setOfSets.flatten();
-          Iter.toArray(combined.values())
+          (combined.values()).toArray()
         },
         M.equals(
           T.array<Nat>(
@@ -399,12 +399,12 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   ),
   test(
     "values",
-    Iter.toArray(Set.values(buildTestSet())),
+    (Set.values(buildTestSet())).toArray(),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(
     "reverseValues",
-    Array.reverse(Iter.toArray(Set.reverseValues(buildTestSet()))),
+    Array.reverse((Set.reverseValues(buildTestSet())).toArray()),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(
@@ -569,7 +569,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
       let set2 = buildTestSet().map<Nat, Int>(func(number) { -number });
       let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
       let combined = Set.join(Iter.fromArray([set1, set2, set3]));
-      Iter.toArray(combined.values())
+      (combined.values()).toArray()
     },
     do {
       let size = buildTestSet().size;
@@ -595,7 +595,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
       let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
       let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { first.compare(second) });
       let combined = Set.flatten(setOfSets, Int.compare);
-      Iter.toArray(combined.values())
+      (combined.values()).toArray()
     },
     do {
       let size = buildTestSet().size;

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -79,12 +79,12 @@ run(
       ),
       test(
         "values",
-        (Set.values(buildTestSet())).toArray(),
+        (buildTestSet().values()).toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
         "reverseValues",
-        (Set.reverseValues(buildTestSet())).toArray(),
+        (buildTestSet().reverseValues()).toArray(),
         M.equals(T.array<Nat>(entryTestable, []))
       ),
       test(
@@ -214,12 +214,12 @@ run(
       ),
       test(
         "values",
-        (Set.values(buildTestSet())).toArray(),
+        (buildTestSet().values()).toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
         "reverseValues",
-        (Set.reverseValues(buildTestSet())).toArray(),
+        (buildTestSet().reverseValues()).toArray(),
         M.equals(T.array<Nat>(entryTestable, expected))
       ),
       test(
@@ -399,12 +399,12 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   ),
   test(
     "values",
-    (Set.values(buildTestSet())).toArray(),
+    (buildTestSet().values()).toArray(),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(
     "reverseValues",
-    Array.reverse((Set.reverseValues(buildTestSet())).toArray()),
+    Array.reverse((buildTestSet().reverseValues()).toArray()),
     M.equals(T.array<Nat>(entryTestable, expected))
   ),
   test(

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -41,7 +41,7 @@ func concatenateKeys2(accum : Text, key : Nat) : Text {
 };
 
 func containsAll(set : Set.Set<Nat>, elems : [Nat]) {
-  for (elem in elems.vals()) {
+  for (elem in elems.values()) {
     assert (set.contains(elem))
   }
 };

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -18,17 +18,17 @@ let entryTestable = T.natTestable;
 
 class SetMatcher(expected : [Nat]) : M.Matcher<Set.Set<Nat>> {
   public func describeMismatch(actual : Set.Set<Nat>, _description : M.Description) {
-    Debug.print(debug_show (Iter.toArray(Set.values(actual))) # " should be " # debug_show (expected))
+    Debug.print(debug_show (Iter.toArray(actual.values())) # " should be " # debug_show (expected))
   };
 
   public func matches(actual : Set.Set<Nat>) : Bool {
-    Iter.toArray(Set.values(actual)) == expected
+    Iter.toArray(actual.values()) == expected
   }
 };
 
 func insert(s : Set.Set<Nat>, key : Nat) : Set.Set<Nat> {
-  let s1 = Set.add(s, Nat.compare, key);
-  Set.assertValid(s1, Nat.compare);
+  let s1 = s.add(key);
+  s1.assertValid();
   s1
 };
 
@@ -42,16 +42,16 @@ func concatenateKeys2(accum : Text, key : Nat) : Text {
 
 func containsAll(set : Set.Set<Nat>, elems : [Nat]) {
   for (elem in elems.vals()) {
-    assert (Set.contains(set, Nat.compare, elem))
+    assert (set.contains(elem))
   }
 };
 
 func clear(initialSet : Set.Set<Nat>) : Set.Set<Nat> {
   var set = initialSet;
-  for (elem in Set.values(initialSet)) {
-    let newSet = Set.remove(set, Nat.compare, elem);
+  for (elem in initialSet.values()) {
+    let newSet = set.remove(elem);
     set := newSet;
-    Set.assertValid(set, Nat.compare)
+    set.assertValid()
   };
   set
 };
@@ -74,7 +74,7 @@ run(
     [
       test(
         "size",
-        Set.size(buildTestSet()),
+        buildTestSet().size,
         M.equals(T.nat(0))
       ),
       test(
@@ -111,13 +111,12 @@ run(
         "for each",
         do {
           let set = Set.empty<Nat>();
-          Set.forEach<Nat>(
-            set,
+          set.forEach(
             func(_) {
               Runtime.trap("test failed")
             }
           );
-          Set.size(set)
+          set.size
         },
         M.equals(T.nat(0))
       ),
@@ -125,20 +124,17 @@ run(
         "filter",
         do {
           let input = Set.empty<Nat>();
-          let output = Set.filter<Nat>(
-            input,
-            Nat.compare,
-            func(_) {
+          let output = input.filter<Nat>(func(_) {
               Runtime.trap("test failed")
             }
           );
-          Set.size(output)
+          output.size
         },
         M.equals(T.nat(0))
       ),
       test(
         "traverse empty set",
-        Set.map(buildTestSet(), Nat.compare, add1),
+        buildTestSet().map(add1),
         SetMatcher([])
       ),
       test(
@@ -166,7 +162,7 @@ run(
         do {
           let set1 = Set.empty<Nat>();
           let set2 = Set.empty<Nat>();
-          assert (Set.compare(set1, set2, Nat.compare) == #equal);
+          assert (set1.compare(set2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -178,7 +174,7 @@ run(
           let set2 = set1;
           let set3 = set2;
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          Set.size(combined)
+          combined.size
         },
         M.equals(T.nat(0))
       ),
@@ -189,9 +185,9 @@ run(
           let subSet2 = subSet1;
           let subSet3 = subSet2;
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
-          let combined = Set.flatten(setOfSets, Nat.compare);
-          Set.size(combined)
+          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
+          let combined = setOfSets.flatten();
+          combined.size
         },
         M.equals(T.nat(0))
       )
@@ -213,7 +209,7 @@ run(
     [
       test(
         "size",
-        Set.size(buildTestSet()),
+        buildTestSet().size,
         M.equals(T.nat(1))
       ),
       test(
@@ -245,13 +241,12 @@ run(
         "for each",
         do {
           let set = buildTestSet();
-          Set.forEach<Nat>(
-            set,
+          set.forEach(
             func(number) {
               assert (number == 0)
             }
           );
-          Set.size(set)
+          set.size
         },
         M.equals(T.nat(1))
       ),
@@ -259,16 +254,13 @@ run(
         "filter",
         do {
           let input = buildTestSet();
-          let output = Set.filter<Nat>(
-            input,
-            Nat.compare,
-            func(number) {
+          let output = input.filter<Nat>(func(number) {
               assert (number == 0);
               true
             }
           );
-          assert (Set.equal(input, output, Nat.compare));
-          Set.size(output)
+          assert (input.equal(output));
+          output.size
         },
         M.equals(T.nat(1))
       ),
@@ -284,7 +276,7 @@ run(
       ),
       test(
         "traverse set",
-        Set.map(buildTestSet(), Nat.compare, add1),
+        buildTestSet().map(add1),
         SetMatcher([1])
       ),
       test(
@@ -327,7 +319,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(1);
-          assert (Set.compare(set1, set2, Nat.compare) == #less);
+          assert (set1.compare(set2) == #less);
           true
         },
         M.equals(T.bool(true))
@@ -337,7 +329,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(0);
           let set2 = Set.singleton<Nat>(0);
-          assert (Set.compare(set1, set2, Nat.compare) == #equal);
+          assert (set1.compare(set2) == #equal);
           true
         },
         M.equals(T.bool(true))
@@ -347,7 +339,7 @@ run(
         do {
           let set1 = Set.singleton<Nat>(1);
           let set2 = Set.singleton<Nat>(0);
-          assert (Set.compare(set1, set2, Nat.compare) == #greater);
+          assert (set1.compare(set2) == #greater);
           true
         },
         M.equals(T.bool(true))
@@ -359,7 +351,7 @@ run(
           let set2 = Set.singleton<Nat>(1);
           let set3 = Set.singleton<Nat>(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
-          Iter.toArray(Set.values(combined))
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Nat>(
@@ -375,9 +367,9 @@ run(
           let subSet2 = Set.singleton<Nat>(1);
           let subSet3 = Set.singleton<Nat>(2);
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
-          let combined = Set.flatten(setOfSets, Nat.compare);
-          Iter.toArray(Set.values(combined))
+          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { first.compare(second) });
+          let combined = setOfSets.flatten();
+          Iter.toArray(combined.values())
         },
         M.equals(
           T.array<Nat>(
@@ -397,7 +389,7 @@ expected := [0, 1, 2];
 func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "size",
-    Set.size(buildTestSet()),
+    buildTestSet().size,
     M.equals(T.nat(3))
   ),
   test(
@@ -446,12 +438,12 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   ),
   test(
     "traverse set",
-    Set.map(buildTestSet(), Nat.compare, add1),
+    buildTestSet().map(add1),
     SetMatcher([1, 2, 3])
   ),
   test(
     "traverse set/reshape",
-    Set.map(buildTestSet(), Nat.compare, func(x : Nat) : Nat { 5 }),
+    buildTestSet().map(func(x : Nat) : Nat { 5 }),
     SetMatcher([5])
   ),
   test(
@@ -459,39 +451,35 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
     do {
       let set = buildTestSet();
       var index = 0;
-      Set.forEach<Nat>(
-        set,
+      set.forEach(
         func(element) {
           assert (element == index);
           index += 1
         }
       );
-      Set.size(set)
+      set.size
     },
-    M.equals(T.nat(Set.size(buildTestSet())))
+    M.equals(T.nat(buildTestSet().size))
   ),
   test(
     "filter",
     do {
       let input = buildTestSet();
-      let output = Set.filter<Nat>(
-        input,
-        Nat.compare,
-        func(number) {
+      let output = input.filter<Nat>(func(number) {
           number % 2 == 0
         }
       );
-      for (index in Nat.range(0, Set.size(input))) {
-        let present = Set.contains(output, Nat.compare, index);
+      for (index in Nat.range(0, input.size)) {
+        let present = output.contains(index);
         if (index % 2 == 0) {
           assert (present)
         } else {
           assert (not present)
         }
       };
-      Set.size(output)
+      output.size
     },
-    M.equals(T.nat((Set.size(buildTestSet()) + 1) / 2))
+    M.equals(T.nat((buildTestSet().size + 1) / 2))
   ),
   test(
     "filterMap / filter all",
@@ -546,9 +534,9 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "compare less key",
     do {
-      let set1 = buildTestSet() |> Set.remove(_, Nat.compare, Set.size(_) - 1 : Nat);
+      let set1 = buildTestSet() |> _.remove(_.size - 1 : Nat);
       let set2 = buildTestSet();
-      assert (Set.compare(set1, set2, Nat.compare) == #less);
+      assert (set1.compare(set2) == #less);
       true
     },
     M.equals(T.bool(true))
@@ -558,7 +546,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
     do {
       let set1 = buildTestSet();
       let set2 = buildTestSet();
-      assert (Set.compare(set1, set2, Nat.compare) == #equal);
+      assert (set1.compare(set2) == #equal);
       true
     },
     M.equals(T.bool(true))
@@ -567,9 +555,9 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
     "compare greater key",
     do {
       let set1 = buildTestSet();
-      let set2 = buildTestSet() |> Set.remove(_, Nat.compare, Set.size(_) - 1 : Nat);
+      let set2 = buildTestSet() |> _.remove(_.size - 1 : Nat);
 
-      assert (Set.compare(set1, set2, Nat.compare) == #greater);
+      assert (set1.compare(set2) == #greater);
       true
     },
     M.equals(T.bool(true))
@@ -577,14 +565,14 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "join",
     do {
-      let set1 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { +number });
-      let set2 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { -number });
+      let set1 = buildTestSet().map<Nat, Int>(func(number) { +number });
+      let set2 = buildTestSet().map<Nat, Int>(func(number) { -number });
       let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
-      let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
-      Iter.toArray(Set.values(combined))
+      let combined = Set.join(Iter.fromArray([set1, set2, set3]));
+      Iter.toArray(combined.values())
     },
     do {
-      let size = Set.size(buildTestSet());
+      let size = buildTestSet().size;
       M.equals(
         T.array<Int>(
           T.intTestable,
@@ -601,16 +589,16 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "flatten",
     do {
-      let subSet1 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { +number });
-      let subSet2 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { -number });
+      let subSet1 = buildTestSet().map<Nat, Int>(func(number) { +number });
+      let subSet2 = buildTestSet().map<Nat, Int>(func(number) { -number });
       let subSet3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
       let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-      let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
+      let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { first.compare(second) });
       let combined = Set.flatten(setOfSets, Int.compare);
-      Iter.toArray(Set.values(combined))
+      Iter.toArray(combined.values())
     },
     do {
-      let size = Set.size(buildTestSet());
+      let size = buildTestSet().size;
       M.equals(
         T.array<Int>(
           T.intTestable,
@@ -682,9 +670,9 @@ run(
         "repeated add",
         do {
           var set = buildTestSet();
-          assert (Set.contains(set, Nat.compare, 1));
-          set := Set.add(set, Nat.compare, 1);
-          Set.size(set)
+          assert (set.contains(1));
+          set := set.add(1);
+          set.size
         },
         M.equals(T.nat(3))
       ),
@@ -692,8 +680,8 @@ run(
         "repeated remove",
         do {
           var set = buildTestSet();
-          set := Set.remove(set, Nat.compare, 1);
-          Set.remove(set, Nat.compare, 1)
+          set := set.remove(1);
+          set.remove(1)
         },
         SetMatcher([0, 2])
       ),
@@ -701,7 +689,7 @@ run(
         "repeated insert",
         do {
           var set = buildTestSet();
-          assert (Set.contains(set, Nat.compare, 1));
+          assert (set.contains(1));
           let (_, changed) = Set.insert(set, Nat.compare, 1);
           changed
         },


### PR DESCRIPTION
Migrates tests and related tooling to contextual receiver syntax with implicit compare/equality where applicable.

Made with [Cursor](https://cursor.com)