### PR TITLE
feat: add `Array.toBlob` and `VarArray.toBlob`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Add `Array.toBlob` and `VarArray.toBlob` so `[Nat8]` and `[var Nat8]` arrays can be converted to `Blob` via dot notation, e.g. `bytes.toBlob()`. Deprecate `Blob.fromArray`, `Blob.fromVarArray`, and `VarArray.fromIter` in favour of the corresponding self-callable forms (`bytes.toBlob()`, `iter.toVarArray()`) (#497).
 * Remove wrong `self` parameter from `Principal.fromBlob` (#492). 
   Change `blob.fromBlob()` to `Principal.fromBlob(blob)` if this causes a compile error in your code.
 

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -104,6 +104,20 @@ module {
     newArray
   };
 
+  /// Creates a `Blob` from an array of bytes (`[Nat8]`), by copying each element.
+  ///
+  /// ```motoko include=import
+  /// let bytes : [Nat8] = [0, 255, 0];
+  /// let blob = Array.toBlob(bytes);
+  /// assert blob == "\00\FF\00";
+  /// assert bytes.toBlob() == "\00\FF\00";
+  /// ```
+  ///
+  /// Runtime: O(size)
+  ///
+  /// Space: O(size)
+  public let toBlob : (self : [Nat8]) -> Blob = Prim.arrayToBlob;
+
   /// Tests if two arrays contain equal values (i.e. they represent the same
   /// list of elements). Uses `equal` to compare elements in the arrays.
   ///

--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -77,6 +77,7 @@ module {
   /// let blob = Blob.fromArray(bytes);
   /// assert blob == "\00\FF\00";
   /// ```
+  /// @deprecated M0235
   public let fromArray : (bytes : [Nat8]) -> Blob = Prim.arrayToBlob;
 
   /// Creates a `Blob` from a mutable array of bytes (`[var Nat8]`), by copying each element.
@@ -87,6 +88,7 @@ module {
   /// let blob = Blob.fromVarArray(bytes);
   /// assert blob == "\00\FF\00";
   /// ```
+  /// @deprecated M0235
   public let fromVarArray : (bytes : [var Nat8]) -> Blob = Prim.arrayMutToBlob;
 
   /// Converts a `Blob` to an array of bytes (`[Nat8]`), by copying each element.

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -858,6 +858,7 @@ module {
   public func fromArray<T>(array : [T]) : [var T] = Prim.Array_tabulateVar<T>(array.size(), func i = array[i]);
 
   /// Converts an iterator to a mutable array.
+  /// @deprecated M0235
   public func fromIter<T>(iter : Types.Iter<T>) : [var T] {
     var list : Types.Pure.List<T> = null;
     var size = 0;
@@ -1270,6 +1271,20 @@ module {
   ///
   /// Space: O(1)
   public func toArray<T>(self : [var T]) : [T] = Prim.Array_tabulate<T>(self.size(), func i = self[i]);
+
+  /// Creates a `Blob` from a mutable array of bytes (`[var Nat8]`), by copying each element.
+  ///
+  /// ```motoko include=import
+  /// let bytes : [var Nat8] = [var 0, 255, 0];
+  /// let blob = VarArray.toBlob(bytes);
+  /// assert blob == "\00\FF\00";
+  /// assert bytes.toBlob() == "\00\FF\00";
+  /// ```
+  ///
+  /// Runtime: O(size)
+  ///
+  /// Space: O(size)
+  public let toBlob : (self : [var Nat8]) -> Blob = Prim.arrayMutToBlob;
 
   /// Converts the mutable array to its textual representation using `f` to convert each element to `Text`.
   ///

--- a/test/Blob.test.mo
+++ b/test/Blob.test.mo
@@ -1,5 +1,7 @@
+import Array "../src/Array";
 import Blob "../src/Blob";
 import Nat8 "../src/Nat8";
+import VarArray "../src/VarArray";
 import { suite; test; expect } "mo:test";
 
 suite(
@@ -69,6 +71,26 @@ suite(
         let blob = "\00\FF\AA" : Blob;
         let bytes = Blob.toVarArray(blob);
         expect.array([bytes[0], bytes[1], bytes[2]], Nat8.toText, Nat8.equal).equal([0, 255, 170])
+      }
+    );
+
+    test(
+      "Array.toBlob converts byte array to blob",
+      func() {
+        let bytes : [Nat8] = [0, 255, 170];
+        expect.blob(Array.toBlob(bytes)).equal("\00\FF\AA");
+        expect.blob(bytes.toBlob()).equal("\00\FF\AA");
+        expect.blob(([] : [Nat8]).toBlob()).equal("")
+      }
+    );
+
+    test(
+      "VarArray.toBlob converts mutable byte array to blob",
+      func() {
+        let bytes : [var Nat8] = [var 0, 255, 170];
+        expect.blob(VarArray.toBlob(bytes)).equal("\00\FF\AA");
+        expect.blob(bytes.toBlob()).equal("\00\FF\AA");
+        expect.blob(([var] : [var Nat8]).toBlob()).equal("")
       }
     )
   }

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -42,6 +42,7 @@
       "public func sliceToVarArray<T>(self : [T], fromInclusive : Int, toExclusive : Int) : [var T]",
       "public func sort<T>(self : [T], compare : (implicit : (T, T) -> Order.Order)) : [T]",
       "public let tabulate : <T>(size : Nat, generator : Nat -> T) -> [T]",
+      "public let toBlob : (self : [Nat8]) -> Blob",
       "public func toText<T>(self : [T], f : (implicit : (toText : T -> Text))) : Text",
       "public func toVarArray<T>(self : [T]) : [var T]",
       "public func values<T>(self : [T]) : Types.Iter<T>"
@@ -1427,6 +1428,7 @@
       "public func sortInPlace<T>(self : [var T], compare : (implicit : (T, T) -> Order.Order)) : ()",
       "public let tabulate : <T>(size : Nat, generator : Nat -> T) -> [var T]",
       "public func toArray<T>(self : [var T]) : [T]",
+      "public let toBlob : (self : [var Nat8]) -> Blob",
       "public func toText<T>(self : [var T], f : (implicit : (toText : T -> Text))) : Text",
       "public func values<T>(self : [var T]) : Types.Iter<T>"
     ]


### PR DESCRIPTION
Adds `Array.toBlob` and `VarArray.toBlob` so byte arrays can be converted via dot notation, mirroring `Principal.toBlob`:

```motoko
let blob = bytes.toBlob();   // was: Blob.fromArray(bytes)
```

Deprecates the now-redundant `Blob.fromArray`, `Blob.fromVarArray`, and `VarArray.fromIter` (M0235), matching the existing pattern for `Iter.fromArray`, `Array.fromVarArray`, etc.