### PR TITLE
chore: enforce M0223 (redundant type instantiation) as error

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -26,3 +26,6 @@ moc = "1.6.0"
 [toolchain]
 moc = "1.8.0"
 wasmtime = "44.0.0"
+
+[moc]
+args = ["-W=M0223"]

--- a/mops.toml
+++ b/mops.toml
@@ -28,4 +28,4 @@ moc = "1.8.0"
 wasmtime = "44.0.0"
 
 [moc]
-args = ["-W=M0223"]
+args = ["-E=M0223"]

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -95,7 +95,7 @@ module {
     if (size == 0) {
       return [var]
     };
-    let newArray = Prim.Array_init<T>(size, self[0]);
+    let newArray = Prim.Array_init(size, self[0]);
     var i = 0;
     while (i < size) {
       newArray[i] := self[i];
@@ -312,7 +312,7 @@ module {
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func filter<T>(self : [T], f : T -> Bool) : [T] {
     var count = 0;
-    let keep = Prim.Array_tabulate<Bool>(
+    let keep = Prim.Array_tabulate(
       self.size(),
       func i {
         if (f(self[i])) {
@@ -356,7 +356,7 @@ module {
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func filterMap<T, R>(self : [T], f : T -> ?R) : [R] {
     var count = 0;
-    let options = Prim.Array_tabulate<?R>(
+    let options = Prim.Array_tabulate(
       self.size(),
       func i {
         let result = f(self[i]);
@@ -417,7 +417,7 @@ module {
     let size = self.size();
 
     var error : ?Types.Result<[R], E> = null;
-    let results = Prim.Array_tabulate<?R>(
+    let results = Prim.Array_tabulate(
       size,
       func i {
         switch (f(self[i])) {
@@ -493,10 +493,10 @@ module {
   /// *Runtime and space assumes that `k` runs in O(1) time and space.
   public func flatMap<T, R>(self : [T], k : T -> Types.Iter<R>) : [R] {
     var flatSize = 0;
-    let arrays = Prim.Array_tabulate<[R]>(
+    let arrays = Prim.Array_tabulate(
       self.size(),
       func i {
-        let subArray = fromIter<R>(k(self[i]));
+        let subArray = fromIter(k(self[i]));
         flatSize += subArray.size();
         subArray
       }
@@ -665,7 +665,7 @@ module {
       }
     };
     if (size == 0) { return [] };
-    let array = Prim.Array_init<T>(
+    let array = Prim.Array_init(
       size,
       switch list {
         case (?(h, _)) h;

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -36,7 +36,7 @@ module {
   /// Creates an array containing `item` repeated `size` times.
   ///
   /// ```motoko include=import
-  /// let array = Array.repeat<Text>("Echo", 3);
+  /// let array = Array.repeat("Echo", 3);
   /// assert array == ["Echo", "Echo", "Echo"];
   /// ```
   ///
@@ -65,7 +65,7 @@ module {
   /// ```motoko include=import
   /// let varArray = [var 0, 1, 2];
   /// varArray[2] := 3;
-  /// let array = Array.fromVarArray<Nat>(varArray);
+  /// let array = Array.fromVarArray(varArray);
   /// assert array == [0, 1, 3];
   /// ```
   ///
@@ -156,7 +156,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [1, 9, 4, 8];
-  /// let found = Array.find<Nat>(array, func x = x > 8);
+  /// let found = Array.find(array, func x = x > 8);
   /// assert found == ?9;
   /// ```
   /// Runtime: O(size)
@@ -178,7 +178,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = ['A', 'B', 'C', 'D'];
-  /// let found = Array.findIndex<Char>(array, func(x) { x == 'C' });
+  /// let found = Array.findIndex(array, func(x) { x == 'C' });
   /// assert found == ?2;
   /// ```
   /// Runtime: O(size)
@@ -201,7 +201,7 @@ module {
   /// ```motoko include=import
   /// let array1 = [1, 2, 3];
   /// let array2 = [4, 5, 6];
-  /// let result = Array.concat<Nat>(array1, array2);
+  /// let result = Array.concat(array1, array2);
   /// assert result == [1, 2, 3, 4, 5, 6];
   /// ```
   /// Runtime: O(size1 + size2)
@@ -287,7 +287,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array1 = [0, 1, 2, 3];
-  /// let array2 = Array.map<Nat, Nat>(array1, func x = x * 2);
+  /// let array2 = Array.map(array1, func x = x * 2);
   /// assert array2 == [0, 2, 4, 6];
   /// ```
   ///
@@ -303,7 +303,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [4, 2, 6, 1, 5];
-  /// let evenElements = Array.filter<Nat>(array, func x = x % 2 == 0);
+  /// let evenElements = Array.filter(array, func x = x % 2 == 0);
   /// assert evenElements == [4, 2, 6];
   /// ```
   /// Runtime: O(size)
@@ -344,7 +344,7 @@ module {
   ///
   /// let array = [4, 2, 0, 1];
   /// let newArray =
-  ///   Array.filterMap<Nat, Text>( // mapping from Nat to Text values
+  ///   Array.filterMap( // mapping from Nat to Text values
   ///     array,
   ///     func x = if (x == 0) { null } else { ?toText(100 / x) } // can't divide by 0, so return null
   ///   );
@@ -397,7 +397,7 @@ module {
   /// ```motoko include=import
   /// let array = [4, 3, 2, 1, 0];
   /// // divide 100 by every element in the array
-  /// let result = Array.mapResult<Nat, Nat, Text>(array, func x {
+  /// let result = Array.mapResult(array, func x {
   ///   if (x > 0) {
   ///     #ok(100 / x)
   ///   } else {
@@ -468,7 +468,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [10, 10, 10, 10];
-  /// let newArray = Array.mapEntries<Nat, Nat>(array, func (x, i) = i * x);
+  /// let newArray = Array.mapEntries(array, func (x, i) = i * x);
   /// assert newArray == [0, 10, 20, 30];
   /// ```
   ///
@@ -484,7 +484,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [1, 2, 3, 4];
-  /// let newArray = Array.flatMap<Nat, Int>(array, func x = [x, -x].values());
+  /// let newArray = Array.flatMap(array, func x = [x, -x].values());
   /// assert newArray == [1, -1, 2, -2, 3, -3, 4, -4];
   /// ```
   /// Runtime: O(size)
@@ -529,7 +529,7 @@ module {
   ///
   /// let array = [4, 2, 0, 1];
   /// let sum =
-  ///   Array.foldLeft<Nat, Nat>(
+  ///   Array.foldLeft(
   ///     array,
   ///     0, // start the sum at 0
   ///     func(sumSoFar, x) = sumSoFar + x // this entire function can be replaced with `add`!
@@ -558,7 +558,7 @@ module {
   /// import {toText} "mo:core/Nat";
   ///
   /// let array = [1, 9, 4, 8];
-  /// let bookTitle = Array.foldRight<Nat, Text>(array, "", func(x, acc) = toText(x) # acc);
+  /// let bookTitle = Array.foldRight(array, "", func(x, acc) = toText(x) # acc);
   /// assert bookTitle == "1948";
   /// ```
   ///
@@ -585,7 +585,7 @@ module {
   ///
   /// ```motoko include=import
   /// let arrays = [[0, 1, 2], [2, 3], [], [4]];
-  /// let joinedArray = Array.join<Nat>(arrays.values());
+  /// let joinedArray = Array.join(arrays.values());
   /// assert joinedArray == [0, 1, 2, 2, 3, 4];
   /// ```
   ///
@@ -603,7 +603,7 @@ module {
   ///
   /// ```motoko include=import
   /// let arrays = [[0, 1, 2], [2, 3], [], [4]];
-  /// let flatArray = Array.flatten<Nat>(arrays);
+  /// let flatArray = Array.flatten(arrays);
   /// assert flatArray == [0, 1, 2, 2, 3, 4];
   /// ```
   ///
@@ -922,16 +922,16 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [1, 2, 3, 4, 5];
-  /// let iter1 = Array.range<Nat>(array, 3, array.size());
+  /// let iter1 = Array.range(array, 3, array.size());
   /// assert iter1.next() == ?4;
   /// assert iter1.next() == ?5;
   /// assert iter1.next() == null;
   ///
-  /// let iter2 = Array.range<Nat>(array, 3, -1);
+  /// let iter2 = Array.range(array, 3, -1);
   /// assert iter2.next() == ?4;
   /// assert iter2.next() == null;
   ///
-  /// let iter3 = Array.range<Nat>(array, 0, 0);
+  /// let iter3 = Array.range(array, 0, 0);
   /// assert iter3.next() == null;
   /// ```
   ///
@@ -976,10 +976,10 @@ module {
   /// ```motoko include=import
   /// let array = [1, 2, 3, 4, 5];
   ///
-  /// let slice1 = Array.sliceToArray<Nat>(array, 1, 4);
+  /// let slice1 = Array.sliceToArray(array, 1, 4);
   /// assert slice1 == [2, 3, 4];
   ///
-  /// let slice2 = Array.sliceToArray<Nat>(array, 1, -1);
+  /// let slice2 = Array.sliceToArray(array, 1, -1);
   /// assert slice2 == [2, 3, 4];
   /// ```
   ///
@@ -1059,7 +1059,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let array = [1, 2, 3];
-  /// let text = Array.toText<Nat>(array, Nat.toText);
+  /// let text = Array.toText(array, Nat.toText);
   /// assert text == "[1, 2, 3]";
   /// ```
   ///

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -806,7 +806,7 @@ module {
 
   /// Sorted iterator.  Will iterate over *all* elements to sort them, necessarily.
   public func sort<T>(self : Iter<T>, compare : (implicit : (T, T) -> Order.Order)) : Iter<T> {
-    let array = toVarArray<T>(self);
+    let array = toVarArray(self);
     VarArray.sortInPlace<T>(array, compare);
     fromVarArray<T>(array)
   };

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -190,7 +190,7 @@ module {
   /// the function to every element produced by the argument iterator.
   /// ```motoko include=import
   /// let iter = [1, 2, 3].values();
-  /// let mappedIter = Iter.map<Nat, Nat>(iter, func (x) = x * 2);
+  /// let mappedIter = Iter.map(iter, func (x) = x * 2);
   /// let result = Iter.toArray(mappedIter);
   /// assert result == [2, 4, 6];
   /// ```
@@ -212,7 +212,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = [1, 2, 3, 4, 5].values();
-  /// let evenNumbers = Iter.filter<Nat>(iter, func (x) = x % 2 == 0);
+  /// let evenNumbers = Iter.filter(iter, func (x) = x % 2 == 0);
   /// let result = Iter.toArray(evenNumbers);
   /// assert result == [2, 4];
   /// ```
@@ -232,7 +232,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = [1, 2, 3].values();
-  /// let evenNumbers = Iter.filterMap<Nat, Nat>(iter, func (x) = if (x % 2 == 0) ?x else null);
+  /// let evenNumbers = Iter.filterMap(iter, func (x) = if (x % 2 == 0) ?x else null);
   /// let result = Iter.toArray(evenNumbers);
   /// assert result == [2];
   /// ```
@@ -273,7 +273,7 @@ module {
 
   /// Transforms every element of an iterator into an iterator and concatenates the results.
   /// ```motoko include=import
-  /// let iter = Iter.flatMap<Nat, Nat>([1, 3, 5].values(), func (x) = [x, x + 1].values());
+  /// let iter = Iter.flatMap([1, 3, 5].values(), func (x) = [x, x + 1].values());
   /// let result = Iter.toArray(iter);
   /// assert result == [1, 2, 3, 4, 5, 6];
   /// ```
@@ -323,7 +323,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5, 4, 3, 2, 1]);
-  /// let result = Iter.takeWhile<Nat>(iter, func (x) = x < 4);
+  /// let result = Iter.takeWhile(iter, func (x) = x < 4);
   /// let array = Iter.toArray(result);
   /// assert array == [1, 2, 3]; // note the difference between `takeWhile` and `filter`
   /// ```
@@ -363,7 +363,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = Iter.fromArray([1, 2, 3, 4, 5, 4, 3, 2, 1]);
-  /// let result = Iter.dropWhile<Nat>(iter, func (x) = x < 4);
+  /// let result = Iter.dropWhile(iter, func (x) = x < 4);
   /// let array = Iter.toArray(result);
   /// assert array == [4, 5, 4, 3, 2, 1]; // notice that `takeWhile` and `dropWhile` are complementary
   /// ```
@@ -425,7 +425,7 @@ module {
   /// ```motoko include=import
   /// let iter1 = ["A", "B"].values();
   /// let iter2 = ["1", "2", "3"].values();
-  /// let zipped = Iter.zipWith<Text, Text, Text>(iter1, iter2, func (a, b) = a # b);
+  /// let zipped = Iter.zipWith(iter1, iter2, func (a, b) = a # b);
   /// let result = Iter.toArray(zipped);
   /// assert result == ["A1", "B2"]; // note that the third element from iter2 is not included, because iter1 is exhausted
   /// ```
@@ -444,7 +444,7 @@ module {
   /// let iter1 = ["A", "B"].values();
   /// let iter2 = ["1", "2", "3"].values();
   /// let iter3 = ["x", "y", "z", "xd"].values();
-  /// let zipped = Iter.zipWith3<Text, Text, Text, Text>(iter1, iter2, iter3, func (a, b, c) = a # b # c);
+  /// let zipped = Iter.zipWith3(iter1, iter2, iter3, func (a, b, c) = a # b # c);
   /// let result = Iter.toArray(zipped);
   /// assert result == ["A1x", "B2y"]; // note that the unmatched elements from iter2 and iter3 are not included
   /// ```
@@ -505,7 +505,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = ['A', 'B', 'C', 'D'].values();
-  /// let found = Iter.findIndex<Char>(iter, func(x) { x == 'C' });
+  /// let found = Iter.findIndex(iter, func(x) { x == 'C' });
   /// assert found == ?2;
   /// ```
   /// Runtime: O(size)
@@ -544,7 +544,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = ["A", "B", "C"].values();
-  /// let result = Iter.foldLeft<Text, Text>(iter, "S", func (acc, x) = "(" # acc # x # ")");
+  /// let result = Iter.foldLeft(iter, "S", func (acc, x) = "(" # acc # x # ")");
   /// assert result == "(((SA)B)C)";
   /// ```
   public func foldLeft<T, R>(self : Iter<T>, initial : R, combine : (R, T) -> R) : R {
@@ -565,7 +565,7 @@ module {
   ///
   /// ```motoko include=import
   /// let iter = ["A", "B", "C"].values();
-  /// let result = Iter.foldRight<Text, Text>(iter, "S", func (x, acc) = "(" # x # acc # ")");
+  /// let result = Iter.foldRight(iter, "S", func (x, acc) = "(" # x # acc # ")");
   /// assert result == "(A(B(CS)))";
   /// ```
   public func foldRight<T, R>(self : Iter<T>, initial : R, combine : (T, R) -> R) : R {
@@ -593,7 +593,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let iter = [1, 2, 3].values();
-  /// let scanned = Iter.scanLeft<Nat, Nat>(iter, 0, Nat.add);
+  /// let scanned = Iter.scanLeft(iter, 0, Nat.add);
   /// let result = Iter.toArray(scanned);
   /// assert result == [0, 1, 3, 6];
   /// ```
@@ -625,7 +625,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let iter = [1, 2, 3].values();
-  /// let scanned = Iter.scanRight<Nat, Nat>(iter, 0, Nat.add);
+  /// let scanned = Iter.scanRight(iter, 0, Nat.add);
   /// let result = Iter.toArray(scanned);
   /// assert result == [0, 3, 5, 6];
   /// ```
@@ -637,7 +637,7 @@ module {
   /// The `step` function takes the current state and returns the next element and the next state, or `null` if the iteration is finished.
   ///
   /// ```motoko include=import
-  /// let iter = Iter.unfold<Nat, Nat>(1, func (x) = if (x <= 3) ?(x, x + 1) else null);
+  /// let iter = Iter.unfold(1, func (x) = if (x <= 3) ?(x, x + 1) else null);
   /// let result = Iter.toArray(iter);
   /// assert result == [1, 2, 3];
   /// ```
@@ -813,7 +813,7 @@ module {
 
   /// Creates an iterator that produces a given item a specified number of times.
   /// ```motoko include=import
-  /// let iter = Iter.repeat<Nat>(3, 2);
+  /// let iter = Iter.repeat(3, 2);
   /// assert ?3 == iter.next();
   /// assert ?3 == iter.next();
   /// assert null == iter.next();

--- a/src/List.mo
+++ b/src/List.mo
@@ -2116,7 +2116,7 @@ module {
   public func toVarArray<T>(self : List<T>) : [var T] {
     let ?fs = first(self) else return [var];
 
-    let array = VarArray.repeat<T>(fs, size(self));
+    let array = VarArray.repeat(fs, size(self));
 
     var index = 0;
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -145,7 +145,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3]);
-  /// let pureList = List.toPure<Nat>(list); // converts to immutable PureList
+  /// let pureList = List.toPure(list); // converts to immutable PureList
   /// ```
   ///
   /// Runtime: `O(size)`
@@ -185,7 +185,7 @@ module {
   /// ```motoko include=import
   /// import PureList "mo:core/pure/List";
   ///
-  /// let pureList = PureList.fromArray<Nat>([1, 2, 3]);
+  /// let pureList = PureList.fromArray([1, 2, 3]);
   /// let list = List.fromPure<Nat>(pureList); // converts to List
   /// ```
   ///
@@ -401,7 +401,7 @@ module {
   /// let lists = List.fromArray<List.List<Nat>>([
   ///   List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])
   /// ]);
-  /// let flatList = List.flatten<Nat>(lists);
+  /// let flatList = List.flatten(lists);
   /// assert List.equal<Nat>(flatList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
@@ -439,7 +439,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let lists = [List.fromArray<Nat>([0, 1, 2]), List.fromArray<Nat>([2, 3]), List.fromArray<Nat>([]), List.fromArray<Nat>([4])];
-  /// let joinedList = List.join<Nat>(lists.vals());
+  /// let joinedList = List.join(lists.vals());
   /// assert List.equal<Nat>(joinedList, List.fromArray<Nat>([0, 1, 2, 2, 3, 4]), Nat.equal);
   /// ```
   ///
@@ -487,7 +487,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let list = List.singleton<Nat>(123);
-  /// let textList = List.map<Nat, Text>(list, Nat.toText);
+  /// let textList = List.map(list, Nat.toText);
   /// assert List.toArray(textList) == ["123"];
   /// ```
   ///
@@ -690,7 +690,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let evenNumbers = List.filter<Nat>(list, func x = x % 2 == 0);
+  /// let evenNumbers = List.filter(list, func x = x % 2 == 0);
   /// assert List.toArray(evenNumbers) == [2, 4];
   /// ```
   ///
@@ -816,7 +816,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3, 4]);
-  /// let newList = List.flatMap<Nat, Int>(list, func x = [x, -x].vals());
+  /// let newList = List.flatMap(list, func x = [x, -x].vals());
   /// assert List.equal(newList, List.fromArray<Int>([1, -1, 2, -2, 3, -3, 4, -4]), Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -1344,7 +1344,7 @@ module {
   ///
   /// ```motoko include=import
   /// import Char "mo:core/Char";
-  /// let list = List.fromArray<Char>(['c', 'o', 'f', 'f', 'e', 'e']);
+  /// let list = List.fromArray(['c', 'o', 'f', 'f', 'e', 'e']);
   /// assert List.nextIndexOf<Char>(list, Char.equal, 'c', 0) == ?0;
   /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 0) == ?2;
   /// assert List.nextIndexOf<Char>(list, Char.equal, 'f', 2) == ?2;
@@ -1411,7 +1411,7 @@ module {
   ///
   /// ```motoko include=import
   /// import Char "mo:core/Char";
-  /// let list = List.fromArray<Char>(['c', 'o', 'f', 'f', 'e', 'e']);
+  /// let list = List.fromArray(['c', 'o', 'f', 'f', 'e', 'e']);
   /// assert List.prevIndexOf<Char>(list, Char.equal, 'c', List.size(list)) == ?0;
   /// assert List.prevIndexOf<Char>(list, Char.equal, 'e', List.size(list)) == ?5;
   /// assert List.prevIndexOf<Char>(list, Char.equal, 'e', 5) == ?4;
@@ -1452,7 +1452,7 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 9, 4, 8]);
-  /// let found = List.find<Nat>(list, func(x) { x > 8 });
+  /// let found = List.find(list, func(x) { x > 8 });
   /// assert found == ?9;
   /// ```
   /// Runtime: O(size)
@@ -2108,7 +2108,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1, 2, 3]);
   ///
-  /// let varArray = List.toVarArray<Nat>(list);
+  /// let varArray = List.toVarArray(list);
   /// assert Array.fromVarArray(varArray) == [1, 2, 3];
   /// ```
   ///
@@ -2152,7 +2152,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// let array = [var 2, 3];
-  /// let list = List.fromVarArray<Nat>(array);
+  /// let list = List.fromVarArray(array);
   /// assert Iter.toArray(List.values(list)) == [2, 3];
   /// ```
   ///
@@ -2343,16 +2343,16 @@ module {
   ///
   /// ```motoko include=import
   /// let list = List.fromArray<Nat>([1, 2, 3, 4, 5]);
-  /// let iter1 = List.range<Nat>(list, 3, List.size(list));
+  /// let iter1 = List.range(list, 3, List.size(list));
   /// assert iter1.next() == ?4;
   /// assert iter1.next() == ?5;
   /// assert iter1.next() == null;
   ///
-  /// let iter2 = List.range<Nat>(list, 3, -1);
+  /// let iter2 = List.range(list, 3, -1);
   /// assert iter2.next() == ?4;
   /// assert iter2.next() == null;
   ///
-  /// let iter3 = List.range<Nat>(list, 0, 0);
+  /// let iter3 = List.range(list, 0, 0);
   /// assert iter3.next() == null;
   /// ```
   ///
@@ -2427,10 +2427,10 @@ module {
   /// ```motoko include=import
   /// let array = List.fromArray<Nat>([1, 2, 3, 4, 5]);
   ///
-  /// let slice1 = List.sliceToArray<Nat>(array, 1, 4);
+  /// let slice1 = List.sliceToArray(array, 1, 4);
   /// assert slice1 == [2, 3, 4];
   ///
-  /// let slice2 = List.sliceToArray<Nat>(array, 1, -1);
+  /// let slice2 = List.sliceToArray(array, 1, -1);
   /// assert slice2 == [2, 3, 4];
   /// ```
   ///
@@ -2451,10 +2451,10 @@ module {
   ///
   /// let array = List.fromArray<Nat>([1, 2, 3, 4, 5]);
   ///
-  /// let slice1 = List.sliceToVarArray<Nat>(array, 1, 4);
+  /// let slice1 = List.sliceToVarArray(array, 1, 4);
   /// assert VarArray.equal(slice1, [var 2, 3, 4], Nat.equal);
   ///
-  /// let slice2 = List.sliceToVarArray<Nat>(array, 1, -1);
+  /// let slice2 = List.sliceToVarArray(array, 1, -1);
   /// assert VarArray.equal(slice2, [var 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -3032,7 +3032,7 @@ module {
   ///
   /// let list = List.fromArray<Nat>([1,2,3]);
   ///
-  /// let rlist = List.reverse<Nat>(list);
+  /// let rlist = List.reverse(list);
   /// assert Iter.toArray(List.values(rlist)) == [3, 2, 1];
   /// ```
   ///

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -63,7 +63,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
   ///   let pureMap = Map.toPure(map, Nat.compare);
   ///   assert Iter.toArray(PureMap.entries(pureMap)) == Iter.toArray(Map.entries(map))
@@ -93,7 +93,7 @@ module {
   /// persistent actor {
   ///   let pureMap = PureMap.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
-  ///   let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
+  ///   let map = Map.fromPure(pureMap, Nat.compare);
   ///   assert Iter.toArray(Map.entries(map)) == Iter.toArray(PureMap.entries(pureMap))
   /// }
   /// ```
@@ -115,7 +115,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let originalMap = Map.fromIter<Nat, Text>(
+  ///   let originalMap = Map.fromIter(
   ///     [(1, "One"), (2, "Two"), (3, "Three")].values(), Nat.compare);
   ///   let clonedMap = Map.clone(originalMap);
   ///   Map.add(originalMap, Nat.compare, 4, "Four");
@@ -192,7 +192,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
@@ -219,7 +219,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
@@ -243,7 +243,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
@@ -269,7 +269,7 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter<Nat, Text>(
+  ///   let map1 = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///   let map2 = Map.clone(map1);
@@ -316,7 +316,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
@@ -341,7 +341,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (1, "One"), (2, "Two")].values(),
   ///     Nat.compare);
   ///
@@ -533,7 +533,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
@@ -563,7 +563,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
@@ -598,7 +598,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>(
+  ///   let map = Map.fromIter(
   ///     [(0, "Zero"), (2, "Two"), (1, "One")].values(),
   ///     Nat.compare);
   ///
@@ -736,7 +736,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
   ///   var sum = 0;
@@ -769,7 +769,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (3, "Three"),  (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (3, "Three"),  (1, "One")].values(), Nat.compare);
   ///   assert Iter.toArray(Map.entriesFrom(map, Nat.compare, 1)) == [(1, "One"), (3, "Three")];
   ///   assert Iter.toArray(Map.entriesFrom(map, Nat.compare, 2)) == [(3, "Three")];
   /// }
@@ -801,7 +801,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Iter.toArray(Map.reverseEntries(map)) == [(2, "Two"), (1, "One"), (0, "Zero")];
   ///   var sum = 0;
@@ -834,7 +834,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One"), (3, "Three")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (1, "One"), (3, "Three")].values(), Nat.compare);
   ///   assert Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, 0)) == [(0, "Zero")];
   ///   assert Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, 2)) == [(1, "One"), (0, "Zero")];
   /// }
@@ -866,7 +866,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Iter.toArray(Map.keys(map)) == [0, 1, 2];
   /// }
@@ -897,7 +897,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   assert Iter.toArray(Map.values(map)) == ["Zero", "One", "Two"];
   /// }
@@ -930,7 +930,7 @@ module {
   ///   transient let iter =
   ///     Iter.fromArray([(0, "Zero"), (2, "Two"), (1, "One")]);
   ///
-  ///   let map = Map.fromIter<Nat, Text>(iter, Nat.compare);
+  ///   let map = Map.fromIter(iter, Nat.compare);
   ///
   ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero"), (1, "One"), (2, "Two")];
   /// }
@@ -991,7 +991,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   var sum = 0;
   ///   var text = "";
   ///   Map.forEach<Nat, Text>(map, func (key, value) {
@@ -1025,9 +1025,9 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let numberNames = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
+  ///   let evenNames = Map.filter(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
   ///   });
   ///
@@ -1060,7 +1060,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, _val : Text) : Nat = key * 2;
   ///
@@ -1092,7 +1092,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(accum : (Nat, Text), key : Nat, val : Text) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1127,7 +1127,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func folder(key : Nat, val : Text, accum : (Nat, Text)) : ((Nat, Text))
   ///     = (key + accum.0, accum.1 # val);
@@ -1163,7 +1163,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.all<Nat, Text>(map, func (k, v) = v == Nat.toText(k));
   ///   assert not Map.all<Nat, Text>(map, func (k, v) = k < 2);
@@ -1193,7 +1193,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "0"), (2, "2"), (1, "1")].values(), Nat.compare);
   ///
   ///   assert Map.any<Nat, Text>(map, func (k, v) = (k >= 0));
   ///   assert not Map.any<Nat, Text>(map, func (k, v) = (k >= 3));
@@ -1227,14 +1227,14 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   func f(key : Nat, val : Text) : ?Text {
   ///     if(key == 0) {null}
   ///     else { ?("Twenty " # val)}
   ///   };
   ///
-  ///   let newMap = Map.filterMap<Nat, Text, Text>(map, Nat.compare, f);
+  ///   let newMap = Map.filterMap(map, Nat.compare, f);
   ///
   ///   assert Iter.toArray(Map.entries(newMap)) == [(1, "Twenty One"), (2, "Twenty Two")];
   /// }
@@ -1294,7 +1294,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let map = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///   let map = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///   assert Map.toText<Nat, Text>(map, Nat.toText, func t { t }) == "Map{(0, Zero), (1, One), (2, Two)}";
   /// }
   /// ```
@@ -1341,8 +1341,8 @@ module {
   /// import Text "mo:core/Text";
   ///
   /// persistent actor {
-  ///   let map1 = Map.fromIter<Nat, Text>([(0, "Zero"), (1, "One")].values(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two")].values(), Nat.compare);
+  ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One")].values(), Nat.compare);
+  ///   let map2 = Map.fromIter([(0, "Zero"), (2, "Two")].values(), Nat.compare);
   ///
   ///   assert Map.compare(map1, map2, Nat.compare, Text.compare) == #less;
   ///   assert Map.compare(map1, map1, Nat.compare, Text.compare) == #equal;

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -452,10 +452,10 @@ module {
   public func swap<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order), key : K, value : V) : ?V {
     let insertResult = switch (self.root) {
       case (#leaf(leafNode)) {
-        leafInsertHelper<K, V>(leafNode, btreeOrder, compare, key, value)
+        leafInsertHelper(leafNode, btreeOrder, compare, key, value)
       };
       case (#internal(internalNode)) {
-        internalInsertHelper<K, V>(internalNode, btreeOrder, compare, key, value)
+        internalInsertHelper(internalNode, btreeOrder, compare, key, value)
       }
     };
 
@@ -621,10 +621,10 @@ module {
     let deletedValue = switch (self.root) {
       case (#leaf(leafNode)) {
         // TODO: think about how this can be optimized so don't have to do two steps (search and then insert)?
-        switch (NodeUtil.getKeyIndex<K, V>(leafNode.data, compare, key)) {
+        switch (NodeUtil.getKeyIndex(leafNode.data, compare, key)) {
           case (#keyFound(deleteIndex)) {
             leafNode.data.count -= 1;
-            let (_, deletedValue) = BTreeHelper.deleteAndShift<(K, V)>(leafNode.data.kvs, deleteIndex);
+            let (_, deletedValue) = BTreeHelper.deleteAndShift(leafNode.data.kvs, deleteIndex);
             self.size -= 1;
             ?deletedValue
           };
@@ -1394,7 +1394,7 @@ module {
   };
 
   func leafEntriesFrom<K, V>({ data } : Leaf<K, V>, compare : (K, K) -> Order.Order, key : K) : Types.Iter<(K, V)> {
-    var i = switch (BinarySearch.binarySearchNode<K, V>(data.kvs, compare, key, data.count)) {
+    var i = switch (BinarySearch.binarySearchNode(data.kvs, compare, key, data.count)) {
       case (#keyFound(i)) i;
       case (#notFound(i)) i
     };
@@ -1427,7 +1427,7 @@ module {
   };
 
   func reverseLeafEntriesFrom<K, V>({ data } : Leaf<K, V>, compare : (K, K) -> Order.Order, key : K) : Types.Iter<(K, V)> {
-    var i = switch (BinarySearch.binarySearchNode<K, V>(data.kvs, compare, key, data.count)) {
+    var i = switch (BinarySearch.binarySearchNode(data.kvs, compare, key, data.count)) {
       case (#keyFound(i)) i + 1; // +1 to include this key
       case (#notFound(i)) i // i is the index of the first key greater than the search key, or count if all keys are less than the search key
     };
@@ -1710,7 +1710,7 @@ module {
         case (#leaf(leafNode)) (leafNode, null);
         case (#internal(internalNode)) (internalNode, ?internalNode.children)
       };
-      let (i, isFound) = switch (NodeUtil.getKeyIndex<K, V>(node.data, compare, key)) {
+      let (i, isFound) = switch (NodeUtil.getKeyIndex(node.data, compare, key)) {
         case (#keyFound(i)) (i, true);
         case (#notFound(i)) (i, false)
       };
@@ -1778,7 +1778,7 @@ module {
         case (#leaf(leafNode)) (leafNode, null);
         case (#internal(internalNode)) (internalNode, ?internalNode.children)
       };
-      let (i, isFound) = switch (NodeUtil.getKeyIndex<K, V>(node.data, compare, key)) {
+      let (i, isFound) = switch (NodeUtil.getKeyIndex(node.data, compare, key)) {
         case (#keyFound(i)) (i + 1, true); // +1 to include this key
         case (#notFound(i)) (i, false) // i is the index of the first key less than the search key, or 0 if all keys are greater than the search key
       };
@@ -1812,7 +1812,7 @@ module {
 
   func internalDeleteHelper<K, V>(internalNode : Internal<K, V>, order : Nat, compare : (K, K) -> Order.Order, deleteKey : K, skipNode : Bool) : IntermediateInternalDeleteResult<K, V> {
     let minKeys = NodeUtil.minKeysFromOrder(order);
-    let keyIndex = NodeUtil.getKeyIndex<K, V>(internalNode.data, compare, deleteKey);
+    let keyIndex = NodeUtil.getKeyIndex(internalNode.data, compare, deleteKey);
 
     // match on both the result of the node binary search, and if this node level should be skipped even if the key is found (internal kv replacement case)
     switch (keyIndex, skipNode) {
@@ -1873,7 +1873,7 @@ module {
                     let kvPairToBePushedToChild = ?BTreeHelper.deleteAndShift(internalNode.data.kvs, 0);
                     internalNode.data.count -= 1;
                     // merge the children and push down the parent
-                    let newChild = NodeUtil.mergeChildrenAndPushDownParent<K, V>(internalChild, kvPairToBePushedToChild, sibling);
+                    let newChild = NodeUtil.mergeChildrenAndPushDownParent(internalChild, kvPairToBePushedToChild, sibling);
                     // update children of the parent
                     internalNode.children[0] := ?#internal(newChild);
                     ignore ?BTreeHelper.deleteAndShift(internalNode.children, 1);
@@ -1954,7 +1954,7 @@ module {
                     let kvPairToBePushedToChild = internalNode.data.kvs[childIndex];
                     internalNode.data.kvs[childIndex] := ?borrowedKVPair;
 
-                    let deletedKV = BTreeHelper.insertAtPostionAndDeleteAtPosition<(K, V)>(leafChild.data.kvs, kvPairToBePushedToChild, leafChild.data.count - 1, leafDeleteIndex);
+                    let deletedKV = BTreeHelper.insertAtPostionAndDeleteAtPosition(leafChild.data.kvs, kvPairToBePushedToChild, leafChild.data.count - 1, leafDeleteIndex);
                     #delete(?deletedKV.1)
                   };
 
@@ -1998,7 +1998,7 @@ module {
                   case (?borrowedKVPair) {
                     let kvPairToBePushedToChild = internalNode.data.kvs[childIndex - 1];
                     internalNode.data.kvs[childIndex - 1] := ?borrowedKVPair;
-                    let kvDelete = BTreeHelper.insertAtPostionAndDeleteAtPosition<(K, V)>(leafChild.data.kvs, kvPairToBePushedToChild, 0, leafDeleteIndex);
+                    let kvDelete = BTreeHelper.insertAtPostionAndDeleteAtPosition(leafChild.data.kvs, kvPairToBePushedToChild, 0, leafDeleteIndex);
                     #delete(?kvDelete.1)
                   };
                   case null {
@@ -2010,7 +2010,7 @@ module {
                           let kvPairToBePushedToChild = internalNode.data.kvs[childIndex];
                           internalNode.data.kvs[childIndex] := ?borrowedKVPair;
                           // insert the successor at the very last element
-                          let kvDelete = BTreeHelper.insertAtPostionAndDeleteAtPosition<(K, V)>(leafChild.data.kvs, kvPairToBePushedToChild, leafChild.data.count - 1, leafDeleteIndex);
+                          let kvDelete = BTreeHelper.insertAtPostionAndDeleteAtPosition(leafChild.data.kvs, kvPairToBePushedToChild, leafChild.data.count - 1, leafDeleteIndex);
                           return #delete(?kvDelete.1)
                         };
                         // if cannot borrow, from left or right, merge (see below)
@@ -2136,7 +2136,7 @@ module {
     deletionSide : DeletionSide
   ) : (Leaf<K, V>, (K, V)) {
     let count = leftChild.data.count * 2;
-    let (kvs, deletedKV) = BTreeHelper.mergeParentWithChildrenAndDelete<(K, V)>(
+    let (kvs, deletedKV) = BTreeHelper.mergeParentWithChildrenAndDelete(
       parentKV,
       leftChild.data.count,
       leftChild.data.kvs,
@@ -2255,7 +2255,7 @@ module {
               };
 
               // split internal children
-              let (leftChildren, rightChildren) = NodeUtil.splitChildrenInTwoWithRebalances<K, V>(
+              let (leftChildren, rightChildren) = NodeUtil.splitChildrenInTwoWithRebalances(
                 internalNode.children,
                 insertIndex,
                 leftChild,
@@ -2319,7 +2319,7 @@ module {
         #leaf { data = mapData(data, project) }
       };
       case (#internal { data; children }) {
-        let mappedData = mapData<K, V1, V2>(data, project);
+        let mappedData = mapData(data, project);
         let mappedChildren = VarArray.map<?Node<K, V1>, ?Node<K, V2>>(
           children,
           func child {

--- a/src/PriorityQueue.mo
+++ b/src/PriorityQueue.mo
@@ -232,7 +232,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
   /// assert PriorityQueue.size(pq) == 3;
   /// assert PriorityQueue.peek(pq) == ?10;
   /// ```
@@ -255,7 +255,7 @@ module {
   /// import PriorityQueue "mo:core/PriorityQueue";
   /// import Nat "mo:core/Nat";
   ///
-  /// let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let original = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
   /// let copy = PriorityQueue.clone(original);
   /// assert PriorityQueue.pop(copy, Nat.compare) == ?10;
   /// assert PriorityQueue.size(original) == 3;
@@ -281,7 +281,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// import Iter "mo:core/Iter";
   ///
-  /// let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+  /// let pq = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
   /// assert Iter.toArray(PriorityQueue.values(pq, Nat.compare)) == [10, 5, 3];
   /// ```
   ///

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -49,7 +49,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let pureQueue = Queue.toPure<Nat>(queue);
+  ///   let pureQueue = Queue.toPure(queue);
   /// }
   /// ```
   ///
@@ -77,7 +77,7 @@ module {
   /// import PureQueue "mo:core/pure/Queue";
   ///
   /// persistent actor {
-  ///   let pureQueue = PureQueue.fromIter<Nat>([1, 2, 3].values());
+  ///   let pureQueue = PureQueue.fromIter([1, 2, 3].values());
   ///   let queue = Queue.fromPure<Nat>(pureQueue);
   /// }
   /// ```
@@ -189,7 +189,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter(["A", "B", "C"].values());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -422,7 +422,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter(["A", "B", "C"].values());
   ///   assert Queue.size(queue) == 3;
   /// }
   /// ```
@@ -447,7 +447,7 @@ module {
   /// persistent actor {
   ///   transient let iter = ["A", "B", "C"].values();
   ///
-  ///   let queue = iter.toQueue<Text>();
+  ///   let queue = iter.toQueue();
   ///
   ///   assert Queue.size(queue) == 3;
   /// }
@@ -468,7 +468,7 @@ module {
   /// import Queue "mo:core/Queue";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let queue = Queue.fromArray(["A", "B", "C"]);
   ///   assert Queue.size(queue) == 3;
   ///   assert Queue.peekFront(queue) == ?"A";
   /// }
@@ -498,7 +498,7 @@ module {
   /// import Array "mo:core/Array";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let queue = Queue.fromArray(["A", "B", "C"]);
   ///   let array = Queue.toArray(queue);
   ///   assert array == ["A", "B", "C"];
   /// }
@@ -531,7 +531,7 @@ module {
   /// ```motoko
   /// import Queue "mo:core/Queue";
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Text>(["A", "B", "C"].values());
+  ///   let queue = Queue.fromIter(["A", "B", "C"].values());
   ///   transient let iter = Queue.values(queue);
   ///   assert iter.next() == ?"A";
   ///   assert iter.next() == ?"B";
@@ -664,7 +664,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
-  ///   let evens = Queue.filter<Nat>(queue, func(x) { x % 2 == 0 });
+  ///   let evens = Queue.filter(queue, func(x) { x % 2 == 0 });
   ///   assert Queue.size(evens) == 2;
   /// }
   /// ```

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -381,10 +381,10 @@ module {
   public func insert<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), element : T) : Bool {
     let insertResult = switch (self.root) {
       case (#leaf(leafNode)) {
-        leafInsertHelper<T>(leafNode, btreeOrder, compare, element)
+        leafInsertHelper(leafNode, btreeOrder, compare, element)
       };
       case (#internal(internalNode)) {
-        internalInsertHelper<T>(internalNode, btreeOrder, compare, element)
+        internalInsertHelper(internalNode, btreeOrder, compare, element)
       }
     };
 
@@ -477,7 +477,7 @@ module {
     let deleted = switch (self.root) {
       case (#leaf(leafNode)) {
         // TODO: think about how this can be optimized so don't have to do two steps (search and then insert)?
-        switch (NodeUtil.getElementIndex<T>(leafNode.data, compare, element)) {
+        switch (NodeUtil.getElementIndex(leafNode.data, compare, element)) {
           case (#elementFound(deleteIndex)) {
             leafNode.data.count -= 1;
             ignore BTreeHelper.deleteAndShift<T>(leafNode.data.elements, deleteIndex);
@@ -809,7 +809,7 @@ module {
   /// where `m` and `n` denote the number of elements stored in the sets `set1` and `set2`, respectively,
   /// and assuming that the `compare` function implements an `O(1)` comparison.
   public func union<T>(self : Set<T>, other : Set<T>, compare : (implicit : (T, T) -> Order.Order)) : Set<T> {
-    let result = clone<T>(self);
+    let result = clone(self);
     for (element in values(other)) {
       if (not contains(result, compare, element)) {
         add(result, compare, element)
@@ -986,7 +986,7 @@ module {
   /// }
   /// ```
   public func retainAll<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), predicate : T -> Bool) : Bool {
-    let array = Array.fromIter<T>(values(self));
+    let array = Array.fromIter(values(self));
     deleteAll(
       self,
       compare,
@@ -1489,7 +1489,7 @@ module {
   };
 
   func leafElementsFrom<T>({ data } : Leaf<T>, compare : (T, T) -> Order.Order, element : T) : Types.Iter<T> {
-    var i = switch (BinarySearch.binarySearchNode<T>(data.elements, compare, element, data.count)) {
+    var i = switch (BinarySearch.binarySearchNode(data.elements, compare, element, data.count)) {
       case (#elementFound(i)) i;
       case (#notFound(i)) i
     };
@@ -1522,7 +1522,7 @@ module {
   };
 
   func reverseLeafElementsFrom<T>({ data } : Leaf<T>, compare : (T, T) -> Order.Order, element : T) : Types.Iter<T> {
-    var i = switch (BinarySearch.binarySearchNode<T>(data.elements, compare, element, data.count)) {
+    var i = switch (BinarySearch.binarySearchNode(data.elements, compare, element, data.count)) {
       case (#elementFound(i)) i + 1; // +1 to include this element
       case (#notFound(i)) i // i is the index of the first element greater than the search element, or count if all elements are less than the search element
     };
@@ -1804,7 +1804,7 @@ module {
         case (#leaf(leafNode)) (leafNode, null);
         case (#internal(internalNode)) (internalNode, ?internalNode.children)
       };
-      let (i, isFound) = switch (NodeUtil.getElementIndex<T>(node.data, compare, element)) {
+      let (i, isFound) = switch (NodeUtil.getElementIndex(node.data, compare, element)) {
         case (#elementFound(i)) (i, true);
         case (#notFound(i)) (i, false)
       };
@@ -1872,7 +1872,7 @@ module {
         case (#leaf(leafNode)) (leafNode, null);
         case (#internal(internalNode)) (internalNode, ?internalNode.children)
       };
-      let (i, isFound) = switch (NodeUtil.getElementIndex<T>(node.data, compare, element)) {
+      let (i, isFound) = switch (NodeUtil.getElementIndex(node.data, compare, element)) {
         case (#elementFound(i)) (i + 1, true); // +1 to include this element
         case (#notFound(i)) (i, false) // i is the index of the first element less than the search element, or 0 if all elements are greater than the search element
       };
@@ -1907,7 +1907,7 @@ module {
 
   func internalDeleteHelper<T>(internalNode : Internal<T>, order : Nat, compare : (T, T) -> Order.Order, deleteElement : T, skipNode : Bool) : IntermediateInternalDeleteResult<T> {
     let minElements = NodeUtil.minElementsFromOrder(order);
-    let elementIndex = NodeUtil.getElementIndex<T>(internalNode.data, compare, deleteElement);
+    let elementIndex = NodeUtil.getElementIndex(internalNode.data, compare, deleteElement);
 
     // match on both the result of the node binary search, and if this node level should be skipped even if the element is found (internal element replacement case)
     switch (elementIndex, skipNode) {
@@ -1971,7 +1971,7 @@ module {
                     let elementsToBePushedToChild = ?BTreeHelper.deleteAndShift(internalNode.data.elements, 0);
                     internalNode.data.count -= 1;
                     // merge the children and push down the parent
-                    let newChild = NodeUtil.mergeChildrenAndPushDownParent<T>(internalChild, elementsToBePushedToChild, sibling);
+                    let newChild = NodeUtil.mergeChildrenAndPushDownParent(internalChild, elementsToBePushedToChild, sibling);
                     // update children of the parent
                     internalNode.children[0] := ?#internal(newChild);
                     ignore ?BTreeHelper.deleteAndShift(internalNode.children, 1);
@@ -2225,7 +2225,7 @@ module {
     deletionSide : DeletionSide
   ) : Leaf<T> {
     let count = leftChild.data.count * 2;
-    let (elements, _) = BTreeHelper.mergeParentWithChildrenAndDelete<T>(
+    let (elements, _) = BTreeHelper.mergeParentWithChildrenAndDelete(
       parentElement,
       leftChild.data.count,
       leftChild.data.elements,
@@ -2348,7 +2348,7 @@ module {
               };
 
               // split internal children
-              let (leftChildren, rightChildren) = NodeUtil.splitChildrenInTwoWithRebalances<T>(
+              let (leftChildren, rightChildren) = NodeUtil.splitChildrenInTwoWithRebalances(
                 internalNode.children,
                 insertIndex,
                 leftChild,

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -59,7 +59,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 2, 1].values(), Nat.compare);
   ///   let pureSet = Set.toPure(set, Nat.compare);
   ///   assert Iter.toArray(PureSet.values(pureSet)) == Iter.toArray(Set.values(set));
   /// }
@@ -165,7 +165,7 @@ module {
   /// import Set "mo:core/Set";
   ///
   /// persistent actor {
-  ///   let cities = Set.singleton<Text>("Zurich");
+  ///   let cities = Set.singleton("Zurich");
   ///   assert Set.size(cities) == 1;
   /// }
   /// ```
@@ -709,7 +709,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([3, 1, 2, 1].values(), Nat.compare);
+  ///   let set = Set.fromIter([3, 1, 2, 1].values(), Nat.compare);
   ///   assert Iter.toArray(Set.values(set)) == [1, 2, 3];
   /// }
   /// ```
@@ -980,7 +980,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
-  ///   let sizeChanged = Set.retainAll<Nat>(set, Nat.compare, func n { n % 2 == 0 });
+  ///   let sizeChanged = Set.retainAll(set, Nat.compare, func n { n % 2 == 0 });
   ///   assert Iter.toArray(Set.values(set)) == [2];
   ///   assert sizeChanged;
   /// }
@@ -1037,7 +1037,7 @@ module {
   /// persistent actor {
   ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
+  ///   let evenNumbers = Set.filter(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
   ///   assert Iter.toArray(Set.values(evenNumbers)) == [0, 2];
@@ -1073,7 +1073,7 @@ module {
   ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let textNumbers =
-  ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
+  ///     Set.map(numbers, Text.compare, Nat.toText);
   ///   assert Iter.toArray(Set.values(textNumbers)) == ["1", "2", "3"];
   /// }
   /// ```
@@ -1108,7 +1108,7 @@ module {
   /// persistent actor {
   ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
   ///
-  ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
+  ///   let evenTextNumbers = Set.filterMap(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
   ///        ?Nat.toText(number)
   ///     } else {
@@ -1146,7 +1146,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
-  ///   let text = Set.foldLeft<Nat, Text>(
+  ///   let text = Set.foldLeft(
   ///      set,
   ///      "",
   ///      func (accumulator, element) {
@@ -1185,7 +1185,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
-  ///   let text = Set.foldRight<Nat, Text>(
+  ///   let text = Set.foldRight(
   ///      set,
   ///      "",
   ///      func (element, accumulator) {
@@ -1301,9 +1301,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let belowTen = Set.all<Nat>(set, func (number) {
+  ///   let belowTen = Set.all(set, func (number) {
   ///     number < 10
   ///   });
   ///   assert belowTen;
@@ -1335,9 +1335,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let aboveTen = Set.any<Nat>(set, func (number) {
+  ///   let aboveTen = Set.any(set, func (number) {
   ///     number > 10
   ///   });
   ///   assert not aboveTen;
@@ -1397,7 +1397,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "Set{0, 1, 2, 3}"
   /// }

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -82,7 +82,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let immutableList = PureList.fromIter<Nat>([1, 2, 3].values());
+  ///   let immutableList = PureList.fromIter([1, 2, 3].values());
   ///   let mutableStack = Stack.fromPure<Nat>(immutableList);
   ///   assert Iter.toArray(Stack.values(mutableStack)) == [1, 2, 3];
   /// }
@@ -175,7 +175,7 @@ module {
   /// import Stack "mo:core/Stack";
   ///
   /// persistent actor {
-  ///   let stack = Stack.singleton<Text>("motoko");
+  ///   let stack = Stack.singleton("motoko");
   ///   assert Stack.peek(stack) == ?"motoko";
   /// }
   /// ```
@@ -611,7 +611,7 @@ module {
   ///   Stack.push(stack, 3);
   ///   Stack.push(stack, 2);
   ///   Stack.push(stack, 1);
-  ///   let evens = Stack.filter<Nat>(stack, func(n) { n % 2 == 0 });
+  ///   let evens = Stack.filter(stack, func(n) { n % 2 == 0 });
   ///   assert Stack.pop(evens) == ?2;
   ///   assert Stack.pop(evens) == ?4;
   ///   assert Stack.pop(evens) == null;
@@ -708,7 +708,7 @@ module {
   ///
   /// persistent actor {
   ///   let stack = Stack.fromPure(?('A', ?('B', ?('C', ?('D', null)))));
-  ///   let found = Stack.findIndex<Char>(stack, func x = x == 'C');
+  ///   let found = Stack.findIndex(stack, func x = x == 'C');
   ///   assert found == ?2;
   /// }
   /// ```

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -161,7 +161,7 @@ module {
     if (n == 0) {
       return [var]
     };
-    let array = Prim.Array_init<Char>(n, ' ');
+    let array = Prim.Array_init(n, ' ');
     var i = 0;
     for (c in self.chars()) {
       array[i] := c;

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -99,7 +99,7 @@ module {
   ///
   /// let text = "Mississippi";
   /// let count =
-  ///   Text.foldLeft<Nat>(
+  ///   Text.foldLeft(
   ///     text,
   ///     0, // start the sum at 0
   ///     func(ss, c) = if (c == 's') ss + 1 else ss

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -40,7 +40,7 @@ module {
   /// ```motoko include=import
   /// import Text "mo:core/Text";
   ///
-  /// let array = VarArray.repeat<Text>("Echo", 3);
+  /// let array = VarArray.repeat("Echo", 3);
   /// assert VarArray.equal(array, [var "Echo", "Echo", "Echo"], Text.equal);
   /// ```
   ///
@@ -55,7 +55,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let array1 = [var 1, 2, 3];
-  /// let array2 = VarArray.clone<Nat>(array1);
+  /// let array2 = VarArray.clone(array1);
   /// array2[0] := 0;
   /// assert VarArray.equal(array1, [var 1, 2, 3], Nat.equal);
   /// assert VarArray.equal(array2, [var 0, 2, 3], Nat.equal);
@@ -121,7 +121,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [var 1, 9, 4, 8];
-  /// let found = VarArray.find<Nat>(array, func x = x > 8);
+  /// let found = VarArray.find(array, func x = x > 8);
   /// assert found == ?9;
   /// ```
   /// Runtime: O(size)
@@ -143,7 +143,7 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [var 'A', 'B', 'C', 'D'];
-  /// let found = VarArray.findIndex<Char>(array, func(x) { x == 'C' });
+  /// let found = VarArray.findIndex(array, func(x) { x == 'C' });
   /// assert found == ?2;
   /// ```
   /// Runtime: O(size)
@@ -168,7 +168,7 @@ module {
   ///
   /// let array1 = [var 1, 2, 3];
   /// let array2 = [var 4, 5, 6];
-  /// let result = VarArray.concat<Nat>(array1, array2);
+  /// let result = VarArray.concat(array1, array2);
   /// assert VarArray.equal(result, [var 1, 2, 3, 4, 5, 6], Nat.equal);
   /// ```
   /// Runtime: O(size1 + size2)
@@ -481,7 +481,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let array = [var 4, 2, 6, 1, 5];
-  /// let evenElements = VarArray.filter<Nat>(array, func x = x % 2 == 0);
+  /// let evenElements = VarArray.filter(array, func x = x % 2 == 0);
   /// assert VarArray.equal(evenElements, [var 4, 2, 6], Nat.equal);
   /// ```
   /// Runtime: O(size)
@@ -523,7 +523,7 @@ module {
   ///
   /// let array = [var 4, 2, 0, 1];
   /// let newArray =
-  ///   VarArray.filterMap<Nat, Text>( // mapping from Nat to Text values
+  ///   VarArray.filterMap( // mapping from Nat to Text values
   ///     array,
   ///     func x = if (x == 0) { null } else { ?Nat.toText(100 / x) } // can't divide by 0, so return null
   ///   );
@@ -671,7 +671,7 @@ module {
   /// import Int "mo:core/Int"
   ///
   /// let array = [var 1, 2, 3, 4];
-  /// let newArray = VarArray.flatMap<Nat, Int>(array, func x = [x, -x].vals());
+  /// let newArray = VarArray.flatMap(array, func x = [x, -x].vals());
   /// assert VarArray.equal(newArray, [var 1, -1, 2, -2, 3, -3, 4, -4], Int.equal);
   /// ```
   /// Runtime: O(size)
@@ -716,7 +716,7 @@ module {
   ///
   /// let array = [var 4, 2, 0, 1];
   /// let sum =
-  ///   VarArray.foldLeft<Nat, Nat>(
+  ///   VarArray.foldLeft(
   ///     array,
   ///     0, // start the sum at 0
   ///     func(sumSoFar, x) = sumSoFar + x // this entire function can be replaced with `add`!
@@ -745,7 +745,7 @@ module {
   /// import {toText} "mo:core/Nat";
   ///
   /// let array = [var 1, 9, 4, 8];
-  /// let bookTitle = VarArray.foldRight<Nat, Text>(array, "", func(x, acc) = toText(x) # acc);
+  /// let bookTitle = VarArray.foldRight(array, "", func(x, acc) = toText(x) # acc);
   /// assert bookTitle == "1948";
   /// ```
   ///
@@ -774,7 +774,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let arrays : [[var Nat]] = [[var 0, 1, 2], [var 2, 3], [var], [var 4]];
-  /// let joinedArray = VarArray.join<Nat>(arrays.vals());
+  /// let joinedArray = VarArray.join(arrays.vals());
   /// assert VarArray.equal(joinedArray, [var 0, 1, 2, 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -794,7 +794,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// let arrays : [var [var Nat]] = [var [var 0, 1, 2], [var 2, 3], [var], [var 4]];
-  /// let flatArray = VarArray.flatten<Nat>(arrays);
+  /// let flatArray = VarArray.flatten(arrays);
   /// assert VarArray.equal(flatArray, [var 0, 1, 2, 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -1128,16 +1128,16 @@ module {
   ///
   /// ```motoko include=import
   /// let array = [var 1, 2, 3, 4, 5];
-  /// let iter1 = VarArray.range<Nat>(array, 3, array.size());
+  /// let iter1 = VarArray.range(array, 3, array.size());
   /// assert iter1.next() == ?4;
   /// assert iter1.next() == ?5;
   /// assert iter1.next() == null;
   ///
-  /// let iter2 = VarArray.range<Nat>(array, 3, -1);
+  /// let iter2 = VarArray.range(array, 3, -1);
   /// assert iter2.next() == ?4;
   /// assert iter2.next() == null;
   ///
-  /// let iter3 = VarArray.range<Nat>(array, 0, 0);
+  /// let iter3 = VarArray.range(array, 0, 0);
   /// assert iter3.next() == null;
   /// ```
   ///
@@ -1182,10 +1182,10 @@ module {
   /// ```motoko include=import
   /// let array = [var 1, 2, 3, 4, 5];
   ///
-  /// let slice1 = VarArray.sliceToArray<Nat>(array, 1, 4);
+  /// let slice1 = VarArray.sliceToArray(array, 1, 4);
   /// assert slice1 == [2, 3, 4];
   ///
-  /// let slice2 = VarArray.sliceToArray<Nat>(array, 1, -1);
+  /// let slice2 = VarArray.sliceToArray(array, 1, -1);
   /// assert slice2 == [2, 3, 4];
   /// ```
   ///
@@ -1224,10 +1224,10 @@ module {
   ///
   /// let array = [var 1, 2, 3, 4, 5];
   ///
-  /// let slice1 = VarArray.sliceToVarArray<Nat>(array, 1, 4);
+  /// let slice1 = VarArray.sliceToVarArray(array, 1, 4);
   /// assert VarArray.equal(slice1, [var 2, 3, 4], Nat.equal);
   ///
-  /// let slice2 = VarArray.sliceToVarArray<Nat>(array, 1, -1);
+  /// let slice2 = VarArray.sliceToVarArray(array, 1, -1);
   /// assert VarArray.equal(slice2, [var 2, 3, 4], Nat.equal);
   /// ```
   ///
@@ -1263,7 +1263,7 @@ module {
   /// ```motoko include=import
   /// let varArray = [var 0, 1, 2];
   /// varArray[2] := 3;
-  /// let array = VarArray.toArray<Nat>(varArray);
+  /// let array = VarArray.toArray(varArray);
   /// assert array == [0, 1, 3];
   /// ```
   ///

--- a/src/VarArray.mo
+++ b/src/VarArray.mo
@@ -230,7 +230,7 @@ module {
       InsertionSort.insertionSortSmall(self, self, compare, 0 : Nat32, size);
       return
     };
-    let buffer = repeat<T>(self[0], nat(size / 2));
+    let buffer = repeat(self[0], nat(size / 2));
     mergeSortRec(self, buffer, compare, 0 : Nat32, size, true, 0 : Nat32)
   };
 
@@ -490,7 +490,7 @@ module {
   /// *Runtime and space assumes that `predicate` runs in O(1) time and space.
   public func filter<T>(self : [var T], f : T -> Bool) : [var T] {
     var count = 0;
-    let keep = Prim.Array_tabulate<Bool>(
+    let keep = Prim.Array_tabulate(
       self.size(),
       func i {
         if (f(self[i])) {
@@ -535,7 +535,7 @@ module {
   /// *Runtime and space assumes that `f` runs in O(1) time and space.
   public func filterMap<T, R>(self : [var T], f : T -> ?R) : [var R] {
     var count = 0;
-    let options = Prim.Array_tabulate<?R>(
+    let options = Prim.Array_tabulate(
       self.size(),
       func i {
         let result = f(self[i]);
@@ -598,7 +598,7 @@ module {
     let size = self.size();
 
     var error : ?Result.Result<[var R], E> = null;
-    let results = tabulate<?R>(
+    let results = tabulate(
       size,
       func i {
         switch (f(self[i])) {
@@ -680,10 +680,10 @@ module {
   /// *Runtime and space assumes that `k` runs in O(1) time and space.
   public func flatMap<T, R>(self : [var T], k : T -> Types.Iter<R>) : [var R] {
     var flatSize = 0;
-    let arrays = Prim.Array_tabulate<[var R]>(
+    let arrays = Prim.Array_tabulate(
       self.size(),
       func i {
-        let subArray = fromIter<R>(k(self[i])); // TODO: optimize
+        let subArray = fromIter(k(self[i])); // TODO: optimize
         flatSize += subArray.size();
         subArray
       }
@@ -872,7 +872,7 @@ module {
       }
     };
     if (size == 0) { return [var] };
-    let array = Prim.Array_init<T>(
+    let array = Prim.Array_init(
       size,
       switch list {
         case (?(h, _)) h;

--- a/src/internal/BTreeHelper.mo
+++ b/src/internal/BTreeHelper.mo
@@ -60,7 +60,7 @@ module {
     if (splitIndex > array.size()) { assert false };
 
     let leftSplit = if (insertIndex < splitIndex) {
-      VarArray.tabulate<?T>(
+      VarArray.tabulate(
         array.size(),
         func(i) {
           // if below the split index
@@ -77,7 +77,7 @@ module {
     }
     // index >= splitIndex
     else {
-      VarArray.tabulate<?T>(
+      VarArray.tabulate(
         array.size(),
         func(i) {
           // right biased splitting
@@ -89,7 +89,7 @@ module {
     let (rightSplit, middleElement) : ([var ?T], ?T) =
     // if insert > split index, inserted element will be inserted into the right split
     if (insertIndex > splitIndex) {
-      let right = VarArray.tabulate<?T>(
+      let right = VarArray.tabulate(
         array.size(),
         func(i) {
           let adjIndex = i + splitIndex + 1; // + 1 accounts for the fact that the split element was part of the original array
@@ -104,7 +104,7 @@ module {
     }
     // if inserted element was placed in the left split
     else if (insertIndex < splitIndex) {
-      let right = VarArray.tabulate<?T>(
+      let right = VarArray.tabulate(
         array.size(),
         func(i) {
           let adjIndex = i + splitIndex;
@@ -115,7 +115,7 @@ module {
     }
     // insertIndex == splitIndex
     else {
-      let right = VarArray.tabulate<?T>(
+      let right = VarArray.tabulate(
         array.size(),
         func(i) {
           let adjIndex = i + splitIndex;
@@ -153,7 +153,7 @@ module {
   public func splitArrayAndInsertTwo<T>(children : [var ?T], rebalancedChildIndex : Nat, leftChildInsert : T, rightChildInsert : T) : ([var ?T], [var ?T]) {
     let splitIndex = children.size() / 2;
 
-    let leftRebalancedChildren = VarArray.tabulate<?T>(
+    let leftRebalancedChildren = VarArray.tabulate(
       children.size(),
       func(i) {
         // only insert elements up to the split index and fill the rest of the children with nulls

--- a/src/pure/List.mo
+++ b/src/pure/List.mo
@@ -571,7 +571,7 @@ module {
   ///
   /// persistent actor {
   ///   let list = List.fromArray(['A', 'B', 'C', 'D']);
-  ///   let found = List.findIndex<Char>(list, func(x) { x == 'C' });
+  ///   let found = List.findIndex(list, func(x) { x == 'C' });
   ///   assert found == ?2;
   /// }
   /// ```
@@ -729,7 +729,7 @@ module {
   /// import List "mo:core/pure/List";
   ///
   /// persistent actor {
-  ///   let list = List.tabulate<Nat>(3, func n = n * 2);
+  ///   let list = List.tabulate(3, func n = n * 2);
   ///   assert list == ?(0, ?(2, ?(4, null)));
   /// }
   /// ```

--- a/src/pure/Map.mo
+++ b/src/pure/Map.mo
@@ -321,7 +321,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///     Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   let map1 = Map.remove(map0, Nat.compare, 1);
   ///   assert Iter.toArray(Map.entries(map1)) == [(0, "Zero"), (2, "Two")];
@@ -357,7 +357,7 @@ module {
   ///
   /// persistent actor {
   ///   let map0 =
-  ///     Map.fromIter<Nat, Text>([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
+  ///     Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
   ///   do {
   ///     let (map1, pres1) = Map.delete(map0, Nat.compare, 1);
@@ -761,7 +761,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let map = Map.singleton<Nat, Text>(0, "Zero");
+  ///   let map = Map.singleton(0, "Zero");
   ///   assert Iter.toArray(Map.entries(map)) == [(0, "Zero")];
   /// }
   /// ```
@@ -814,7 +814,7 @@ module {
   /// persistent actor {
   ///   let numberNames = Map.fromIter([(0, "Zero"), (2, "Two"), (1, "One")].values(), Nat.compare);
   ///
-  ///   let evenNames = Map.filter<Nat, Text>(numberNames, Nat.compare, func (key, value) {
+  ///   let evenNames = Map.filter(numberNames, Nat.compare, func (key, value) {
   ///     key % 2 == 0
   ///   });
   ///
@@ -904,7 +904,7 @@ module {
   ///
   /// persistent actor {
   ///   let map1 = Map.fromIter([(0, "Zero"), (1, "One"), (2, "Two")].values(), Nat.compare);
-  ///   let map2 = Map.fromIter<Nat, Text>([(2, "Two"), (1, "One"), (0, "Zero")].values(), Nat.compare);
+  ///   let map2 = Map.fromIter([(2, "Two"), (1, "One"), (0, "Zero")].values(), Nat.compare);
   ///   assert(Map.equal(map1, map2, Nat.compare, Text.equal));
   /// }
   /// ```

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -336,7 +336,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let queue = Queue.fromArray(["A", "B", "C"]);
   ///   assert Queue.size(queue) == 3;
   ///   assert Queue.peekFront(queue) == ?"A";
   /// }
@@ -358,7 +358,7 @@ module {
   /// import Array "mo:core/Array";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let queue = Queue.fromArray(["A", "B", "C"]);
   ///   let array = Queue.toArray(queue);
   ///   assert array == ["A", "B", "C"];
   /// }
@@ -442,7 +442,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   let allGreaterThanOne = Queue.all<Nat>(queue, func n = n > 1);
+  ///   let allGreaterThanOne = Queue.all(queue, func n = n > 1);
   ///   assert not allGreaterThanOne; // false because 1 is not > 1
   /// }
   /// ```
@@ -464,7 +464,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   let hasGreaterThanOne = Queue.any<Nat>(queue, func n = n > 1);
+  ///   let hasGreaterThanOne = Queue.any(queue, func n = n > 1);
   ///   assert hasGreaterThanOne; // true because 2 and 3 are > 1
   /// }
   /// ```
@@ -511,7 +511,7 @@ module {
   ///
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2].values());
-  ///   let textQueue = Queue.map<Nat, Text>(queue, Nat.toText);
+  ///   let textQueue = Queue.map(queue, Nat.toText);
   ///   assert Iter.toArray(Queue.values(textQueue)) == ["0", "1", "2"];
   /// }
   /// ```
@@ -535,7 +535,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   let queue = Queue.fromIter([0, 1, 2, 1].values());
-  ///   let filtered = Queue.filter<Nat>(queue, func n = n != 1);
+  ///   let filtered = Queue.filter(queue, func n = n != 1);
   ///   assert Queue.size(filtered) == 2;
   /// }
   /// ```
@@ -561,7 +561,7 @@ module {
   /// ```motoko include=import
   /// persistent actor {
   ///   let queue = Queue.fromIter([1, 2, 3].values());
-  ///   let doubled = Queue.filterMap<Nat, Nat>(
+  ///   let doubled = Queue.filterMap(
   ///     queue,
   ///     func n = if (n > 1) ?(n * 2) else null
   ///   );

--- a/src/pure/RealTimeQueue.mo
+++ b/src/pure/RealTimeQueue.mo
@@ -102,7 +102,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.singleton<Nat>(25);
+  ///   let queue = Queue.singleton(25);
   ///   assert Queue.size(queue) == 1;
   ///   assert Queue.peekFront(queue) == ?25;
   /// }
@@ -118,7 +118,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.singleton<Nat>(42);
+  ///   let queue = Queue.singleton(42);
   ///   assert Queue.size(queue) == 1;
   /// }
   /// ```
@@ -530,7 +530,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([0, 1, 2, 3, 4].values());
+  ///   let queue = Queue.fromIter([0, 1, 2, 3, 4].values());
   ///   assert Queue.peekFront(queue) == ?0;
   ///   assert Queue.peekBack(queue) == ?4;
   ///   assert Queue.size(queue) == 5;
@@ -575,7 +575,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert Iter.toArray(Queue.values(queue)) == [1, 2, 3];
   /// }
   /// ```
@@ -606,9 +606,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue3 = Queue.fromIter<Nat>([1, 3, 2].values());
+  ///   let queue1 = Queue.fromIter([1, 2, 3].values());
+  ///   let queue2 = Queue.fromIter([1, 2, 3].values());
+  ///   let queue3 = Queue.fromIter([1, 3, 2].values());
   ///   assert Queue.equal(queue1, queue2, Nat.equal);
   ///   assert not Queue.equal(queue1, queue3, Nat.equal);
   /// }
@@ -637,8 +637,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue1 = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let queue2 = Queue.fromIter<Nat>([1, 2, 4].values());
+  ///   let queue1 = Queue.fromIter([1, 2, 3].values());
+  ///   let queue2 = Queue.fromIter([1, 2, 4].values());
   ///   assert Queue.compare(queue1, queue2, Nat.compare) == #less;
   /// }
   /// ```
@@ -663,7 +663,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([2, 4, 6].values());
+  ///   let queue = Queue.fromIter([2, 4, 6].values());
   ///   assert Queue.all<Nat>(queue, func n = n % 2 == 0);
   ///   assert not Queue.all<Nat>(queue, func n = n > 4);
   /// }
@@ -690,7 +690,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert Queue.any<Nat>(queue, func n = n > 2);
   ///   assert not Queue.any<Nat>(queue, func n = n > 3);
   /// }
@@ -719,7 +719,7 @@ module {
   /// import Nat "mo:core/Nat";
   /// persistent actor {
   ///   var text = "";
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   Queue.forEach<Nat>(queue, func n = text #= Nat.toText(n));
   ///   assert text == "123";
   /// }
@@ -750,8 +750,8 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
-  ///   let mapped = Queue.map<Nat, Nat>(queue, func n = n * 2);
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
+  ///   let mapped = Queue.map(queue, func n = n * 2);
   ///   assert Queue.size(mapped) == 3;
   ///   assert Queue.peekFront(mapped) == ?2;
   ///   assert Queue.peekBack(mapped) == ?6;
@@ -784,8 +784,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
-  ///   let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
+  ///   let queue = Queue.fromIter([1, 2, 3, 4].values());
+  ///   let filtered = Queue.filter(queue, func n = n % 2 == 0);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
   ///   assert Queue.peekBack(filtered) == ?4;
@@ -809,8 +809,8 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3, 4].values());
-  ///   let filtered = Queue.filterMap<Nat, Nat>(queue, func n = if (n % 2 == 0) { ?n } else null);
+  ///   let queue = Queue.fromIter([1, 2, 3, 4].values());
+  ///   let filtered = Queue.filterMap(queue, func n = if (n % 2 == 0) { ?n } else null);
   ///   assert Queue.size(filtered) == 2;
   ///   assert Queue.peekFront(filtered) == ?2;
   ///   assert Queue.peekBack(filtered) == ?4;
@@ -840,7 +840,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   assert Queue.toText(queue, Nat.toText) == "RealTimeQueue[1, 2, 3]";
   /// }
   /// ```
@@ -866,7 +866,7 @@ module {
   /// Example:
   /// ```motoko include=import
   /// persistent actor {
-  ///   let queue = Queue.fromIter<Nat>([1, 2, 3].values());
+  ///   let queue = Queue.fromIter([1, 2, 3].values());
   ///   let reversed = Queue.reverse(queue);
   ///   assert Queue.peekFront(reversed) == ?3;
   ///   assert Queue.peekBack(reversed) == ?1;

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -271,7 +271,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([0, 2, 1].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([0, 2, 1].values(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.max(set1) == ?2;
   ///   assert Set.max(set2) == null;
@@ -292,7 +292,7 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set1 = Set.fromIter<Nat>([2, 0, 1].values(), Nat.compare);
+  ///   let set1 = Set.fromIter([2, 0, 1].values(), Nat.compare);
   ///   let set2 = Set.empty<Nat>();
   ///   assert Set.min(set1) == ?0;
   ///   assert Set.min(set2) == null;
@@ -447,7 +447,7 @@ module {
   ///   let numbers = Set.fromIter([3, 1, 2].values(), Nat.compare);
   ///
   ///   let textNumbers =
-  ///     Set.map<Nat, Text>(numbers, Text.compare, Nat.toText);
+  ///     Set.map(numbers, Text.compare, Nat.toText);
   ///   assert Iter.toArray(Set.values(textNumbers)) == ["1", "2", "3"];
   /// }
   /// ```
@@ -500,7 +500,7 @@ module {
   /// persistent actor {
   ///   let numbers = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let evenNumbers = Set.filter<Nat>(numbers, Nat.compare, func (number) {
+  ///   let evenNumbers = Set.filter(numbers, Nat.compare, func (number) {
   ///     number % 2 == 0
   ///   });
   ///   assert Iter.toArray(Set.values(evenNumbers)) == [0, 2];
@@ -536,7 +536,7 @@ module {
   /// persistent actor {
   ///   let numbers = Set.fromIter([3, 0, 2, 1].values(), Nat.compare);
   ///
-  ///   let evenTextNumbers = Set.filterMap<Nat, Text>(numbers, Text.compare, func (number) {
+  ///   let evenTextNumbers = Set.filterMap(numbers, Text.compare, func (number) {
   ///     if (number % 2 == 0) {
   ///        ?Nat.toText(number)
   ///     } else {
@@ -821,7 +821,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
-  ///   let text = Set.foldLeft<Nat, Text>(
+  ///   let text = Set.foldLeft(
   ///      set,
   ///      "",
   ///      func (accumulator, element) {
@@ -852,7 +852,7 @@ module {
   /// persistent actor {
   ///   let set = Set.fromIter([0, 3, 2, 1].values(), Nat.compare);
   ///
-  ///   let text = Set.foldRight<Nat, Text>(
+  ///   let text = Set.foldRight(
   ///      set,
   ///      "",
   ///      func (element, accumulator) {
@@ -881,7 +881,7 @@ module {
   ///
   /// persistent actor {
   ///   let set1 = Set.empty<Nat>();
-  ///   let set2 = Set.singleton<Nat>(1);
+  ///   let set2 = Set.singleton(1);
   ///
   ///   assert Set.isEmpty(set1);
   ///   assert not Set.isEmpty(set2);
@@ -907,9 +907,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let belowTen = Set.all<Nat>(set, func (number) {
+  ///   let belowTen = Set.all(set, func (number) {
   ///     number < 10
   ///   });
   ///   assert belowTen;
@@ -931,9 +931,9 @@ module {
   /// import Nat "mo:core/Nat";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
-  ///   let aboveTen = Set.any<Nat>(set, func (number) {
+  ///   let aboveTen = Set.any(set, func (number) {
   ///     number > 10
   ///   });
   ///   assert not aboveTen;
@@ -961,7 +961,7 @@ module {
   /// import Iter "mo:core/Iter";
   ///
   /// persistent actor {
-  ///   let set = Set.fromIter<Nat>([0, 3, 1, 2].values(), Nat.compare);
+  ///   let set = Set.fromIter([0, 3, 1, 2].values(), Nat.compare);
   ///
   ///   assert Set.toText(set, Nat.toText) == "PureSet{0, 1, 2, 3}";
   /// }

--- a/test/Array.test.mo
+++ b/test/Array.test.mo
@@ -32,7 +32,7 @@ func varArrayTestable<A>(testableA : T.Testable<A>) : T.Testable<[var A]> {
 };
 
 func varArray<A>(testableA : T.Testable<A>, xs : [var A]) : T.TestableItem<[var A]> {
-  let testableAs = varArrayTestable<A>(testableA);
+  let testableAs = varArrayTestable(testableA);
   {
     item = xs;
     display = testableAs.display;
@@ -761,7 +761,7 @@ let suite = Suite.suite(
     Suite.test(
       "binarySearch duplicates",
       do {
-        let result = Array.binarySearch<Nat>([1, 2, 2, 2, 3], Nat.compare, 2);
+        let result = Array.binarySearch([1, 2, 2, 2, 3], Nat.compare, 2);
         switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }

--- a/test/Func.test.mo
+++ b/test/Func.test.mo
@@ -4,7 +4,7 @@ import { suite; test; expect } "mo:test";
 
 func isEven(x : Int) : Bool { x % 2 == 0 };
 func not_(x : Bool) : Bool { not x };
-let isOdd = Function.compose<Int, Bool, Bool>(not_, isEven);
+let isOdd = Function.compose(not_, isEven);
 
 suite(
   "compose",

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -39,7 +39,7 @@ suite(
       "maps elements using provided function",
       func() {
         let isEven = func(x : Int) : Bool { x % 2 == 0 };
-        let _actual = Iter.map<Nat, Bool>([1, 2, 3].vals(), isEven);
+        let _actual = Iter.map([1, 2, 3].vals(), isEven);
         let actual = [var true, false, true];
         Iter.forEach<(Nat, Bool)>(
           Iter.enumerate(_actual),
@@ -62,7 +62,7 @@ suite(
       "filters elements using predicate",
       func() {
         let isOdd = func(x : Int) : Bool { x % 2 == 1 };
-        let _actual = Iter.filter<Nat>([1, 2, 3].vals(), isOdd);
+        let _actual = Iter.filter([1, 2, 3].vals(), isOdd);
         let actual = [var 0, 0];
         Iter.forEach<(Nat, Nat)>(
           Iter.enumerate(_actual),
@@ -78,7 +78,7 @@ suite(
   "filterMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.filterMap<Nat, Nat>(inputs.vals(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
+      let actual = Iter.filterMap(inputs.vals(), func(x) = if (x % 2 == 0) ?(x * 10) else null);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [20, 40]));
@@ -91,7 +91,7 @@ suite(
   "flatten",
   func() {
     func mk(inputs : [[Nat]], expected : [Nat]) {
-      let actual = Iter.flatten(Iter.map<[Nat], Iter.Iter<Nat>>(inputs.vals(), func(x) = Iter.fromArray<Nat>(x)));
+      let actual = Iter.flatten(Iter.map(inputs.vals(), func(x) = Iter.fromArray(x)));
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([[1, 2], [3], [4, 5, 6]], [1, 2, 3, 4, 5, 6]));
@@ -104,7 +104,7 @@ suite(
   "flatMap",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.flatMap<Nat, Nat>(inputs.vals(), func(x) = [x, x * 10].vals());
+      let actual = Iter.flatMap(inputs.vals(), func(x) = [x, x * 10].vals());
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3], [1, 10, 2, 20, 3, 30]));
@@ -116,7 +116,7 @@ suite(
   "take",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.take<Nat>(inputs.vals(), n);
+      let actual = Iter.take(inputs.vals(), n);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [1, 2, 3]));
@@ -131,7 +131,7 @@ suite(
   "drop",
   func() {
     func mk(inputs : [Nat], n : Nat, expected : [Nat]) {
-      let actual = Iter.drop<Nat>(inputs.vals(), n);
+      let actual = Iter.drop(inputs.vals(), n);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5], 3, [4, 5]));
@@ -146,7 +146,7 @@ suite(
   "takeWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.takeWhile<Nat>(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.takeWhile(inputs.vals(), func(x) = x < 4);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3]));
@@ -160,7 +160,7 @@ suite(
   "dropWhile",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.dropWhile<Nat>(inputs.vals(), func(x) = x < 4);
+      let actual = Iter.dropWhile(inputs.vals(), func(x) = x < 4);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4, 5, 4, 3, 2, 1], [4, 5, 4, 3, 2, 1]));
@@ -174,7 +174,7 @@ suite(
   "zip",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [(Nat, Nat)]) {
-      let actual = Iter.zip<Nat, Nat>(input1.vals(), input2.vals());
+      let actual = Iter.zip(input1.vals(), input2.vals());
       expect.array<(Nat, Nat)>(Iter.toArray(actual), Tuple2.makeToText<Nat, Nat>(Nat.toText, Nat.toText), Tuple2.makeEqual<Nat, Nat>(Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [(1, 4), (2, 5), (3, 6)]));
@@ -190,7 +190,7 @@ suite(
   "zipWith",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith<Nat, Nat, Nat>(input1.vals(), input2.vals(), func(x, y) = x + y);
+      let actual = Iter.zipWith(input1.vals(), input2.vals(), func(x, y) = x + y);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [5, 7, 9]));
@@ -206,7 +206,7 @@ suite(
   "zip3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [(Nat, Nat, Nat)]) {
-      let actual = Iter.zip3<Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals());
+      let actual = Iter.zip3(input1.vals(), input2.vals(), input3.vals());
       expect.array<(Nat, Nat, Nat)>(Iter.toArray(actual), Tuple3.makeToText<Nat, Nat, Nat>(Nat.toText, Nat.toText, Nat.toText), Tuple3.makeEqual<Nat, Nat, Nat>(Nat.equal, Nat.equal, Nat.equal)).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [(1, 4, 7), (2, 5, 8), (3, 6, 9)]));
@@ -223,7 +223,7 @@ suite(
   "zipWith3",
   func() {
     func mk(input1 : [Nat], input2 : [Nat], input3 : [Nat], expected : [Nat]) {
-      let actual = Iter.zipWith3<Nat, Nat, Nat, Nat>(input1.vals(), input2.vals(), input3.vals(), func(x, y, z) = x + y + z);
+      let actual = Iter.zipWith3(input1.vals(), input2.vals(), input3.vals(), func(x, y, z) = x + y + z);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("matched", func() = mk([1, 2, 3], [4, 5, 6], [7, 8, 9], [12, 15, 18]));
@@ -243,7 +243,7 @@ suite(
       "creates iterator with single element",
       func() {
         let x = 1;
-        let y = Iter.singleton<Nat>(x);
+        let y = Iter.singleton(x);
         assert (y.next() == ?x);
         assert (y.next() == null)
       }
@@ -258,7 +258,7 @@ suite(
       "creates infinite iterator of same element",
       func() {
         let x = 1;
-        let y = Iter.infinite<Nat>(x);
+        let y = Iter.infinite(x);
         for (_ in Nat.range(0, 10000)) {
           assert (y.next() == ?x)
         }
@@ -274,7 +274,7 @@ suite(
       "creates iterator from array",
       func() {
         let expected = [1, 2, 3];
-        let _actual = Iter.fromArray<Nat>(expected);
+        let _actual = Iter.fromArray(expected);
         let actual = [var 0, 0, 0];
 
         Iter.forEach<(Nat, Nat)>(
@@ -297,7 +297,7 @@ suite(
       "creates iterator from var array",
       func() {
         let expected = [var 1, 2, 3];
-        let _actual = Iter.fromVarArray<Nat>(expected);
+        let _actual = Iter.fromVarArray(expected);
         let actual = [var 0, 0, 0];
 
         Iter.forEach<(Nat, Nat)>(
@@ -320,7 +320,7 @@ suite(
       "converts iterator to array",
       func() {
         let expected = [1, 2, 3];
-        let actual = Iter.toArray<Nat>(expected.vals());
+        let actual = Iter.toArray(expected.vals());
         expect.nat(actual.size()).equal(expected.size());
         for (i in actual.keys()) {
           expect.nat(actual[i]).equal(expected[i])
@@ -355,7 +355,7 @@ suite(
       func() {
         let input : [Nat] = [4, 3, 1, 2, 5];
         let expected : [Nat] = [1, 2, 3, 4, 5];
-        let actual = Iter.toArray(Iter.sort<Nat>(input.vals(), Nat.compare));
+        let actual = Iter.toArray(Iter.sort(input.vals(), Nat.compare));
         expect.array<Nat>(actual, Nat.toText, Nat.equal).equal(expected)
       }
     )
@@ -466,7 +466,7 @@ suite(
     test(
       "repeats element specified number of times",
       func() {
-        let iter1 = Iter.repeat<Char>('a', 3);
+        let iter1 = Iter.repeat('a', 3);
         assert (iter1.next() == ?'a');
         assert (iter1.next() == ?'a');
         assert (iter1.next() == ?'a');
@@ -477,7 +477,7 @@ suite(
     test(
       "zero count returns empty iterator",
       func() {
-        let iter2 = Iter.repeat<Nat>(1, 0);
+        let iter2 = Iter.repeat(1, 0);
         assert (iter2.next() == null)
       }
     );
@@ -485,7 +485,7 @@ suite(
     test(
       "count of one returns singleton iterator",
       func() {
-        let iter3 = Iter.repeat<Bool>(true, 1);
+        let iter3 = Iter.repeat(true, 1);
         assert (iter3.next() == ?true);
         assert (iter3.next() == null)
       }
@@ -694,7 +694,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
       let iter = inputs.vals();
-      let actual = Iter.all<Nat>(iter, func(x) = x % 2 == 0);
+      let actual = Iter.all(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
@@ -710,7 +710,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : Bool, rest : [Nat]) {
       let iter = inputs.vals();
-      let actual = Iter.any<Nat>(iter, func(x) = x % 2 == 0);
+      let actual = Iter.any(iter, func(x) = x % 2 == 0);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
@@ -726,7 +726,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
       let iter = inputs.vals();
-      let actual = Iter.find<Nat>(iter, func(x) = x % 2 == 0);
+      let actual = Iter.find(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = Iter.toArray(iter);
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
@@ -742,7 +742,7 @@ suite(
   func() {
     func mk(inputs : [Nat], expected : ?Nat, rest : [Nat]) {
       let iter = inputs.vals();
-      let actual = Iter.findIndex<Nat>(iter, func(x) = x % 2 == 0);
+      let actual = Iter.findIndex(iter, func(x) = x % 2 == 0);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected);
       let remaining = Iter.toArray(iter);
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
@@ -758,7 +758,7 @@ suite(
   func() {
     func mk(inputs : [Nat], x : Nat, expected : Bool, rest : [Nat]) {
       let iter = inputs.vals();
-      let actual = Iter.contains<Nat>(iter, Nat.equal, x);
+      let actual = Iter.contains(iter, Nat.equal, x);
       expect.bool(actual).equal(expected);
       let remaining = Iter.toArray(iter);
       expect.array<Nat>(remaining, Nat.toText, Nat.equal).equal(rest)
@@ -773,7 +773,7 @@ suite(
   "foldLeft",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldLeft<Text, Text>(inputs.vals(), "S", func(acc, x) = "(" # acc # x # ")");
+      let actual = Iter.foldLeft(inputs.vals(), "S", func(acc, x) = "(" # acc # x # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(((SA)B)C)"));
@@ -785,7 +785,7 @@ suite(
   "foldRight",
   func() {
     func mk(inputs : [Text], expected : Text) {
-      let actual = Iter.foldRight<Text, Text>(inputs.vals(), "S", func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.foldRight(inputs.vals(), "S", func(x, acc) = "(" # x # acc # ")");
       expect.text(actual).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], "(A(B(CS)))"));
@@ -797,7 +797,7 @@ suite(
   "reduce",
   func() {
     func mk(inputs : [Text], expected : ?Text) {
-      let actual = Iter.reduce<Text>(inputs.vals(), func(x, acc) = "(" # x # acc # ")");
+      let actual = Iter.reduce(inputs.vals(), func(x, acc) = "(" # x # acc # ")");
       expect.option(actual, func(x : Text) : Text = x, Text.equal).equal(expected)
     };
     test("some", func() = mk(["A", "B", "C"], ?"((AB)C)"));
@@ -810,7 +810,7 @@ suite(
   "scanLeft",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanLeft<Nat, Nat>(inputs.vals(), 0, func(acc, x) = acc + x);
+      let actual = Iter.scanLeft(inputs.vals(), 0, func(acc, x) = acc + x);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 1, 3, 6, 10]));
@@ -822,7 +822,7 @@ suite(
   "scanRight",
   func() {
     func mk(inputs : [Nat], expected : [Nat]) {
-      let actual = Iter.scanRight<Nat, Nat>(inputs.vals(), 0, func(x, acc) = acc + x);
+      let actual = Iter.scanRight(inputs.vals(), 0, func(x, acc) = acc + x);
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 4], [0, 4, 7, 9, 10]));
@@ -834,7 +834,7 @@ suite(
   "unfold",
   func() {
     func mk(n : Nat, expected : [Nat]) {
-      let actual = Iter.unfold<Nat, Nat>(n, func(x) = if (x == 0) null else ?(x, x - 1));
+      let actual = Iter.unfold(n, func(x) = if (x == 0) null else ?(x, x - 1));
       expect.array<Nat>(Iter.toArray(actual), Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk(5, [5, 4, 3, 2, 1]));
@@ -846,7 +846,7 @@ suite(
   "max",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.max<Nat>(inputs.vals(), Nat.compare);
+      let actual = Iter.max(inputs.vals(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 3, 2, 3], ?3));
@@ -858,7 +858,7 @@ suite(
   "min",
   func() {
     func mk(inputs : [Nat], expected : ?Nat) {
-      let actual = Iter.min<Nat>(inputs.vals(), Nat.compare);
+      let actual = Iter.min(inputs.vals(), Nat.compare);
       expect.option(actual, Nat.toText, Nat.equal).equal(expected)
     };
     test("some", func() = mk([1, 2, 1, 4], ?1));

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -1350,8 +1350,8 @@ func testRange(n : Nat) : Bool {
   let vec = List.tabulate<Nat>(n, func(i) = i);
   for (left in Nat.range(0, n)) {
     for (right in Nat.range(left, n + 1)) {
-      let range = Iter.toArray<Nat>(List.range<Nat>(vec, left, right));
-      let expected = Array.tabulate<Nat>(right - left, func(i) = left + i);
+      let range = Iter.toArray(List.range(vec, left, right));
+      let expected = Array.tabulate(right - left, func(i) = left + i);
       if (range != expected) {
         Debug.print(
           "Range mismatch for left = " # Nat.toText(left) # ", right = " # Nat.toText(right) # ": expected " # debug_show (expected) # ", got " # debug_show (range)
@@ -1368,9 +1368,9 @@ func testSliceToArray(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
   for (left in Nat.range(0, n)) {
     for (right in Nat.range(left, n + 1)) {
-      let slice = List.sliceToArray<Nat>(vec, left, right);
-      let sliceVar = List.sliceToVarArray<Nat>(vec, left, right);
-      let expected = Array.tabulate<Nat>(right - left, func(i) = left + i);
+      let slice = List.sliceToArray(vec, left, right);
+      let sliceVar = List.sliceToVarArray(vec, left, right);
+      let expected = Array.tabulate(right - left, func(i) = left + i);
       let expectedVar = VarArray.tabulate<Nat>(right - left, func(i) = left + i);
       if (slice != expected or not VarArray.equal<Nat>(sliceVar, expectedVar, Nat.equal)) {
         Debug.print(
@@ -1446,7 +1446,7 @@ func testContains(n : Nat) : Bool {
 func testReverse(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
   assertValid(vec);
-  let reversed = List.reverse<Nat>(vec);
+  let reversed = List.reverse(vec);
   assertValid(reversed);
   List.reverseInPlace(vec);
   assertValid(vec);
@@ -1459,12 +1459,12 @@ func testReverse(n : Nat) : Bool {
 
 func testSort(n : Nat) : Bool {
   let array = Array.tabulate<Int>(n, func(i) = (i * 123) % 100 - 50);
-  let vec = List.fromArray<Int>(array);
+  let vec = List.fromArray(array);
 
   let sorted = List.sort(vec, Int.compare);
   List.sortInPlace(vec, Int.compare);
 
-  let expected = List.fromArray<Int>(Array.sort(array, Int.compare));
+  let expected = List.fromArray(Array.sort(array, Int.compare));
 
   List.equal(vec, expected, Int.equal) and List.equal(sorted, expected, Int.equal)
 };
@@ -1506,7 +1506,7 @@ func testDeduplicate(n : Nat) : Bool {
 };
 
 func testToArray(n : Nat) : Bool {
-  let array = Array.tabulate<Nat>(n, func(i) = i);
+  let array = Array.tabulate(n, func(i) = i);
   let vec = List.fromArray<Nat>(array);
   assertValid(vec);
   Array.equal(List.toArray(vec), array, Nat.equal)
@@ -1520,12 +1520,12 @@ func testToVarArray(n : Nat) : Bool {
 
 func testFromVarArray(n : Nat) : Bool {
   let array = VarArray.tabulate<Nat>(n, func(i) = i);
-  let vec = List.fromVarArray<Nat>(array);
+  let vec = List.fromVarArray(array);
   List.equal(vec, List.fromArray<Nat>(Array.fromVarArray(array)), Nat.equal)
 };
 
 func testFromArray(n : Nat) : Bool {
-  let array = Array.tabulate<Nat>(n, func(i) = i);
+  let array = Array.tabulate(n, func(i) = i);
   let vec = List.fromArray<Nat>(array);
   List.equal(vec, List.fromArray<Nat>(array), Nat.equal)
 };
@@ -1570,7 +1570,7 @@ func testFoldRight(n : Nat) : Bool {
 func testFilter(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
 
-  let evens = List.filter<Nat>(vec, func x = x % 2 == 0);
+  let evens = List.filter(vec, func x = x % 2 == 0);
   assertValid(evens);
 
   let expectedEvens = List.fromArray<Nat>(Array.tabulate<Nat>((n + 1) / 2, func(i) = i * 2));
@@ -1579,14 +1579,14 @@ func testFilter(n : Nat) : Bool {
     return false
   };
 
-  let none = List.filter<Nat>(vec, func _ = false);
+  let none = List.filter(vec, func _ = false);
   assertValid(none);
   if (not List.isEmpty(none)) {
     Debug.print("Filter none failed");
     return false
   };
 
-  let all = List.filter<Nat>(vec, func _ = true);
+  let all = List.filter(vec, func _ = true);
   assertValid(all);
   if (not List.equal<Nat>(all, vec, Nat.equal)) {
     Debug.print("Filter all failed");
@@ -1603,7 +1603,7 @@ func testRetain(n : Nat) : Bool {
     for (rem in Nat.range(0, mod + 1)) {
       let f : Nat -> Bool = func x = x % mod == rem;
       let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i));
-      let expected = List.filter<Nat>(vec, f);
+      let expected = List.filter(vec, f);
       List.retain<Nat>(vec, f);
       if (not List.equal<Nat>(vec, expected, Nat.equal)) {
         Debug.print("Retain failed for mod " # Nat.toText(mod) # " and rem " # Nat.toText(rem) # "");
@@ -1645,9 +1645,9 @@ func testFilterMap(n : Nat) : Bool {
 };
 
 func testPure(n : Nat) : Bool {
-  let idArray = Array.tabulate<Nat>(n, func(i) = i);
+  let idArray = Array.tabulate(n, func(i) = i);
   let vec = List.fromArray<Nat>(idArray);
-  let pureList = List.toPure<Nat>(vec);
+  let pureList = List.toPure(vec);
   let newVec = List.fromPure<Nat>(pureList);
   assertValid(newVec);
 
@@ -1730,7 +1730,7 @@ func testFlatten(n : Nat) : Bool {
       func(i) = List.fromArray<Nat>(Array.tabulate<Nat>(i + 1, func(j) = j))
     )
   );
-  let flattened = List.flatten<Nat>(vec);
+  let flattened = List.flatten(vec);
   let expectedSize = (n * (n + 1)) / 2;
 
   if (List.size(flattened) != expectedSize) {
@@ -1751,11 +1751,11 @@ func testFlatten(n : Nat) : Bool {
 };
 
 func testJoin(n : Nat) : Bool {
-  let iter = Array.tabulate<List.List<Nat>>(
+  let iter = Array.tabulate(
     n,
     func(i) = List.fromArray<Nat>(Array.tabulate<Nat>(i + 1, func(j) = j))
   ).vals();
-  let flattened = List.join<Nat>(iter);
+  let flattened = List.join(iter);
   let expectedSize = (n * (n + 1)) / 2;
 
   if (List.size(flattened) != expectedSize) {
@@ -1808,7 +1808,7 @@ func testNextIndexOf(n : Nat) : Bool {
   let vec = List.tabulate<Nat>(n, func(i) = i);
   for (from in Nat.range(0, n)) {
     for (element in Nat.range(0, n + 1)) {
-      let actual = List.nextIndexOf<Nat>(vec, Nat.equal, element, from);
+      let actual = List.nextIndexOf(vec, Nat.equal, element, from);
       let expected = nextIndexOf(vec, element, from);
       if (expected != actual) {
         Debug.print(
@@ -1838,7 +1838,7 @@ func testPrevIndexOf(n : Nat) : Bool {
   let vec = List.tabulate<Nat>(n, func(i) = i);
   for (from in Nat.range(0, n + 1)) {
     for (element in Nat.range(0, n + 1)) {
-      let actual = List.prevIndexOf<Nat>(vec, Nat.equal, element, from);
+      let actual = List.prevIndexOf(vec, Nat.equal, element, from);
       let expected = prevIndexOf(vec, element, from);
       if (expected != actual) {
         Debug.print(
@@ -1864,7 +1864,7 @@ func testMin(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i + 1));
   for (i in Nat.range(0, n)) {
     List.put(vec, i, 0);
-    let min = List.min<Nat>(vec, Nat.compare);
+    let min = List.min(vec, Nat.compare);
     if (min != ?0) {
       Debug.print("Min failed: expected ?0, got " # debug_show (min));
       return false
@@ -1887,7 +1887,7 @@ func testMax(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i + 1));
   for (i in Nat.range(0, n)) {
     List.put(vec, i, n + 1);
-    let max = List.max<Nat>(vec, Nat.compare);
+    let max = List.max(vec, Nat.compare);
     if (max != ?(n + 1)) {
       Debug.print("Max failed: expected ?" # Nat.toText(n + 1) # ", got " # debug_show (max));
       return false
@@ -2074,8 +2074,8 @@ Test.suite(
     Test.test(
       "binarySearch",
       func() {
-        let result1 = List.binarySearch<Nat>(empty, Nat.compare, 0);
-        let result2 = List.binarySearch<Nat>(emptied, Nat.compare, 0);
+        let result1 = List.binarySearch(empty, Nat.compare, 0);
+        let result2 = List.binarySearch(emptied, Nat.compare, 0);
         Test.expect.bool(result1 == #insertionIndex(0)).equal(true);
         Test.expect.bool(result2 == #insertionIndex(0)).equal(true)
       }
@@ -2091,7 +2091,7 @@ Test.suite(
       "found",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 5);
+        let result = List.binarySearch(list, Nat.compare, 5);
         Test.expect.bool(result == #found(2)).equal(true)
       }
     );
@@ -2099,7 +2099,7 @@ Test.suite(
       "not found",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 6);
+        let result = List.binarySearch(list, Nat.compare, 6);
         Test.expect.bool(result == #insertionIndex(3)).equal(true)
       }
     );
@@ -2107,7 +2107,7 @@ Test.suite(
       "first element",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 1);
+        let result = List.binarySearch(list, Nat.compare, 1);
         Test.expect.bool(result == #found(0)).equal(true)
       }
     );
@@ -2115,7 +2115,7 @@ Test.suite(
       "last element",
       func() {
         let list = List.fromArray<Nat>([1, 3, 5, 7, 9, 11]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 11);
+        let result = List.binarySearch(list, Nat.compare, 11);
         Test.expect.bool(result == #found(5)).equal(true)
       }
     );
@@ -2123,7 +2123,7 @@ Test.suite(
       "single element found",
       func() {
         let list = List.fromArray<Nat>([42]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 42);
+        let result = List.binarySearch(list, Nat.compare, 42);
         Test.expect.bool(result == #found(0)).equal(true)
       }
     );
@@ -2131,7 +2131,7 @@ Test.suite(
       "single element not found",
       func() {
         let list = List.fromArray<Nat>([42]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 43);
+        let result = List.binarySearch(list, Nat.compare, 43);
         Test.expect.bool(result == #insertionIndex(1)).equal(true)
       }
     );
@@ -2139,7 +2139,7 @@ Test.suite(
       "duplicates",
       func() {
         let list = List.fromArray<Nat>([1, 2, 2, 2, 3]);
-        let result = List.binarySearch<Nat>(list, Nat.compare, 2);
+        let result = List.binarySearch(list, Nat.compare, 2);
         let ok = switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }

--- a/test/Map.test.mo
+++ b/test/Map.test.mo
@@ -207,7 +207,7 @@ run(
         "filter",
         do {
           let input = Map.empty<Nat, Text>();
-          let output = input.filter<Nat, Text>(
+          let output = input.filter(
             func(_, _) {
               Runtime.trap("test failed")
             }
@@ -586,7 +586,7 @@ run(
       test(
         "from iterator",
         do {
-          let map = Map.fromIter<Nat, Text>(Iter.fromArray<(Nat, Text)>([(0, "0")]), Nat.compare);
+          let map = Map.fromIter(Iter.fromArray([(0, "0")]), Nat.compare);
           assert (Map.get(map, Nat.compare, 0) == ?"0");
           assert (Map.equal(map, Map.singleton<Nat, Text>(0, "0"), Nat.compare, Text.equal));
           Map.size(map)
@@ -612,7 +612,7 @@ run(
         "filter",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filter<Nat, Text>(
+          let output = Map.filter(
             input,
             Nat.compare,
             func(key, value) {
@@ -630,7 +630,7 @@ run(
         "map",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.map<Nat, Text, Int>(
+          let output = Map.map(
             input,
             func(key, value) {
               assert (key == 0);
@@ -647,7 +647,7 @@ run(
         "filter map",
         do {
           let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filterMap<Nat, Text, Int>(
+          let output = Map.filterMap(
             input,
             Nat.compare,
             func(key, value) {
@@ -1014,8 +1014,8 @@ run(
       test(
         "from iterator",
         do {
-          let array = Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) });
-          let map = Map.fromIter<Nat, Text>(Iter.fromArray(array), Nat.compare);
+          let array = Array.tabulate(smallSize, func(index) { (index, Nat.toText(index)) });
+          let map = Map.fromIter(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
             assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
           };
@@ -1045,7 +1045,7 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = Map.filter<Nat, Text>(
+          let output = Map.filter(
             input,
             Nat.compare,
             func(key, value) {
@@ -1070,7 +1070,7 @@ run(
         "map",
         do {
           let input = smallMap();
-          let output = Map.map<Nat, Text, Int>(
+          let output = Map.map(
             input,
             func(key, value) {
               +key
@@ -1087,7 +1087,7 @@ run(
         "filter map",
         do {
           let input = smallMap();
-          let output = Map.filterMap<Nat, Text, Int>(
+          let output = Map.filterMap(
             input,
             Nat.compare,
             func(key, value) {
@@ -1532,7 +1532,7 @@ run(
           for (index in Nat.range(0, numberOfEntries)) {
             pureMap := PureMap.add(pureMap, Nat.compare, index, Nat.toText(index))
           };
-          let map = Map.fromPure<Nat, Text>(pureMap, Nat.compare);
+          let map = Map.fromPure(pureMap, Nat.compare);
           for (index in Nat.range(0, numberOfEntries)) {
             assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
           };
@@ -1576,7 +1576,7 @@ Test.suite(
           Map.add(map, Nat.compare, i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
             let actual = Iter.toArray(Map.entriesFrom(map, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(Map.entries(map), func(k, v) = k < j));
+            let expected = Iter.toArray(Iter.dropWhile(Map.entries(map), func(k, v) = k < j));
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }
@@ -1616,7 +1616,7 @@ Test.suite(
           Map.add(map, Nat.compare, i, Nat.toText(i));
           for (j in Nat.range(0, i + 2)) {
             let actual = Iter.toArray(Map.reverseEntriesFrom(map, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat, Text)>(Map.reverseEntries(map), func(k, v) = k > j));
+            let expected = Iter.toArray(Iter.dropWhile(Map.reverseEntries(map), func(k, v) = k > j));
             Test.expect.array(actual, Tuple2.makeToText(Nat.toText, Text.toText), Tuple2.makeEqual(Nat.equal, Text.equal)).equal(expected)
           }
         }

--- a/test/PriorityQueue.test.mo
+++ b/test/PriorityQueue.test.mo
@@ -179,7 +179,7 @@ func testPushAndPeekThenPopArray<T>(
   };
 
   expect.array<T>(
-    VarArray.map<?T, T>(
+    VarArray.map(
       extractedValues,
       func(optTop) {
         switch (optTop) {
@@ -241,7 +241,7 @@ suite(
           PriorityQueue.push(priorityQueue, compareValue, (tag, v))
         };
 
-        let extractedTags = Array.tabulate<Nat>(
+        let extractedTags = Array.tabulate(
           values.size(),
           func _ {
             let ?(tag, v) = PriorityQueue.pop(priorityQueue, compareValue) else Runtime.trap("priorityQueue unexpectedly empty");
@@ -277,14 +277,14 @@ func opToText<T>(op : PriorityQueueUpdateOperation<T>, toText : T -> Text) : Tex
 func opsToText<T>(ops : [PriorityQueueUpdateOperation<T>], toText : T -> Text) : Text {
   let cap : Nat = 10;
   let n = ops.size();
-  let shown = Array.tabulate<Text>(
+  let shown = Array.tabulate(
     Nat.min(ops.size(), cap),
     func i {
-      opToText<T>(ops[i], toText)
+      opToText(ops[i], toText)
     }
   );
 
-  let body = Array.toText<Text>(shown, func x = x); // join with ", "
+  let body = Array.toText(shown, func x = x); // join with ", "
 
   let ?stripped = Text.stripEnd(body, #char ']');
   stripped # (if (n > cap) "...]" else "]")
@@ -528,7 +528,7 @@ suite(
     test(
       "empty iterator",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>(Iter.empty<Nat>(), Nat.compare);
+        let pq = PriorityQueue.fromIter(Iter.empty<Nat>(), Nat.compare);
         expect.bool(PriorityQueue.isEmpty(pq)).equal(true);
         expect.nat(PriorityQueue.size(pq)).equal(0)
       }
@@ -537,7 +537,7 @@ suite(
     test(
       "single element",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([42].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([42].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(1);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?42)
       }
@@ -546,7 +546,7 @@ suite(
     test(
       "multiple elements",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?10)
       }
@@ -555,7 +555,7 @@ suite(
     test(
       "preserves all elements in priority order",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5, 9, 2, 6].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([3, 1, 4, 1, 5, 9, 2, 6].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(8);
         expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?9);
         expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?6);
@@ -572,7 +572,7 @@ suite(
     test(
       "duplicates",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([5, 5, 5].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([5, 5, 5].values(), Nat.compare);
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
         expect.option<Nat>(PriorityQueue.pop(pq, Nat.compare), Nat.toText, Nat.equal).equal(?5);
@@ -598,7 +598,7 @@ suite(
     test(
       "deep copy preserves elements",
       func() {
-        let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let original = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         let copy = PriorityQueue.clone(original);
         expect.nat(PriorityQueue.size(copy)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(copy), Nat.toText, Nat.equal).equal(?10)
@@ -608,7 +608,7 @@ suite(
     test(
       "mutating the copy does not affect the original",
       func() {
-        let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let original = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         let copy = PriorityQueue.clone(original);
         ignore PriorityQueue.pop(copy, Nat.compare);
         ignore PriorityQueue.pop(copy, Nat.compare);
@@ -621,7 +621,7 @@ suite(
     test(
       "mutating the original does not affect the copy",
       func() {
-        let original = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let original = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         let copy = PriorityQueue.clone(original);
         PriorityQueue.clear(original);
         expect.bool(PriorityQueue.isEmpty(original)).equal(true);
@@ -656,7 +656,7 @@ suite(
     test(
       "yields elements in descending priority order",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([10, 5, 3])
       }
@@ -665,7 +665,7 @@ suite(
     test(
       "does not modify the original queue",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([5, 10, 3].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([5, 10, 3].values(), Nat.compare);
         ignore Iter.toArray(PriorityQueue.values(pq, Nat.compare));
         expect.nat(PriorityQueue.size(pq)).equal(3);
         expect.option<Nat>(PriorityQueue.peek(pq), Nat.toText, Nat.equal).equal(?10)
@@ -675,7 +675,7 @@ suite(
     test(
       "with duplicates",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([3, 1, 4, 1, 5].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([3, 1, 4, 1, 5].values(), Nat.compare);
         let vals = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
         expect.array<Nat>(vals, Nat.toText, Nat.equal).equal([5, 4, 3, 1, 1])
       }
@@ -684,7 +684,7 @@ suite(
     test(
       "can be called multiple times",
       func() {
-        let pq = PriorityQueue.fromIter<Nat>([2, 7, 1].values(), Nat.compare);
+        let pq = PriorityQueue.fromIter([2, 7, 1].values(), Nat.compare);
         let vals1 = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
         let vals2 = Iter.toArray(PriorityQueue.values(pq, Nat.compare));
         expect.array<Nat>(vals1, Nat.toText, Nat.equal).equal([7, 2, 1]);

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -341,7 +341,7 @@ suite(
       "map",
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3].vals());
-        let mapped = Queue.map<Nat, Text>(queue, Nat.toText);
+        let mapped = Queue.map(queue, Nat.toText);
         assert Iter.toArray(Queue.values(mapped)) == ["1", "2", "3"]
       }
     );
@@ -350,7 +350,7 @@ suite(
       "filter",
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
-        let filtered = Queue.filter<Nat>(queue, func n = n % 2 == 0);
+        let filtered = Queue.filter(queue, func n = n % 2 == 0);
         assert Iter.toArray(Queue.values(filtered)) == [2, 4]
       }
     );
@@ -359,7 +359,7 @@ suite(
       "filter map",
       func() {
         let queue = Queue.fromIter<Nat>([1, 2, 3, 4].vals());
-        let result = Queue.filterMap<Nat, Text>(
+        let result = Queue.filterMap(
           queue,
           func n = if (n % 2 == 0) ?Nat.toText(n) else null
         );

--- a/test/Random.async.test.mo
+++ b/test/Random.async.test.mo
@@ -288,7 +288,7 @@ await suite(
       func() : async () {
         let state = Random.emptyState();
         func sequentialGenerator() : async* Blob {
-          let bytes = Array.tabulate<Nat8>(16, func(i) { Nat8.fromNat(i) });
+          let bytes = Array.tabulate(16, func(i) { Nat8.fromNat(i) });
           Blob.fromArray(bytes)
         };
         let random = Random.AsyncRandom(state, sequentialGenerator);

--- a/test/Set.test.mo
+++ b/test/Set.test.mo
@@ -169,7 +169,7 @@ run(
         "filter",
         do {
           let input = Set.empty<Nat>();
-          let output = input.filter<Nat>(
+          let output = input.filter(
             func(_) {
               Runtime.trap("test failed")
             }
@@ -279,7 +279,7 @@ run(
       test(
         "is sub-set",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray<Nat>([]), Nat.compare);
           let set2 = Set.clone(set1);
           set1.isSubset(set2)
         },
@@ -288,7 +288,7 @@ run(
       test(
         "join",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray<Nat>([]), Nat.compare);
           let set2 = Set.clone(set1);
           let set3 = Set.clone(set2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]));
@@ -525,7 +525,7 @@ run(
       test(
         "from iterator",
         do {
-          let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([0]), Nat.compare);
+          let set = Set.fromIter(Iter.fromArray([0]), Nat.compare);
           assert (Set.contains(set, Nat.compare, 0));
           assert (Set.equal(set, Set.singleton<Nat>(0), Nat.compare));
           Set.size(set)
@@ -550,7 +550,7 @@ run(
         "filter",
         do {
           let input = Set.singleton<Nat>(0);
-          let output = Set.filter<Nat>(
+          let output = Set.filter(
             input,
             Nat.compare,
             func(number) {
@@ -567,7 +567,7 @@ run(
         "map",
         do {
           let input = Set.singleton<Nat>(0);
-          let output = Set.map<Nat, Int>(
+          let output = Set.map(
             input,
             Int.compare,
             func(number) {
@@ -584,7 +584,7 @@ run(
         "filter map",
         do {
           let input = Set.singleton<Nat>(0);
-          let output = Set.filterMap<Nat, Int>(
+          let output = Set.filterMap(
             input,
             Int.compare,
             func(number) {
@@ -737,7 +737,7 @@ run(
         "is strict sub-set",
         do {
           let set1 = Set.singleton<Nat>(1);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([0, 1, 2]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([0, 1, 2]), Nat.compare);
           Set.isSubset(set1, set2, Nat.compare)
         },
         M.equals(T.bool(true))
@@ -1057,8 +1057,8 @@ run(
       test(
         "from iterator",
         do {
-          let array = Array.tabulate<Nat>(smallSize, func(index) { index });
-          let set = Set.fromIter<Nat>(Iter.fromArray(array), Nat.compare);
+          let array = Array.tabulate(smallSize, func(index) { index });
+          let set = Set.fromIter(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
             assert (Set.contains(set, Nat.compare, index))
           };
@@ -1087,7 +1087,7 @@ run(
         "filter",
         do {
           let input = smallSet();
-          let output = Set.filter<Nat>(
+          let output = Set.filter(
             input,
             Nat.compare,
             func(number) {
@@ -1110,7 +1110,7 @@ run(
         "map",
         do {
           let input = smallSet();
-          let output = Set.map<Nat, Int>(
+          let output = Set.map(
             input,
             Int.compare,
             func(number) {
@@ -1128,7 +1128,7 @@ run(
         "filter map",
         do {
           let input = smallSet();
-          let output = Set.filterMap<Nat, Int>(
+          let output = Set.filterMap(
             input,
             Int.compare,
             func(number) {
@@ -1258,8 +1258,8 @@ run(
       test(
         "union",
         do {
-          let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
-          let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
+          let set1 = Set.map(smallSet(), Int.compare, func(number) { +number });
+          let set2 = Set.map(smallSet(), Int.compare, func(number) { -number });
           let union = Set.union(set1, set2, Int.compare);
           Iter.toArray(Set.values(union))
         },
@@ -1278,9 +1278,9 @@ run(
       test(
         "intersection",
         do {
-          let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
+          let set1 = Set.map(smallSet(), Int.compare, func(number) { +number });
           Set.add(set1, Int.compare, -1);
-          let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
+          let set2 = Set.map(smallSet(), Int.compare, func(number) { -number });
           Set.add(set2, Int.compare, 1);
           let intersection = Set.intersection(set1, set2, Int.compare);
           Iter.toArray(Set.values(intersection))
@@ -1313,9 +1313,9 @@ run(
       test(
         "join",
         do {
-          let set1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
-          let set2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
-          let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
+          let set1 = Set.map(smallSet(), Int.compare, func(number) { +number });
+          let set2 = Set.map(smallSet(), Int.compare, func(number) { -number });
+          let set3 = Set.fromIter(Iter.fromArray([-1, 1]), Int.compare);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
           Iter.toArray(Set.values(combined))
         },
@@ -1334,9 +1334,9 @@ run(
       test(
         "flatten",
         do {
-          let subSet1 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { +number });
-          let subSet2 = Set.map<Nat, Int>(smallSet(), Int.compare, func(number) { -number });
-          let subSet3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
+          let subSet1 = Set.map(smallSet(), Int.compare, func(number) { +number });
+          let subSet2 = Set.map(smallSet(), Int.compare, func(number) { -number });
+          let subSet3 = Set.fromIter(Iter.fromArray([-1, 1]), Int.compare);
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
           let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
           let combined = Set.flatten(setOfSets, Int.compare);
@@ -1558,7 +1558,7 @@ run(
         "union first non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let union = Set.union(set1, set2, Nat.compare);
           Iter.toArray(Set.values(union))
         },
@@ -1567,7 +1567,7 @@ run(
       test(
         "union first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let union = Set.union(set1, set2, Nat.compare);
           Iter.toArray(Set.values(union))
@@ -1577,8 +1577,8 @@ run(
       test(
         "union both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           let union = Set.union(set1, set2, Nat.compare);
           Set.size(union)
         },
@@ -1587,8 +1587,8 @@ run(
       test(
         "union both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           let union = Set.union(set1, set2, Nat.compare);
           Set.size(union)
         },
@@ -1607,7 +1607,7 @@ run(
       test(
         "intersect first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let intersection = Set.intersection(set1, set2, Nat.compare);
           Set.size(intersection)
@@ -1618,7 +1618,7 @@ run(
         "intersect second non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let intersection = Set.intersection(set1, set2, Nat.compare);
           Set.size(intersection)
         },
@@ -1627,8 +1627,8 @@ run(
       test(
         "intersect both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           let intersection = Set.intersection(set1, set2, Nat.compare);
           Set.size(intersection)
         },
@@ -1637,8 +1637,8 @@ run(
       test(
         "intersect both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           let intersection = Set.intersection(set1, set2, Nat.compare);
           Iter.toArray(Set.values(intersection))
         },
@@ -1657,7 +1657,7 @@ run(
       test(
         "diff first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           let difference = Set.difference(set1, set2, Nat.compare);
           Iter.toArray(Set.values(difference))
@@ -1668,7 +1668,7 @@ run(
         "diff second non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let difference = Set.difference(set1, set2, Nat.compare);
           Set.size(difference)
         },
@@ -1677,8 +1677,8 @@ run(
       test(
         "diff both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           let difference = Set.difference(set1, set2, Nat.compare);
           Iter.toArray(Set.values(difference))
         },
@@ -1687,8 +1687,8 @@ run(
       test(
         "diff both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           let difference = Set.difference(set1, set2, Nat.compare);
           Iter.toArray(Set.values(difference))
         },
@@ -1707,7 +1707,7 @@ run(
       test(
         "addAll first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           Set.addAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
@@ -1718,7 +1718,7 @@ run(
         "addAll second non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           Set.addAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
         },
@@ -1727,8 +1727,8 @@ run(
       test(
         "addAll both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           Set.addAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
         },
@@ -1737,8 +1737,8 @@ run(
       test(
         "addAll both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           Set.addAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
         },
@@ -1756,7 +1756,7 @@ run(
       test(
         "retainAll all",
         do {
-          let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (not Set.retainAll<Nat>(set, Nat.compare, func(n) { true }));
           Iter.toArray(Set.values(set))
         },
@@ -1765,7 +1765,7 @@ run(
       test(
         "retainAll none",
         do {
-          let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { false }));
           Set.size(set)
         },
@@ -1774,7 +1774,7 @@ run(
       test(
         "retainAll even",
         do {
-          let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4]), Nat.compare);
+          let set = Set.fromIter(Iter.fromArray([1, 2, 3, 4]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n % 2 == 0 }));
           Iter.toArray(Set.values(set))
         },
@@ -1783,7 +1783,7 @@ run(
       test(
         "retainAll predicate",
         do {
-          let set = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3, 4, 5]), Nat.compare);
+          let set = Set.fromIter(Iter.fromArray([1, 2, 3, 4, 5]), Nat.compare);
           assert (Set.retainAll<Nat>(set, Nat.compare, func(n) { n > 2 and n < 5 }));
           Iter.toArray(Set.values(set))
         },
@@ -1802,7 +1802,7 @@ run(
       test(
         "deleteAll first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not Set.deleteAll(set1, Nat.compare, Set.values(set2)));
           Iter.toArray(Set.values(set1))
@@ -1812,8 +1812,8 @@ run(
       test(
         "deleteAll both non-empty equal",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (Set.deleteAll(set1, Nat.compare, Set.values(set2)));
           Set.size(set1)
         },
@@ -1823,7 +1823,7 @@ run(
         "deleteAll second non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (not (Set.deleteAll(set1, Nat.compare, Set.values(set2))));
           Set.size(set1)
         },
@@ -1832,8 +1832,8 @@ run(
       test(
         "deleteAll both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           assert (not (Set.deleteAll(set1, Nat.compare, Set.values(set2))));
           Iter.toArray(Set.values(set1))
         },
@@ -1842,8 +1842,8 @@ run(
       test(
         "deleteAll both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           assert Set.deleteAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
         },
@@ -1853,7 +1853,7 @@ run(
       test(
         "insertAll first non-empty",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           let set2 = Set.empty<Nat>();
           assert (not Set.insertAll(set1, Nat.compare, Set.values(set2)));
           Iter.toArray(Set.values(set1))
@@ -1863,8 +1863,8 @@ run(
       test(
         "insertAll both non-empty equal",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (not Set.insertAll(set1, Nat.compare, Set.values(set2)));
           Set.size(set1)
         },
@@ -1874,7 +1874,7 @@ run(
         "insertAll second non-empty",
         do {
           let set1 = Set.empty<Nat>();
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
           assert (Set.insertAll(set1, Nat.compare, Set.values(set2)));
           Set.size(set1)
         },
@@ -1883,8 +1883,8 @@ run(
       test(
         "insertAll both non-empty disjoint",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([4, 5, 6]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([4, 5, 6]), Nat.compare);
           assert (Set.insertAll(set1, Nat.compare, Set.values(set2)));
           Iter.toArray(Set.values(set1))
         },
@@ -1893,8 +1893,8 @@ run(
       test(
         "insertAll both non-empty overlapping",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([1, 2, 3]), Nat.compare);
-          let set2 = Set.fromIter<Nat>(Iter.fromArray<Nat>([2, 3, 4]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray([1, 2, 3]), Nat.compare);
+          let set2 = Set.fromIter(Iter.fromArray([2, 3, 4]), Nat.compare);
           assert Set.insertAll(set1, Nat.compare, Set.values(set2));
           Iter.toArray(Set.values(set1))
         },
@@ -1935,7 +1935,7 @@ Test.suite(
           Set.add(set, Nat.compare, i);
           for (j in Nat.range(0, i + 2)) {
             let actual = Iter.toArray(Set.valuesFrom(set, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(Set.values(set), func(k) = k < j));
+            let expected = Iter.toArray(Iter.dropWhile(Set.values(set), func(k) = k < j));
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }
@@ -1975,7 +1975,7 @@ Test.suite(
           Set.add(set, Nat.compare, i);
           for (j in Nat.range(0, i + 2)) {
             let actual = Iter.toArray(Set.reverseValuesFrom(set, Nat.compare, j));
-            let expected = Iter.toArray(Iter.dropWhile<(Nat)>(Set.reverseValues(set), func(k) = k > j));
+            let expected = Iter.toArray(Iter.dropWhile(Set.reverseValues(set), func(k) = k > j));
             Test.expect.array(actual, Nat.toText, Nat.equal).equal(expected)
           }
         }

--- a/test/Stack.test.mo
+++ b/test/Stack.test.mo
@@ -177,7 +177,7 @@ suite(
       "filter keeps matching elements",
       func() {
         let s = Stack.fromIter<Nat>([1, 2, 3, 4].vals());
-        let evens = Stack.filter<Nat>(s, func(x) { x % 2 == 0 });
+        let evens = Stack.filter(s, func(x) { x % 2 == 0 });
         expect.array(Iter.toArray(Stack.values(evens)), Nat.toText, Nat.equal).equal([4, 2])
       }
     );
@@ -356,7 +356,7 @@ suite(
       func() {
         let original = Stack.tabulate<Nat>(largeSize, func(i) { i });
         let doubled = Stack.map<Nat, Nat>(original, func(x) { x * 2 });
-        let filtered = Stack.filter<Nat>(doubled, func(x) { x % 4 == 0 });
+        let filtered = Stack.filter(doubled, func(x) { x % 4 == 0 });
         let mapped = Stack.filterMap<Nat, Nat>(
           filtered,
           func(x) {

--- a/test/Text.test.mo
+++ b/test/Text.test.mo
@@ -140,7 +140,7 @@ run(
         M.equals(iterT(['a', 'b', 'c']))
       ),
       do {
-        let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
+        let a = Array.tabulate(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-2",
           Text.toIter(Text.join(Array.map(a, Char.toText).vals(), "")),
@@ -171,7 +171,7 @@ run(
         M.equals(T.text "abc")
       ),
       do {
-        let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
+        let a = Array.tabulate(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "fromIter-3",
           Text.fromIter(a.vals()),
@@ -278,7 +278,7 @@ run(
         M.equals(T.text "abbcccdddd")
       ),
       do {
-        let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
+        let a = Array.tabulate(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
           Text.join(Array.map(a, Char.toText).vals(), ""),
@@ -319,7 +319,7 @@ run(
         M.equals(T.text "a,bb,ccc,dddd")
       ),
       do {
-        let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
+        let a = Array.tabulate(1000, func i = Char.fromNat32(65 +% Nat32.fromIntWrap(i % 26)));
         test(
           "join-3",
           Text.join(Array.map(a, Char.toText).vals(), ""),
@@ -375,7 +375,7 @@ run(
         M.equals(textIterT(["a", "", "", "ab", "", "abc", ""]))
       ),
       do {
-        let a = Array.tabulate<Text>(1000, func _ = "abc");
+        let a = Array.tabulate(1000, func _ = "abc");
         let t = Text.join(a.vals(), ";");
         test(
           "split-char-large",
@@ -384,7 +384,7 @@ run(
         )
       },
       do {
-        let a = Array.tabulate<Text>(100000, func _ = "abc");
+        let a = Array.tabulate(100000, func _ = "abc");
         let t = Text.join(a.vals(), ";");
         test(
           "split-char-very-large",
@@ -433,7 +433,7 @@ do {
           M.equals(textIterT(["a", "", "", "ab", "", "abc", ""]))
         ),
         do {
-          let a = Array.tabulate<Text>(1000, func _ = "abc");
+          let a = Array.tabulate(1000, func _ = "abc");
           let t = Text.join(a.vals(), ";");
           test(
             "split-pred-large",
@@ -442,7 +442,7 @@ do {
           )
         },
         do {
-          let a = Array.tabulate<Text>(10000, func _ = "abc");
+          let a = Array.tabulate(10000, func _ = "abc");
           let t = Text.join(a.vals(), ";");
           test(
             "split-pred-very-large",
@@ -492,7 +492,7 @@ do {
           M.equals(textIterT(["a", "", "", "ab", "", "abc", ""]))
         ),
         do {
-          let a = Array.tabulate<Text>(1000, func _ = "abc");
+          let a = Array.tabulate(1000, func _ = "abc");
           let t = Text.join(a.vals(), "PAT");
           test(
             "split-pat-large",
@@ -501,7 +501,7 @@ do {
           )
         },
         do {
-          let a = Array.tabulate<Text>(10000, func _ = "abc");
+          let a = Array.tabulate(10000, func _ = "abc");
           let t = Text.join(a.vals(), "PAT");
           test(
             "split-pat-very-large",
@@ -549,7 +549,7 @@ run(
         M.equals(textIterT(["a", "ab", "abc"]))
       ),
       do {
-        let a = Array.tabulate<Text>(1000, func _ = "abc");
+        let a = Array.tabulate(1000, func _ = "abc");
         let t = Text.join(a.vals(), ";;");
         test(
           "tokens-char-large",
@@ -558,7 +558,7 @@ run(
         )
       },
       do {
-        let a = Array.tabulate<Text>(100000, func _ = "abc");
+        let a = Array.tabulate(100000, func _ = "abc");
         let t = Text.join(a.vals(), ";;");
         test(
           "tokens-char-very-large",

--- a/test/VarArray.test.mo
+++ b/test/VarArray.test.mo
@@ -32,7 +32,7 @@ func varArrayTestable<A>(testableA : T.Testable<A>) : T.Testable<[var A]> {
 };
 
 func varArray<A>(testableA : T.Testable<A>, xs : [var A]) : T.TestableItem<[var A]> {
-  let testableAs = varArrayTestable<A>(testableA);
+  let testableAs = varArrayTestable(testableA);
   {
     item = xs;
     display = testableAs.display;
@@ -789,7 +789,7 @@ let suite = Suite.suite(
     Suite.test(
       "binarySearch duplicates",
       do {
-        let result = VarArray.binarySearch<Nat>([var 1, 2, 2, 2, 3], Nat.compare, 2);
+        let result = VarArray.binarySearch([var 1, 2, 2, 2, 3], Nat.compare, 2);
         switch result {
           case (#found index) { index >= 1 and index <= 3 };
           case _ { false }

--- a/test/pure/List.test.mo
+++ b/test/pure/List.test.mo
@@ -50,8 +50,8 @@ func opnatEq(a : ?Nat, b : ?Nat) : Bool {
 
 // ## Construction
 let l1 = List.empty<X>();
-let l2 = List.pushFront<X>(l1, 2);
-let l3 = List.pushFront<X>(l2, 3);
+let l2 = List.pushFront(l1, 2);
+let l3 = List.pushFront(l2, 3);
 
 // ## Projection -- use nth
 assert (opnatEq(List.get<X>(l3, 0), ?3));
@@ -72,11 +72,11 @@ assert (opnatEq(List.get<X>(l3, 2), null));
    */
 
 // ## Deconstruction
-let (a1, _t1) = List.popFront<X>(l3);
+let (a1, _t1) = List.popFront(l3);
 assert (opnatEq(a1, ?3));
-let (a2, _t2) = List.popFront<X>(l2);
+let (a2, _t2) = List.popFront(l2);
 assert (opnatEq(a2, ?2));
-let (a3, t3) = List.popFront<X>(l1);
+let (a3, t3) = List.popFront(l1);
 assert (opnatEq(a3, null));
 assert (List.isEmpty<X>(t3));
 
@@ -91,7 +91,7 @@ do {
   let expected : List.List<Nat> = ?(1, ?(2, ?(3, null)));
   // [[1, 2], [3]]
   let nested : List.List<List.List<Nat>> = ?(?(1, ?(2, null)), ?(?(3, null), null));
-  let actual = List.flatten<Nat>(nested);
+  let actual = List.flatten(nested);
 
   assert List.equal<Nat>(expected, actual, func(x1, x2) = x1 == x2);
 
@@ -102,7 +102,7 @@ do {
 
   let expected : List.List<Nat> = ?(1, ?(2, ?(3, List.empty<Nat>())));
   let array = [1, 2, 3];
-  let actual = List.fromArray<Nat>(array);
+  let actual = List.fromArray(array);
 
   assert List.equal<Nat>(expected, actual, func(x1, x2) = x1 == x2)
 };
@@ -112,7 +112,7 @@ do {
 
   let expected : List.List<Nat> = ?(1, ?(2, ?(3, List.empty<Nat>())));
   let array = [var 1, 2, 3];
-  let actual = List.fromVarArray<Nat>(array);
+  let actual = List.fromVarArray(array);
 
   assert List.equal<Nat>(expected, actual, func(x1, x2) = x1 == x2)
 };
@@ -122,7 +122,7 @@ do {
 
   let expected = [1, 2, 3];
   let list : List.List<Nat> = ?(1, ?(2, ?(3, List.empty<Nat>())));
-  let actual = List.toArray<Nat>(list);
+  let actual = List.toArray(list);
 
   assert (actual.size() == expected.size());
 
@@ -149,7 +149,7 @@ do {
   Debug.print("  values");
 
   let list : List.List<Nat> = ?(1, ?(2, ?(3, List.empty<Nat>())));
-  let vals = List.values<Nat>(list);
+  let vals = List.values(list);
   let actual = [var 0, 0, 0];
   let expected = [1, 2, 3];
 
@@ -168,7 +168,7 @@ do {
   Debug.print("  enumerate");
 
   let list : List.List<Nat> = ?(1, ?(2, ?(3, List.empty<Nat>())));
-  let items = List.enumerate<Nat>(list);
+  let items = List.enumerate(list);
   let actual = [var 0, 0, 0];
   let expected = [1, 2, 3];
 
@@ -1595,7 +1595,7 @@ let fromIter = suite(
     ),
     test(
       "large",
-      List.fromIter<Nat>(Nat.range(0, 100_000)) |> List.size _,
+      List.fromIter(Nat.range(0, 100_000)) |> List.size _,
       M.equals(T.nat 100_000)
     )
   ]
@@ -1663,7 +1663,7 @@ Test.suite(
   "join",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputIter = Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x));
+      let inputIter = Iter.map(input.vals(), func x = List.fromArray(x));
       let result = List.join(inputIter);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };
@@ -1677,7 +1677,7 @@ Test.suite(
   "flatten",
   func() {
     func t(input : [[Nat]], expected : [Nat]) : () -> () = func() {
-      let inputList = List.fromIter(Iter.map<[Nat], List<Nat>>(input.vals(), func x = List.fromArray(x)));
+      let inputList = List.fromIter(Iter.map(input.vals(), func x = List.fromArray(x)));
       let result = List.flatten(inputList);
       Test.expect.array(List.toArray(result), Nat.toText, Nat.equal).equal(expected)
     };

--- a/test/pure/Map.prop.test.mo
+++ b/test/pure/Map.prop.test.mo
@@ -409,7 +409,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "max through fold",
               func(m) {
-                let expected = Map.foldLeft<Nat, Text, ?(Nat, Text)>(m, null : ?(Nat, Text), func(_, k, v) = ?(k, v));
+                let expected = Map.foldLeft(m, null : ?(Nat, Text), func(_, k, v) = ?(k, v));
                 M.equals(T.optional(entryTestable, expected)).matches(Map.maxEntry(m))
               }
             ),
@@ -417,7 +417,7 @@ func run_all_props(range : (Nat, Nat), size : Nat, map_samples : Nat, query_samp
             prop(
               "min through fold",
               func(m) {
-                let expected = Map.foldRight<Nat, Text, ?(Nat, Text)>(m, null : ?(Nat, Text), func(k, v, _) = ?(k, v));
+                let expected = Map.foldRight(m, null : ?(Nat, Text), func(k, v, _) = ?(k, v));
                 M.equals(T.optional(entryTestable, expected)).matches(Map.minEntry(m))
               }
             )

--- a/test/pure/Map.test.mo
+++ b/test/pure/Map.test.mo
@@ -220,7 +220,7 @@ run(
         "filter",
         do {
           let input = Map.empty<Nat, Text>();
-          let output = Map.filter<Nat, Text>(
+          let output = Map.filter(
             input,
             Nat.compare,
             func(_, _) {
@@ -408,7 +408,7 @@ run(
       test(
         "for each",
         do {
-          let map = Map.singleton<Nat, Text>(0, "0");
+          let map = Map.singleton(0, "0");
           Map.forEach<Nat, Text>(
             map,
             func(key, value) {
@@ -423,8 +423,8 @@ run(
       test(
         "filter",
         do {
-          let input = Map.singleton<Nat, Text>(0, "0");
-          let output = Map.filter<Nat, Text>(
+          let input = Map.singleton(0, "0");
+          let output = Map.filter(
             input,
             Nat.compare,
             func(key, value) {
@@ -451,8 +451,8 @@ run(
       test(
         "compare less key",
         do {
-          let map1 = Map.singleton<Nat, Text>(0, "0");
-          let map2 = Map.singleton<Nat, Text>(1, "1");
+          let map1 = Map.singleton(0, "0");
+          let map2 = Map.singleton(1, "1");
           assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
           true
         },
@@ -461,8 +461,8 @@ run(
       test(
         "compare less value",
         do {
-          let map1 = Map.singleton<Nat, Text>(0, "0");
-          let map2 = Map.singleton<Nat, Text>(0, "Zero");
+          let map1 = Map.singleton(0, "0");
+          let map2 = Map.singleton(0, "Zero");
           assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #less);
           true
         },
@@ -471,8 +471,8 @@ run(
       test(
         "compare equal",
         do {
-          let map1 = Map.singleton<Nat, Text>(0, "0");
-          let map2 = Map.singleton<Nat, Text>(0, "0");
+          let map1 = Map.singleton(0, "0");
+          let map2 = Map.singleton(0, "0");
           assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #equal);
           true
         },
@@ -481,8 +481,8 @@ run(
       test(
         "compare greater key",
         do {
-          let map1 = Map.singleton<Nat, Text>(1, "1");
-          let map2 = Map.singleton<Nat, Text>(0, "0");
+          let map1 = Map.singleton(1, "1");
+          let map2 = Map.singleton(0, "0");
           assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
           true
         },
@@ -491,8 +491,8 @@ run(
       test(
         "compare greater value",
         do {
-          let map1 = Map.singleton<Nat, Text>(0, "Zero");
-          let map2 = Map.singleton<Nat, Text>(0, "0");
+          let map1 = Map.singleton(0, "Zero");
+          let map2 = Map.singleton(0, "0");
           assert (Map.compare(map1, map2, Nat.compare, Text.compare) == #greater);
           true
         },
@@ -656,7 +656,7 @@ func rebalanceTests(buildTestMap : () -> Map.Map<Nat, Text>) : [Suite.Suite] = [
     "filter",
     do {
       let input = buildTestMap();
-      let output = Map.filter<Nat, Text>(
+      let output = Map.filter(
         input,
         Nat.compare,
         func(key, value) {
@@ -956,8 +956,8 @@ run(
       test(
         "from iterator",
         do {
-          let array = Array.tabulate<(Nat, Text)>(smallSize, func(index) { (index, Nat.toText(index)) });
-          let map = Map.fromIter<Nat, Text>(Iter.fromArray(array), Nat.compare);
+          let array = Array.tabulate(smallSize, func(index) { (index, Nat.toText(index)) });
+          let map = Map.fromIter(Iter.fromArray(array), Nat.compare);
           for (index in Nat.range(0, smallSize)) {
             assert (Map.get(map, Nat.compare, index) == ?Nat.toText(index))
           };
@@ -987,7 +987,7 @@ run(
         "filter",
         do {
           let input = smallMap();
-          let output = Map.filter<Nat, Text>(
+          let output = Map.filter(
             input,
             Nat.compare,
             func(key, value) {
@@ -1012,7 +1012,7 @@ run(
         "map",
         do {
           let input = smallMap();
-          let output = Map.map<Nat, Text, Int>(
+          let output = Map.map(
             input,
             func(key, value) {
               +key
@@ -1029,7 +1029,7 @@ run(
         "filter map",
         do {
           let input = smallMap();
-          let output = Map.filterMap<Nat, Text, Int>(
+          let output = Map.filterMap(
             input,
             Nat.compare,
             func(key, value) {

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -590,7 +590,7 @@ suite(
     test(
       "single element",
       func() {
-        let queue = Queue.fromArray<Nat>([42]);
+        let queue = Queue.fromArray([42]);
         assert Queue.size(queue) == 1;
         assert Queue.peekFront(queue) == ?42;
         assert Queue.peekBack(queue) == ?42
@@ -600,7 +600,7 @@ suite(
     test(
       "multiple elements",
       func() {
-        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        let queue = Queue.fromArray([1, 2, 3]);
         assert Queue.size(queue) == 3;
         assert Queue.peekFront(queue) == ?1;
         assert Queue.peekBack(queue) == ?3;
@@ -642,7 +642,7 @@ suite(
     test(
       "single element",
       func() {
-        let queue = Queue.singleton<Nat>(42);
+        let queue = Queue.singleton(42);
         let array = Queue.toArray(queue);
         assert array == [42]
       }
@@ -651,7 +651,7 @@ suite(
     test(
       "multiple elements",
       func() {
-        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        let queue = Queue.fromArray([1, 2, 3]);
         let array = Queue.toArray(queue);
         assert array == [1, 2, 3]
       }
@@ -661,7 +661,7 @@ suite(
       "round trip",
       func() {
         let original = [1, 2, 3, 4, 5];
-        let queue = Queue.fromArray<Nat>(original);
+        let queue = Queue.fromArray(original);
         let result = Queue.toArray(queue);
         assert result == original
       }

--- a/test/pure/RealTimeQueue.test.mo
+++ b/test/pure/RealTimeQueue.test.mo
@@ -613,7 +613,7 @@ suite(
       func() {
         let testFilterMap = func(testElements : [Nat]) {
           let q = Queue.fromIter(testElements.vals());
-          let mapped = Queue.filterMap<Nat, Text>(
+          let mapped = Queue.filterMap(
             q,
             func n = if (n % 2 == 0) ?Nat.toText(n) else null
           );
@@ -735,7 +735,7 @@ suite(
       func() {
         let testMap = func(testElements : [Nat]) {
           let q = Queue.fromIter(testElements.vals());
-          let mapped = Queue.map<Nat, Nat>(q, func n = n * 2);
+          let mapped = Queue.map(q, func n = n * 2);
           expect.array(
             Iter.toArray(Queue.values(mapped)),
             Nat.toText,

--- a/test/pure/Set.prop.test.mo
+++ b/test/pure/Set.prop.test.mo
@@ -219,14 +219,14 @@ func run_all_props(range : (Nat, Nat), size : Nat, set_samples : Nat, query_samp
             prop(
               "max through fold",
               func(s) {
-                let expected = Set.foldLeft<Nat, ?Nat>(s, null : ?Nat, func(_, v) = ?v);
+                let expected = Set.foldLeft(s, null : ?Nat, func(_, v) = ?v);
                 M.equals(T.optional(T.natTestable, expected)).matches(Set.max(s))
               }
             ),
             prop(
               "min through fold",
               func(s) {
-                let expected = Set.foldRight<Nat, ?Nat>(s, null : ?Nat, func(v, _) = ?v);
+                let expected = Set.foldRight(s, null : ?Nat, func(v, _) = ?v);
                 M.equals(T.optional(T.natTestable, expected)).matches(Set.min(s))
               }
             )

--- a/test/pure/Set.test.mo
+++ b/test/pure/Set.test.mo
@@ -125,7 +125,7 @@ run(
         "filter",
         do {
           let input = Set.empty<Nat>();
-          let output = Set.filter<Nat>(
+          let output = Set.filter(
             input,
             Nat.compare,
             func(_) {
@@ -174,7 +174,7 @@ run(
       test(
         "join",
         do {
-          let set1 = Set.fromIter<Nat>(Iter.fromArray<Nat>([]), Nat.compare);
+          let set1 = Set.fromIter(Iter.fromArray<Nat>([]), Nat.compare);
           let set2 = set1;
           let set3 = set2;
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
@@ -189,7 +189,7 @@ run(
           let subSet2 = subSet1;
           let subSet3 = subSet2;
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
+          let setOfSets = Set.fromIter(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
           let combined = Set.flatten(setOfSets, Nat.compare);
           Set.size(combined)
         },
@@ -259,7 +259,7 @@ run(
         "filter",
         do {
           let input = buildTestSet();
-          let output = Set.filter<Nat>(
+          let output = Set.filter(
             input,
             Nat.compare,
             func(number) {
@@ -325,8 +325,8 @@ run(
       test(
         "compare less",
         do {
-          let set1 = Set.singleton<Nat>(0);
-          let set2 = Set.singleton<Nat>(1);
+          let set1 = Set.singleton(0);
+          let set2 = Set.singleton(1);
           assert (Set.compare(set1, set2, Nat.compare) == #less);
           true
         },
@@ -335,8 +335,8 @@ run(
       test(
         "compare equal",
         do {
-          let set1 = Set.singleton<Nat>(0);
-          let set2 = Set.singleton<Nat>(0);
+          let set1 = Set.singleton(0);
+          let set2 = Set.singleton(0);
           assert (Set.compare(set1, set2, Nat.compare) == #equal);
           true
         },
@@ -345,8 +345,8 @@ run(
       test(
         "compare greater key",
         do {
-          let set1 = Set.singleton<Nat>(1);
-          let set2 = Set.singleton<Nat>(0);
+          let set1 = Set.singleton(1);
+          let set2 = Set.singleton(0);
           assert (Set.compare(set1, set2, Nat.compare) == #greater);
           true
         },
@@ -355,9 +355,9 @@ run(
       test(
         "join",
         do {
-          let set1 = Set.singleton<Nat>(0);
-          let set2 = Set.singleton<Nat>(1);
-          let set3 = Set.singleton<Nat>(2);
+          let set1 = Set.singleton(0);
+          let set2 = Set.singleton(1);
+          let set3 = Set.singleton(2);
           let combined = Set.join(Iter.fromArray([set1, set2, set3]), Nat.compare);
           Iter.toArray(Set.values(combined))
         },
@@ -371,11 +371,11 @@ run(
       test(
         "flatten",
         do {
-          let subSet1 = Set.singleton<Nat>(0);
-          let subSet2 = Set.singleton<Nat>(1);
-          let subSet3 = Set.singleton<Nat>(2);
+          let subSet1 = Set.singleton(0);
+          let subSet2 = Set.singleton(1);
+          let subSet3 = Set.singleton(2);
           let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-          let setOfSets = Set.fromIter<Set.Set<Nat>>(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
+          let setOfSets = Set.fromIter(iterator, func(first, second) { Set.compare(first, second, Nat.compare) });
           let combined = Set.flatten(setOfSets, Nat.compare);
           Iter.toArray(Set.values(combined))
         },
@@ -474,7 +474,7 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
     "filter",
     do {
       let input = buildTestSet();
-      let output = Set.filter<Nat>(
+      let output = Set.filter(
         input,
         Nat.compare,
         func(number) {
@@ -577,9 +577,9 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "join",
     do {
-      let set1 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { +number });
-      let set2 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { -number });
-      let set3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
+      let set1 = Set.map(buildTestSet(), Int.compare, func(number) { +number });
+      let set2 = Set.map(buildTestSet(), Int.compare, func(number) { -number });
+      let set3 = Set.fromIter(Iter.fromArray([-1, 1]), Int.compare);
       let combined = Set.join(Iter.fromArray([set1, set2, set3]), Int.compare);
       Iter.toArray(Set.values(combined))
     },
@@ -601,11 +601,11 @@ func rebalanceTests(buildTestSet : () -> Set.Set<Nat>) : [Suite.Suite] = [
   test(
     "flatten",
     do {
-      let subSet1 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { +number });
-      let subSet2 = Set.map<Nat, Int>(buildTestSet(), Int.compare, func(number) { -number });
-      let subSet3 = Set.fromIter(Iter.fromArray<Int>([-1, 1]), Int.compare);
+      let subSet1 = Set.map(buildTestSet(), Int.compare, func(number) { +number });
+      let subSet2 = Set.map(buildTestSet(), Int.compare, func(number) { -number });
+      let subSet3 = Set.fromIter(Iter.fromArray([-1, 1]), Int.compare);
       let iterator = Iter.fromArray([subSet1, subSet2, subSet3]);
-      let setOfSets = Set.fromIter<Set.Set<Int>>(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
+      let setOfSets = Set.fromIter(iterator, func(first, second) { Set.compare(first, second, Int.compare) });
       let combined = Set.flatten(setOfSets, Int.compare);
       Iter.toArray(Set.values(combined))
     },

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -40,6 +40,7 @@ async function main() {
 
   const virtualBaseDirectory = "motoko-base";
   motoko.usePackage("core", join(virtualBaseDirectory, "src")); // Register `mo:core`
+  motoko.setExtraFlags(["-E=M0223"]); // Treat redundant type instantiations as errors in doc snippets
 
   let skippable = true;
   const snippets: Snippet[] = (


### PR DESCRIPTION
Promote `M0223` (redundant type instantiation) from off-by-default to a hard error, in both source and doc snippets, and strip the existing violations so the wall stands.

- `mops.toml` → `[moc] args = ["-E=M0223"]` (covers all `.mo` source).
- `test/ts/validate/docs.ts` → adds the same flag so `///` snippets that ship in our public docs can't drift either.
- Mechanical autofix across source + tests + ~190 doc snippets (no behavior change).

```mo
-let array = Prim.Array_init<T>(size, self[0]);
+let array = Prim.Array_init(size, self[0]);
```