### PR TITLE
feat: un-deprecate APIs without clean replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Un-deprecate `List.get`, `Map.swap`, `Map.replace`, `Map.take`, `Set.deleteAll`, `Set.insertAll`, and the `Result.Result` type alias. These had no equivalent replacement (e.g. `List.get` returns `?T`, distinct from the trapping `List.at`) (#502).
 * Add `Array.toBlob` and `VarArray.toBlob` so `[Nat8]` and `[var Nat8]` arrays can be converted to `Blob` via dot notation, e.g. `bytes.toBlob()`. Deprecate `Blob.fromArray`, `Blob.fromVarArray`, and `VarArray.fromIter` in favour of the corresponding self-callable forms (`bytes.toBlob()`, `iter.toVarArray()`) (#497).
 * Remove wrong `self` parameter from `Principal.fromBlob` (#492). 
   Change `blob.fromBlob()` to `Principal.fromBlob(blob)` if this causes a compile error in your code.

--- a/src/List.mo
+++ b/src/List.mo
@@ -1099,7 +1099,6 @@ module {
   /// Runtime: `O(1)`
   ///
   /// Space: `O(1)`
-  /// @deprecated M0235
   public func get<T>(self : List<T>, index : Nat) : ?T {
     // inlined version of locate
     let (a, b) = do {

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -448,7 +448,6 @@ module {
   /// Space: `O(log(n))`.
   /// where `n` denotes the number of key-value entries stored in the map and
   /// assuming that the `compare` function implements an `O(1)` comparison.
-  /// @deprecated M0235
   public func swap<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order), key : K, value : V) : ?V {
     let insertResult = switch (self.root) {
       case (#leaf(leafNode)) {
@@ -514,7 +513,6 @@ module {
   /// Space: `O(log(n))`.
   /// where `n` denotes the number of key-value entries stored in the map and
   /// assuming that the `compare` function implements an `O(1)` comparison.
-  /// @deprecated M0235
   public func replace<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order), key : K, value : V) : ?V {
     // TODO: Could be optimized in future
     if (containsKey(self, compare, key)) {
@@ -616,7 +614,6 @@ module {
   /// assuming that the `compare` function implements an `O(1)` comparison.
   ///
   /// Note: Creates `O(log(n))` objects that will be collected as garbage.
-  /// @deprecated M0235
   public func take<K, V>(self : Map<K, V>, compare : (implicit : (K, K) -> Order.Order), key : K) : ?V {
     let deletedValue = switch (self.root) {
       case (#leaf(leafNode)) {

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -43,7 +43,6 @@ module {
   /// assert validateEmail("@domain.com") == #err("Username cannot be empty");
   /// assert validateEmail("user@invalid") == #err("Invalid domain format");
   /// ```
-  /// @deprecated M0235
   public type Result<Ok, Err> = Types.Result<Ok, Err>;
 
   /// Compares two Results for equality.

--- a/src/Set.mo
+++ b/src/Set.mo
@@ -927,7 +927,6 @@ module {
   /// Space: `O(1)` retained memory plus garbage, see the note below.
   /// where `m` and `n` denote the number of elements in `set` and `iter`, respectively,
   /// and assuming that the `compare` function implements an `O(1)` comparison.
-  /// @deprecated M0235
   public func deleteAll<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), iter : Types.Iter<T>) : Bool {
     var deleted = false;
     for (element in iter) {
@@ -958,7 +957,6 @@ module {
   /// Space: `O(1)` retained memory plus garbage, see the note below.
   /// where `m` and `n` denote the number of elements in `set` and `iter`, respectively,
   /// and assuming that the `compare` function implements an `O(1)` comparison.
-  /// @deprecated M0235
   public func insertAll<T>(self : Set<T>, compare : (implicit : (T, T) -> Order.Order), iter : Types.Iter<T>) : Bool {
     var inserted = false;
     for (element in iter) {


### PR DESCRIPTION
`List.get`, `Map.swap`/`replace`/`take`, `Set.deleteAll`/`insertAll`, and the `Result.Result` type alias no longer trigger the `M0235` deprecation lint. None had an equivalent in core, so the lint forced users into worse code — or, for the type alias, no migration at all.

| API | Why restore |
| --- | --- |
| `List.get` | Returns `?T`. `List.at` traps on out-of-bounds — different semantics. |
| `Map.swap`, `Map.replace`, `Map.take` | Return previous/removed value atomically. Replacing them forces a `get` + `add`/`remove` pair, doubling tree lookups. |
| `Set.deleteAll`, `Set.insertAll` | No `Set.removeAll`/`Set.addAll` returning `()` exists; bulk removal would have no convenience function. |
| `Result.Result` | Type alias has no syntactic alternative in Motoko — code referring to `Result.Result<Ok, Err>` would have to switch to `Types.Result<Ok, Err>` and import `Types`. |

## What is unchanged

`assertValid`, `toPure`/`fromPure`, the stateful `Random` class, the pure type aliases (`pure/List`, `pure/Map`, `pure/Set`, `pure/Queue`), and `Map.insert`/`delete`, `Set.insert`/`delete` stay `M0235`-deprecated — those are caffeine-specific preferences with reasonable replacements.

Split out of [#501](https://github.com/caffeinelabs/motoko-core/pull/501) for clean review; the `Module.fromX` -> `Module.toX` deprecation work will be rebased on top once this lands.