### PR TITLE
feat: add `Principal.toActor`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Add `Principal.toActor` — inverse of `fromActor`, casts a Principal to a typed actor reference (#490).
 
 ## 2.4.0
 * Fix `Float32.rem` to use native `%` operator instead of round-tripping through `Float` (#482).

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -52,8 +52,8 @@ module {
   /// ```
   public let fromActor : (a : actor {}) -> Principal = Prim.principalOfActor;
 
-  /// Turns a `Principal` into an actor reference. The presence of the methods (and their respective types)
-  /// is not guaranteed.
+  /// Turns a `Principal` into an actor reference. The presence of the methods
+  /// (and their respective types) is not guaranteed.
   ///
   /// This is the inverse of `fromActor`. The returned reference is
   /// typed with the given actor type `A`.

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -52,6 +52,18 @@ module {
   /// ```
   public let fromActor : (a : actor {}) -> Principal = Prim.principalOfActor;
 
+  /// Cast a `Principal` to an actor reference.
+  ///
+  /// This is the inverse of `fromActor`. The returned reference is
+  /// typed with the given actor type `A`.
+  ///
+  /// Example:
+  /// ```motoko include=import no-repl
+  /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
+  /// let canister : actor {} = Principal.toActor<actor {}>(principal);
+  /// ```
+  public let toActor : <A <: actor {}>(p : Principal) -> A = Prim.actorOfPrincipal;
+
   /// Compute the Ledger account identifier of a principal. Optionally specify a sub-account.
   ///
   /// Example:

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -52,7 +52,8 @@ module {
   /// ```
   public let fromActor : (a : actor {}) -> Principal = Prim.principalOfActor;
 
-  /// Cast a `Principal` to an actor reference.
+  /// Turns a `Principal` into an actor reference. The presence of the methods (and their respective types)
+  /// is not guaranteed.
   ///
   /// This is the inverse of `fromActor`. The returned reference is
   /// typed with the given actor type `A`.

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -1031,6 +1031,7 @@
       "public func lessOrEqual(self : Principal, other : Principal) : Bool",
       "public func notEqual(self : Principal, other : Principal) : Bool",
       "public type Principal",
+      "public let toActor : <A <: actor",
       "public let toBlob : (self : Principal) -> Blob",
       "public func toLedgerAccount(self : Principal, subAccount : ?Blob) : Blob",
       "public func toText(self : Principal) : Text"


### PR DESCRIPTION
## Summary

Add `Principal.toActor` — the inverse of `Principal.fromActor`. Casts a `Principal` to a typed actor reference.

```motoko
let canister : actor {} = Principal.toActor<actor {}>(principal);
```

Wraps the `Prim.actorOfPrincipal` primitive added in caffeinelabs/motoko#5882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)