### PR TITLE
perf: speed up validate:docs with native moc and a worker pool

### DIFF
--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -21,6 +21,9 @@ on:
       has_mops_package_version_changes:
         description: "Whether the version field in mops.toml was changed"
         value: ${{ jobs.check.outputs.has_mops_package_version_changes }}
+      has_validate_docs_script_changes:
+        description: "Whether the validate:docs script was changed"
+        value: ${{ jobs.check.outputs.has_validate_docs_script_changes }}
 
 jobs:
   check:
@@ -32,6 +35,7 @@ jobs:
       has_changelog_changes: ${{ steps.check_mo_changes.outputs.has_changelog_changes }}
       has_mops_dependency_changes: ${{ steps.check_mo_changes.outputs.has_mops_dependency_changes }}
       has_mops_package_version_changes: ${{ steps.check_mo_changes.outputs.has_mops_package_version_changes }}
+      has_validate_docs_script_changes: ${{ steps.check_mo_changes.outputs.has_validate_docs_script_changes }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -85,5 +89,13 @@ jobs:
             echo "No mops package version changes detected"
           else
             echo "has_mops_package_version_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check for validate:docs script changes
+          if [ -z "$(git diff --name-only $BASE_SHA $HEAD_SHA -- test/ts/validate/docs.ts)" ]; then
+            echo "has_validate_docs_script_changes=false" >> $GITHUB_OUTPUT
+            echo "No validate:docs script changes detected"
+          else
+            echo "has_validate_docs_script_changes=true" >> $GITHUB_OUTPUT
           fi
           

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,21 +58,21 @@ jobs:
 
   validate-docs:
     needs: check-motoko-changes
-    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true'
+    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Validate docs for changed src/*.mo files
-        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false'
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false' && needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'false'
         run: |
           echo "${{ needs.check-motoko-changes.outputs.src_mo_changed_files }}" | while read -r file; do
             npm run validate:docs "$file"
           done
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
-      - name: Validate all docs on version change
-        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true'
+      - name: Validate all docs on version or script change
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true'
         run: npm run validate:docs
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,10 @@ jobs:
           while IFS= read -r file; do
             [[ -n "$file" ]] && files+=("$file")
           done <<< "${{ needs.check-motoko-changes.outputs.src_mo_changed_files }}"
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No changed src/*.mo files."
+            exit 0
+          fi
           npm run validate:docs -- "${files[@]}"
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,14 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Validate docs for changed src/*.mo files
         if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false' && needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'false'
+        shell: bash
         run: |
-          echo "${{ needs.check-motoko-changes.outputs.src_mo_changed_files }}" | while read -r file; do
-            npm run validate:docs "$file"
-          done
+          set -euo pipefail
+          files=()
+          while IFS= read -r file; do
+            [[ -n "$file" ]] && files+=("$file")
+          done <<< "${{ needs.check-motoko-changes.outputs.src_mo_changed_files }}"
+          npm run validate:docs -- "${files[@]}"
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
       - name: Validate all docs on version or script change

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "fast-glob": "^3.3.2",
         "ic-mops": "^2.7.0",
         "mo-dev": "^0.13.0",
-        "motoko": "^4.5.0",
         "npm-run-all": "^4.1.5",
         "prettier": "2",
         "prettier-plugin-motoko": "^0.11.2",
@@ -6886,29 +6885,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/motoko": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/motoko/-/motoko-4.5.0.tgz",
-      "integrity": "sha512-1FooILcYIicCPiSzueGsdSAHM7uKpAuMruqDdsm4TVPl+LZ+QEjxEbhD1Fw981onlZEwRiB4WFtfN77RRMtUtA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "^4.4.3",
-        "parse-github-url": "1.0.3",
-        "sanitize-filename": "^1.6.4"
-      }
-    },
-    "node_modules/motoko/node_modules/sanitize-filename": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
-      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
-      "dev": true,
-      "license": "WTFPL OR ISC",
-      "dependencies": {
-        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "fast-glob": "^3.3.2",
     "ic-mops": "^2.7.0",
     "mo-dev": "^0.13.0",
-    "motoko": "^4.5.0",
     "npm-run-all": "^4.1.5",
     "prettier": "2",
     "prettier-plugin-motoko": "^0.11.2",

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -57,16 +57,19 @@ async function resolveMocPath(): Promise<string> {
 async function pMap<T, R>(
   items: T[],
   limit: number,
-  fn: (item: T, idx: number) => Promise<R>
+  fn: (item: T, idx: number, workerIdx: number) => Promise<R>
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let next = 0;
+  // `workerIdx` is bound to the JS loop, not the item index. This is what
+  // callers rely on to claim per-worker resources (temp files, canisters)
+  // without collisions when items finish out of order.
   await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, async () => {
+    Array.from({ length: Math.min(limit, items.length) }, async (_, workerIdx) => {
       while (true) {
         const idx = next++;
         if (idx >= items.length) return;
-        results[idx] = await fn(items[idx], idx);
+        results[idx] = await fn(items[idx], idx, workerIdx);
       }
     })
   );
@@ -76,16 +79,10 @@ async function pMap<T, R>(
 // PocketIC returns 409/202 under load; the pic client surfaces these as
 // transient string errors. Retry with backoff so concurrent installs across
 // worker canisters don't spuriously fail validation.
-//
-// `CanisterMethodNotFound` is included because under high concurrency a call
-// occasionally races a fresh `reinstallCode` and the certified state hasn't
-// caught up yet. Real missing-method errors still surface after retries
-// exhaust.
 const transientPicErrors = [
   "Server busy",
   "Server started processing",
   "Unknown state",
-  "CanisterMethodNotFound",
 ];
 
 async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
@@ -111,12 +108,12 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 async function main() {
   const testFilters = process.argv.slice(2);
 
+  const sourcePaths = (await glob(join(rootDirectory, "src/**/*.mo"))).sort();
+
   let skippable = true;
   const snippets: Snippet[] = (
     await Promise.all(
-      (await glob(join(rootDirectory, "src/**/*.mo")))
-        .sort()
-        .map(async (path) => {
+      sourcePaths.map(async (path) => {
           const virtualPath = relative(rootDirectory, path);
 
           // Require matching at least one test filter
@@ -227,7 +224,7 @@ async function main() {
   // it via `--package core`, replacing the in-memory virtual FS used previously.
   const workDir = await mkdtemp(join(tmpdir(), "validate-docs-"));
   const corePackageDir = join(workDir, "core");
-  for (const path of await glob(join(rootDirectory, "src/**/*.mo"))) {
+  for (const path of sourcePaths) {
     const target = join(corePackageDir, relative(join(rootDirectory, "src"), path));
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, await readFile(path));
@@ -239,103 +236,113 @@ async function main() {
   // installs and calls can run in parallel (different canisters do not block
   // each other on the PocketIC server).
   const poolSize = Math.max(1, Math.min(snippets.length, cpus().length));
-  const pocketIcServer = await PocketIcServer.start({
-    showRuntimeLogs: false,
-    showCanisterLogs: false, // TODO: enable with --verbose flag?
-  });
-  const pocketIc = await PocketIc.create(pocketIcServer.getUrl());
 
-  console.log(`Creating ${poolSize} canister${poolSize === 1 ? "" : "s"}...`);
-  const principals: Principal[] = await Promise.all(
-    Array.from({ length: poolSize }, async () => {
-      const principal = await pocketIc.createCanister();
-      await pocketIc.updateCanisterSettings({
-        canisterId: principal,
-        controllers: [Principal.anonymous()],
-      });
-      return principal;
-    })
-  );
-
-  console.log(`Running snippets...`);
   const results: (TestResult | undefined)[] = new Array(snippets.length);
   const testResults: TestResult[] = [];
-  // Print results live as snippets finish, but always in the original snippet
-  // order so per-file headers and the summary stay coherent.
-  let nextToPrint = 0;
-  let previousSnippet: Snippet | undefined;
-  const flush = () => {
-    while (nextToPrint < snippets.length) {
-      const snippet = snippets[nextToPrint];
-      const result = results[nextToPrint];
-      const isSkipped =
-        snippet.language !== "motoko" || snippet.tags.includes("no-validate");
-      if (!isSkipped && !result) break;
-      if (snippet.path !== previousSnippet?.path) {
-        console.log(chalk.gray(snippet.path));
-      }
-      if (result) {
-        testResults.push(result);
-        if (testFilters.length || result.status !== "passed") {
+  let pocketIcServer: PocketIcServer | undefined;
+  let pocketIc: PocketIc | undefined;
+  try {
+    pocketIcServer = await PocketIcServer.start({
+      showRuntimeLogs: false,
+      showCanisterLogs: false, // TODO: enable with --verbose flag?
+    });
+    pocketIc = await PocketIc.create(pocketIcServer.getUrl());
+    const ic = pocketIc;
+
+    console.log(`Creating ${poolSize} canister${poolSize === 1 ? "" : "s"}...`);
+    const principals: Principal[] = await Promise.all(
+      Array.from({ length: poolSize }, async () => {
+        const principal = await ic.createCanister();
+        await ic.updateCanisterSettings({
+          canisterId: principal,
+          controllers: [Principal.anonymous()],
+        });
+        return principal;
+      })
+    );
+
+    console.log(`Running snippets...`);
+
+    // Print results live as snippets finish, but always in the original snippet
+    // order so per-file headers and the summary stay coherent.
+    let nextToPrint = 0;
+    let previousSnippet: Snippet | undefined;
+    const flush = () => {
+      while (nextToPrint < snippets.length) {
+        const snippet = snippets[nextToPrint];
+        const result = results[nextToPrint];
+        const isSkipped =
+          snippet.language !== "motoko" || snippet.tags.includes("no-validate");
+        if (!isSkipped && !result) break;
+        if (snippet.path !== previousSnippet?.path) {
+          console.log(chalk.gray(snippet.path));
+        }
+        if (result) {
+          testResults.push(result);
+          if (testFilters.length || result.status !== "passed") {
+            console.log(
+              testStatusEmojis[result.status],
+              `${snippet.path}:${snippet.line}`.padEnd(30),
+              chalk.grey(`${(result.time / 1000).toFixed(1)}s`)
+            );
+          }
+          if (result.error) {
+            console.log(chalk.grey(displaySnippet(snippet)));
+            console.error(chalk.red(result.error));
+          }
+        } else {
           console.log(
-            testStatusEmojis[result.status],
-            `${snippet.path}:${snippet.line}`.padEnd(30),
-            chalk.grey(`${(result.time / 1000).toFixed(1)}s`)
+            testStatusEmojis["skipped"],
+            `${snippet.path}:${snippet.line}`,
+            chalk.grey("skipped")
           );
-        }
-        if (result.error) {
           console.log(chalk.grey(displaySnippet(snippet)));
-          console.error(chalk.red(result.error));
         }
-      } else {
-        console.log(
-          testStatusEmojis["skipped"],
-          `${snippet.path}:${snippet.line}`,
-          chalk.grey("skipped")
-        );
-        console.log(chalk.grey(displaySnippet(snippet)));
+        previousSnippet = snippet;
+        nextToPrint++;
       }
-      previousSnippet = snippet;
-      nextToPrint++;
-    }
-  };
-
-  await pMap(snippets, poolSize, async (snippet, idx) => {
-    if (snippet.language !== "motoko" || snippet.tags.includes("no-validate")) {
-      flush();
-      return;
-    }
-    const startTime = Date.now();
-    let status: TestResult["status"];
-    let error;
-    try {
-      const workerIdx = idx % poolSize;
-      await runSnippet(snippet, {
-        mocPath,
-        corePackageDir,
-        workDir,
-        workerIdx,
-        principal: principals[workerIdx],
-        pocketIc,
-      });
-      status = "passed";
-    } catch (err) {
-      error = err;
-      status = "failed";
-    }
-    results[idx] = {
-      snippet,
-      status,
-      error,
-      time: Date.now() - startTime,
     };
-    flush();
-  });
-  flush();
 
-  await pocketIc.tearDown();
-  await pocketIcServer.stop();
-  await rm(workDir, { recursive: true, force: true });
+    await pMap(snippets, poolSize, async (snippet, idx, workerIdx) => {
+      if (snippet.language !== "motoko" || snippet.tags.includes("no-validate")) {
+        flush();
+        return;
+      }
+      const startTime = Date.now();
+      let status: TestResult["status"];
+      let error;
+      try {
+        await runSnippet(snippet, {
+          mocPath,
+          corePackageDir,
+          workDir,
+          workerIdx,
+          principal: principals[workerIdx],
+          pocketIc: ic,
+        });
+        status = "passed";
+      } catch (err) {
+        error = err;
+        status = "failed";
+      }
+      results[idx] = {
+        snippet,
+        status,
+        error,
+        time: Date.now() - startTime,
+      };
+      flush();
+    });
+    flush();
+  } finally {
+    // Best-effort cleanup; warn rather than throw so we don't mask a primary
+    // error from the `try` body.
+    const warn = (label: string) => (err: unknown) =>
+      console.warn(`Cleanup of ${label} failed:`, err);
+    await pocketIc?.tearDown().catch(warn("PocketIC instance"));
+    await pocketIcServer?.stop().catch(warn("PocketIC server"));
+    await rm(workDir, { recursive: true, force: true }).catch(warn(workDir));
+  }
 
   const paths = new Set(snippets.map((snippet) => snippet.path));
   const failedPaths = new Set(
@@ -490,8 +497,9 @@ const runSnippet = async (snippet: Snippet, ctx: RunContext) => {
     })
   );
 
-  // Call `main()` if present
-  const hasMain = /\bfunc\s+main\b/.test(actorSource);
+  // Call `main()` if present. Strip line/block comments so the heuristic
+  // doesn't match `func main` mentioned in prose comments.
+  const hasMain = /\bfunc\s+main\b/.test(stripComments(actorSource));
   const actor: ExampleActor = ctx.pocketIc.createActor(({ IDL }) => {
     return IDL.Service(
       hasMain
@@ -506,10 +514,10 @@ const runSnippet = async (snippet: Snippet, ctx: RunContext) => {
   }
 };
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Strips line and block comments. Doesn't handle string literals; acceptable
+// for the heuristic uses below.
+const stripComments = (source: string): string =>
+  source.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
 
 const displaySnippet = (snippet: Snippet) => {
   const tripleBacktick = "```";
@@ -517,3 +525,8 @@ const displaySnippet = (snippet: Snippet) => {
     snippet.tags.length ? ` ${snippet.tags.join(" ")}` : ""
   }\n${snippet.sourceCode}\n${tripleBacktick}`;
 };
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -114,99 +114,99 @@ async function main() {
   const snippets: Snippet[] = (
     await Promise.all(
       sourcePaths.map(async (path) => {
-          const virtualPath = relative(rootDirectory, path);
+        const virtualPath = relative(rootDirectory, path);
 
-          // Require matching at least one test filter
-          if (
-            testFilters.length &&
-            testFilters.every((testFilter) => !virtualPath.includes(testFilter))
-          ) {
-            return [];
+        // Require matching at least one test filter
+        if (
+          testFilters.length &&
+          testFilters.every((testFilter) => !virtualPath.includes(testFilter))
+        ) {
+          return [];
+        }
+
+        // Skip internal modules
+        if (skippable && !virtualPath.startsWith("src/internal/")) {
+          skippable = false;
+        }
+
+        const content = await readFile(path, "utf8");
+
+        // Empty non-doc-comment lines to preserve line numbers
+        const docComments = content.replace(/^[ \t]*\/\/\/ ?/gm, "");
+
+        const codeBlocks: {
+          line: number;
+          language: string | undefined;
+          sourceCode: string;
+          tags: string[];
+        }[] = [];
+
+        const getLineNumber = (text: string, charIndex: number): number => {
+          if (!text || charIndex < 0 || charIndex >= text.length) {
+            return -1;
           }
-
-          // Skip internal modules
-          if (skippable && !virtualPath.startsWith("src/internal/")) {
-            skippable = false;
+          let line = 1;
+          for (let i = 0; i < charIndex; i++) {
+            if (text[i] === "\n") {
+              line++;
+            }
           }
+          return line;
+        };
 
-          const content = await readFile(path, "utf8");
+        for (const match of docComments.matchAll(
+          /```(\S*)?(?:[ \t]+([^\n]+)?)?\n([\s\S]*?)\n[ \t]*```/g
+        )) {
+          const [_, language, tags, sourceCode] = match;
+          codeBlocks.push({
+            line: getLineNumber(docComments, match.index),
+            language,
+            tags: tags?.trim() ? tags.trim().split(/\s+/) : [],
+            sourceCode: sourceCode.trim(),
+          });
+        }
 
-          // Empty non-doc-comment lines to preserve line numbers
-          const docComments = content.replace(/^[ \t]*\/\/\/ ?/gm, "");
-
-          const codeBlocks: {
-            line: number;
-            language: string | undefined;
-            sourceCode: string;
-            tags: string[];
-          }[] = [];
-
-          const getLineNumber = (text: string, charIndex: number): number => {
-            if (!text || charIndex < 0 || charIndex >= text.length) {
-              return -1;
-            }
-            let line = 1;
-            for (let i = 0; i < charIndex; i++) {
-              if (text[i] === "\n") {
-                line++;
-              }
-            }
-            return line;
+        const snippets: Snippet[] = [];
+        const snippetMap = new Map<string, Snippet>();
+        for (const { line, language, tags, sourceCode } of codeBlocks) {
+          const snippet: Snippet = {
+            path: virtualPath,
+            line,
+            language,
+            tags,
+            name: tags
+              .find((attr) => attr.startsWith("name="))
+              ?.substring("name=".length),
+            includes: [],
+            sourceCode,
           };
-
-          for (const match of docComments.matchAll(
-            /```(\S*)?(?:[ \t]+([^\n]+)?)?\n([\s\S]*?)\n[ \t]*```/g
-          )) {
-            const [_, language, tags, sourceCode] = match;
-            codeBlocks.push({
-              line: getLineNumber(docComments, match.index),
-              language,
-              tags: tags?.trim() ? tags.trim().split(/\s+/) : [],
-              sourceCode: sourceCode.trim(),
-            });
+          snippets.push(snippet);
+          if (snippet.name) {
+            if (snippetMap.has(snippet.name)) {
+              throw new Error(
+                `${snippet.path}:${snippet.line} Duplicate snippet name: ${snippet.name}`
+              );
+            }
+            snippetMap.set(snippet.name, snippet);
           }
-
-          const snippets: Snippet[] = [];
-          const snippetMap = new Map<string, Snippet>();
-          for (const { line, language, tags, sourceCode } of codeBlocks) {
-            const snippet: Snippet = {
-              path: virtualPath,
-              line,
-              language,
-              tags,
-              name: tags
-                .find((attr) => attr.startsWith("name="))
-                ?.substring("name=".length),
-              includes: [],
-              sourceCode,
-            };
-            snippets.push(snippet);
-            if (snippet.name) {
-              if (snippetMap.has(snippet.name)) {
+        }
+        // Resolve "include=..." references
+        for (const snippet of snippets) {
+          for (const attr of snippet.tags) {
+            if (attr.startsWith("include=")) {
+              const name = attr.substring("include=".length);
+              const include = snippetMap.get(name);
+              if (!include) {
                 throw new Error(
-                  `${snippet.path}:${snippet.line} Duplicate snippet name: ${snippet.name}`
+                  `${snippet.path}:${snippet.line} Unresolved snippet attribute: ${attr}`
                 );
               }
-              snippetMap.set(snippet.name, snippet);
+              snippet.includes.push(include);
             }
           }
-          // Resolve "include=..." references
-          for (const snippet of snippets) {
-            for (const attr of snippet.tags) {
-              if (attr.startsWith("include=")) {
-                const name = attr.substring("include=".length);
-                const include = snippetMap.get(name);
-                if (!include) {
-                  throw new Error(
-                    `${snippet.path}:${snippet.line} Unresolved snippet attribute: ${attr}`
-                  );
-                }
-                snippet.includes.push(include);
-              }
-            }
-          }
-          return snippets;
-        })
+        }
+        return snippets;
+      })
     )
   ).flatMap((snippets) => snippets);
 
@@ -514,6 +514,11 @@ const runSnippet = async (snippet: Snippet, ctx: RunContext) => {
   }
 };
 
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
 // Strips line and block comments. Doesn't handle string literals; acceptable
 // for the heuristic uses below.
 const stripComments = (source: string): string =>
@@ -525,8 +530,3 @@ const displaySnippet = (snippet: Snippet) => {
     snippet.tags.length ? ` ${snippet.tags.join(" ")}` : ""
   }\n${snippet.sourceCode}\n${tripleBacktick}`;
 };
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -1,10 +1,11 @@
 import { Principal } from "@dfinity/principal";
 import { PocketIc, PocketIcServer } from "@dfinity/pic";
 import chalk from "chalk";
-import { readFile } from "fs/promises";
+import execa from "execa";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { glob } from "glob";
-import motoko from "motoko";
-import { join, relative } from "path";
+import { cpus, tmpdir } from "os";
+import { dirname, join, relative } from "path";
 
 interface TestResult {
   snippet: Snippet;
@@ -35,12 +36,80 @@ const testStatusEmojis: Record<TestResult["status"], string> = {
 
 const rootDirectory = join(__dirname, "../../..");
 
+// Treat redundant type instantiations (M0223) and `@deprecated` usages (M0154)
+// as errors in doc snippets — examples must never use deprecated APIs.
+const mocExtraFlags = ["-E=M0223,M0154"];
+
+async function resolveMocPath(): Promise<string> {
+  if (process.env.DFX_MOC_PATH) return process.env.DFX_MOC_PATH;
+  const { stdout } = await execa("npx", ["mops", "toolchain", "bin", "moc"], {
+    cwd: rootDirectory,
+  });
+  const path = stdout.trim();
+  if (!path) {
+    throw new Error(
+      "Could not resolve `moc` binary. Set DFX_MOC_PATH or run `mops toolchain init`."
+    );
+  }
+  return path;
+}
+
+async function pMap<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, idx: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (true) {
+        const idx = next++;
+        if (idx >= items.length) return;
+        results[idx] = await fn(items[idx], idx);
+      }
+    })
+  );
+  return results;
+}
+
+// PocketIC returns 409/202 under load; the pic client surfaces these as
+// transient string errors. Retry with backoff so concurrent installs across
+// worker canisters don't spuriously fail validation.
+//
+// `CanisterMethodNotFound` is included because under high concurrency a call
+// occasionally races a fresh `reinstallCode` and the certified state hasn't
+// caught up yet. Real missing-method errors still surface after retries
+// exhaust.
+const transientPicErrors = [
+  "Server busy",
+  "Server started processing",
+  "Unknown state",
+  "CanisterMethodNotFound",
+];
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  const maxAttempts = 8;
+  let delayMs = 50;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      const msg = String(err?.message ?? err);
+      if (
+        attempt >= maxAttempts ||
+        !transientPicErrors.some((m) => msg.includes(m))
+      ) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, 1000);
+    }
+  }
+}
+
 async function main() {
   const testFilters = process.argv.slice(2);
-
-  const virtualBaseDirectory = "motoko-base";
-  motoko.usePackage("core", join(virtualBaseDirectory, "src")); // Register `mo:core`
-  motoko.setExtraFlags(["-E=M0223,M0154"]); // Treat redundant type instantiations and `@deprecated` usages as errors in doc snippets — examples must never use deprecated APIs
 
   let skippable = true;
   const snippets: Snippet[] = (
@@ -49,10 +118,6 @@ async function main() {
         .sort()
         .map(async (path) => {
           const virtualPath = relative(rootDirectory, path);
-
-          // Write to virtual file system
-          const content = await readFile(path, "utf8");
-          motoko.write(join(virtualBaseDirectory, virtualPath), content);
 
           // Require matching at least one test filter
           if (
@@ -66,6 +131,8 @@ async function main() {
           if (skippable && !virtualPath.startsWith("src/internal/")) {
             skippable = false;
           }
+
+          const content = await readFile(path, "utf8");
 
           // Empty non-doc-comment lines to preserve line numbers
           const docComments = content.replace(/^[ \t]*\/\/\/ ?/gm, "");
@@ -156,72 +223,119 @@ async function main() {
     process.exit(1);
   }
 
-  // Start PocketIC
+  // Mirror `mo:core` source files to a temp directory once. Each compile passes
+  // it via `--package core`, replacing the in-memory virtual FS used previously.
+  const workDir = await mkdtemp(join(tmpdir(), "validate-docs-"));
+  const corePackageDir = join(workDir, "core");
+  for (const path of await glob(join(rootDirectory, "src/**/*.mo"))) {
+    const target = join(corePackageDir, relative(join(rootDirectory, "src"), path));
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, await readFile(path));
+  }
+
+  const mocPath = await resolveMocPath();
+
+  // Start PocketIC with a pool of canisters. Each worker owns one canister so
+  // installs and calls can run in parallel (different canisters do not block
+  // each other on the PocketIC server).
+  const poolSize = Math.max(1, Math.min(snippets.length, cpus().length));
   const pocketIcServer = await PocketIcServer.start({
     showRuntimeLogs: false,
     showCanisterLogs: false, // TODO: enable with --verbose flag?
   });
   const pocketIc = await PocketIc.create(pocketIcServer.getUrl());
 
-  console.log("Creating canisters...");
-  const sourcePrincipal = await pocketIc.createCanister();
-  //   const testPrincipal = await pocketIc.createCanister();
-  await pocketIc.updateCanisterSettings({
-    canisterId: sourcePrincipal,
-    controllers: [Principal.anonymous() /* , testPrincipal */],
-  });
+  console.log(`Creating ${poolSize} canister${poolSize === 1 ? "" : "s"}...`);
+  const principals: Principal[] = await Promise.all(
+    Array.from({ length: poolSize }, async () => {
+      const principal = await pocketIc.createCanister();
+      await pocketIc.updateCanisterSettings({
+        canisterId: principal,
+        controllers: [Principal.anonymous()],
+      });
+      return principal;
+    })
+  );
 
   console.log(`Running snippets...`);
+  const results: (TestResult | undefined)[] = new Array(snippets.length);
   const testResults: TestResult[] = [];
+  // Print results live as snippets finish, but always in the original snippet
+  // order so per-file headers and the summary stay coherent.
+  let nextToPrint = 0;
   let previousSnippet: Snippet | undefined;
-  for (const snippet of snippets) {
-    if (snippet.path !== previousSnippet?.path) {
-      console.log(chalk.gray(snippet.path));
-    }
-    if (
-      snippet.language === "motoko" &&
-      !snippet.tags.includes("no-validate")
-    ) {
-      const startTime = Date.now();
-      let status: TestResult["status"];
-      let error;
-      try {
-        await runSnippet(snippet, pocketIc, sourcePrincipal);
-        status = "passed";
-      } catch (err) {
-        error = err;
-        status = "failed";
+  const flush = () => {
+    while (nextToPrint < snippets.length) {
+      const snippet = snippets[nextToPrint];
+      const result = results[nextToPrint];
+      const isSkipped =
+        snippet.language !== "motoko" || snippet.tags.includes("no-validate");
+      if (!isSkipped && !result) break;
+      if (snippet.path !== previousSnippet?.path) {
+        console.log(chalk.gray(snippet.path));
       }
-      const result: TestResult = {
-        snippet,
-        status,
-        error,
-        time: Date.now() - startTime,
-      };
-      testResults.push(result);
-      if (testFilters.length || status !== "passed") {
+      if (result) {
+        testResults.push(result);
+        if (testFilters.length || result.status !== "passed") {
+          console.log(
+            testStatusEmojis[result.status],
+            `${snippet.path}:${snippet.line}`.padEnd(30),
+            chalk.grey(`${(result.time / 1000).toFixed(1)}s`)
+          );
+        }
+        if (result.error) {
+          console.log(chalk.grey(displaySnippet(snippet)));
+          console.error(chalk.red(result.error));
+        }
+      } else {
         console.log(
-          testStatusEmojis[status],
-          `${snippet.path}:${snippet.line}`.padEnd(30),
-          chalk.grey(`${(result.time / 1000).toFixed(1)}s`)
+          testStatusEmojis["skipped"],
+          `${snippet.path}:${snippet.line}`,
+          chalk.grey("skipped")
         );
-      }
-      if (result.error) {
         console.log(chalk.grey(displaySnippet(snippet)));
-        console.error(chalk.red(result.error));
       }
-    } else {
-      console.log(
-        testStatusEmojis["skipped"],
-        `${snippet.path}:${snippet.line}`,
-        chalk.grey("skipped")
-      );
-      console.log(chalk.grey(displaySnippet(snippet)));
+      previousSnippet = snippet;
+      nextToPrint++;
     }
-    previousSnippet = snippet;
-  }
+  };
+
+  await pMap(snippets, poolSize, async (snippet, idx) => {
+    if (snippet.language !== "motoko" || snippet.tags.includes("no-validate")) {
+      flush();
+      return;
+    }
+    const startTime = Date.now();
+    let status: TestResult["status"];
+    let error;
+    try {
+      const workerIdx = idx % poolSize;
+      await runSnippet(snippet, {
+        mocPath,
+        corePackageDir,
+        workDir,
+        workerIdx,
+        principal: principals[workerIdx],
+        pocketIc,
+      });
+      status = "passed";
+    } catch (err) {
+      error = err;
+      status = "failed";
+    }
+    results[idx] = {
+      snippet,
+      status,
+      error,
+      time: Date.now() - startTime,
+    };
+    flush();
+  });
+  flush();
+
   await pocketIc.tearDown();
   await pocketIcServer.stop();
+  await rm(workDir, { recursive: true, force: true });
 
   const paths = new Set(snippets.map((snippet) => snippet.path));
   const failedPaths = new Set(
@@ -260,15 +374,16 @@ async function main() {
   process.exit(hasError ? 1 : 0);
 }
 
-const runSnippet = async (
-  snippet: Snippet,
-  pocketIc: PocketIc,
-  sourcePrincipal: Principal
-) => {
-  // Set canister alias
-  const sourceCanisterName = "snippet";
-  motoko.setAliases(".", { [sourceCanisterName]: sourcePrincipal.toText() });
+interface RunContext {
+  mocPath: string;
+  corePackageDir: string;
+  workDir: string;
+  workerIdx: number;
+  principal: Principal;
+  pocketIc: PocketIc;
+}
 
+const runSnippet = async (snippet: Snippet, ctx: RunContext) => {
   const extractImports = (source: string) => {
     const importLines = [];
     const nonImportLines = [];
@@ -334,26 +449,50 @@ const runSnippet = async (
     );
   }
 
-  // Write to virtual file system
-  const virtualPath = join(
-    "snippet",
-    `${snippet.path.replace(/\.mo$/, "")}_${snippet.line}.mo`
+  // Write source to a worker-scoped temp file. Reusing the same path per worker
+  // keeps the temp directory bounded and avoids cross-worker collisions.
+  const sourcePath = join(ctx.workDir, `worker-${ctx.workerIdx}.mo`);
+  const wasmPath = join(ctx.workDir, `worker-${ctx.workerIdx}.wasm`);
+  await writeFile(sourcePath, actorSource);
+
+  try {
+    await execa(
+      ctx.mocPath,
+      [
+        "--package",
+        "core",
+        ctx.corePackageDir,
+        "--actor-alias",
+        "snippet",
+        ctx.principal.toText(),
+        ...mocExtraFlags,
+        "-o",
+        wasmPath,
+        sourcePath,
+      ],
+      { stdio: "pipe" }
+    );
+  } catch (err: any) {
+    const stderr = (err.stderr ?? "").toString().trim();
+    throw new Error(stderr || err.message || String(err));
+  }
+
+  const wasmBuffer = await readFile(wasmPath);
+  const wasm = wasmBuffer.buffer.slice(
+    wasmBuffer.byteOffset,
+    wasmBuffer.byteOffset + wasmBuffer.byteLength
+  ) as ArrayBuffer;
+
+  await withRetry(() =>
+    ctx.pocketIc.reinstallCode({
+      canisterId: ctx.principal,
+      wasm,
+    })
   );
-  motoko.write(virtualPath, actorSource);
 
-  // Compile source Wasm
-  const sourceResult = motoko.wasm(virtualPath, "ic");
-  motoko.write(`${sourcePrincipal.toText()}.did`, sourceResult.candid);
-
-  // Install Wasm files
-  await pocketIc.reinstallCode({
-    canisterId: sourcePrincipal,
-    wasm: sourceResult.wasm,
-  });
-
-  // Call `example()` method
-  const hasMain = actorSource.includes("func main"); // TODO: more robust?
-  const actor: ExampleActor = pocketIc.createActor(({ IDL }) => {
+  // Call `main()` if present
+  const hasMain = /\bfunc\s+main\b/.test(actorSource);
+  const actor: ExampleActor = ctx.pocketIc.createActor(({ IDL }) => {
     return IDL.Service(
       hasMain
         ? {
@@ -361,8 +500,10 @@ const runSnippet = async (
           }
         : {}
     );
-  }, sourcePrincipal);
-  await actor.main?.();
+  }, ctx.principal);
+  if (hasMain) {
+    await withRetry(() => actor.main!());
+  }
 };
 
 main().catch((err) => {

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -40,15 +40,16 @@ const rootDirectory = join(__dirname, "../../..");
 // as errors in doc snippets — examples must never use deprecated APIs.
 const mocExtraFlags = ["-E=M0223,M0154"];
 
+// Always use the mops-pinned `moc` so snippets compile against the exact
+// toolchain version the project targets. Never fall back to a dfx-provided moc.
 async function resolveMocPath(): Promise<string> {
-  if (process.env.DFX_MOC_PATH) return process.env.DFX_MOC_PATH;
   const { stdout } = await execa("npx", ["mops", "toolchain", "bin", "moc"], {
     cwd: rootDirectory,
   });
   const path = stdout.trim();
   if (!path) {
     throw new Error(
-      "Could not resolve `moc` binary. Set DFX_MOC_PATH or run `mops toolchain init`."
+      "Could not resolve `moc` binary. Run `mops toolchain init`."
     );
   }
   return path;

--- a/test/ts/validate/docs.ts
+++ b/test/ts/validate/docs.ts
@@ -77,8 +77,12 @@ async function pMap<T, R>(
 }
 
 // PocketIC returns 409/202 under load; the pic client surfaces these as
-// transient string errors. Retry with backoff so concurrent installs across
-// worker canisters don't spuriously fail validation.
+// transient string errors. Retry with backoff so concurrent operations across
+// worker canisters don't spuriously fail validation. `Server busy` is always
+// pre-accept (safe to retry); the other two can fire after the request was
+// accepted but the client gave up polling — re-submission is acceptable here
+// because doc snippets are stateless (reinstall wipes state, and re-running
+// `main()` produces the same result).
 const transientPicErrors = [
   "Server busy",
   "Server started processing",
@@ -99,7 +103,9 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
       ) {
         throw err;
       }
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      // Jitter so concurrent retriers don't wake in lockstep.
+      const jitter = delayMs * (0.5 + Math.random() * 0.5);
+      await new Promise((resolve) => setTimeout(resolve, jitter));
       delayMs = Math.min(delayMs * 2, 1000);
     }
   }
@@ -252,11 +258,13 @@ async function main() {
     console.log(`Creating ${poolSize} canister${poolSize === 1 ? "" : "s"}...`);
     const principals: Principal[] = await Promise.all(
       Array.from({ length: poolSize }, async () => {
-        const principal = await ic.createCanister();
-        await ic.updateCanisterSettings({
-          canisterId: principal,
-          controllers: [Principal.anonymous()],
-        });
+        const principal = await withRetry(() => ic.createCanister());
+        await withRetry(() =>
+          ic.updateCanisterSettings({
+            canisterId: principal,
+            controllers: [Principal.anonymous()],
+          })
+        );
         return principal;
       })
     );


### PR DESCRIPTION
## Why

`validate:docs` was painfully slow — minutes per file, ~30+ minutes for the full ~1.4k snippets. Two reasons stacked: the JS-compiled `motoko` npm package (single-threaded, much slower than native `moc`) and a strictly sequential compile → reinstall → call loop.

## What changes for users

- `npm run validate:docs <file>` returns roughly **3–4× faster** (e.g. `List.mo`: 1m45s → 27s on a 12-core machine).
- Full `npm run validate:docs` drops from ~30+ min to ~14 min, all 1397 snippets passing.
- Output unchanged: per-file headers and per-snippet status print live in source order.
- The native `moc` binary is resolved via `mops toolchain bin moc` — the mops-pinned toolchain version, so CI's existing `mops toolchain init` step is sufficient.

## How

Replace `motoko` (JS compiler) with the native `moc` binary, mirror `mo:core` to a temp dir once, and run snippets through a worker pool of PocketIC canisters so compile/install/call proceed in parallel. Each worker owns its own canister and temp file, so concurrent installs don't serialize on a shared canister. Transient PocketIC overload errors (`Server busy`) are retried with backoff.

## Follow-ups (out of scope)

A bigger speedup is available by routing snippets that don't touch IC primitives (cycles, principal, time, …) through `moc -r` and skipping PocketIC entirely. That cuts another order of magnitude off most snippets but needs a primitive-usage classifier and dual execution paths — sized for a separate PR.