### PR TITLE
chore: bump dev-deps, toolchain, disable benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,12 +1,7 @@
 name: Benchmarks
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   check-motoko-changes:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 
 # Mops
 .mops
+mops.lock
 
 # `mo-doc`
 /docs

--- a/mops.toml
+++ b/mops.toml
@@ -13,8 +13,8 @@ keywords = [
 license = "Apache-2.0"
 
 [dev-dependencies]
-test = "2.1.1"
-bench = "1.0.0"
+test = "2.1.2"
+bench = "2.0.1"
 fuzz = "1.0.0"
 matchers = "2.1.0"
 base-0-14-13 = "https://github.com/dfinity/motoko-base#moc-0.14.13@794174a307975c225cfb26b57f73e38a841c0415"
@@ -25,4 +25,4 @@ moc = "1.6.0"
 
 [toolchain]
 moc = "1.6.0"
-wasmtime = "35.0.0"
+wasmtime = "44.0.0"


### PR DESCRIPTION
- Bump dev-dependencies (`test` 2.1.2, `bench` 2.0.1) and toolchain (`wasmtime` 44.0.0).
- Gitignore `mops.lock`.
- Disable broken benchmark workflow (kept as manual `workflow_dispatch`).