### PR TITLE
feat: `Base64.decode` (RFC 4648 standard alphabet)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 ## Next
-* Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#NNN).
+* Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).
 * Un-deprecate `List.get`, `Map.swap`, `Map.replace`, `Map.take`, `Set.deleteAll`, `Set.insertAll`, and the `Result.Result` type alias. These had no equivalent replacement (e.g. `List.get` returns `?T`, distinct from the trapping `List.at`) (#502).
 * Deprecate every `Module.fromX` conversion that has a `Module.toX` counterpart across `Nat`, `NatN`, `Int`, `IntN`, `Float`, `Float32`, `Text`, `Char`, `Blob`, `Array`, `VarArray`, and `Iter` (e.g. `Nat32.fromNat8` → `Nat8.toNat32`, `Int8.fromInt` → `Int.toInt8`, `Float.fromInt` → `Int.toFloat`, `Blob.fromArray` → `Array.toBlob`). The compiler now emits a regular `@deprecated` warning naming the replacement, instead of the caffeine-only `M0235` lint (#501).
 * Add `Array.toBlob` and `VarArray.toBlob` so `[Nat8]` and `[var Nat8]` arrays can be converted to `Blob` via dot notation, e.g. `bytes.toBlob()`. Deprecate `Blob.fromArray`, `Blob.fromVarArray`, and `VarArray.fromIter` in favour of the corresponding self-callable forms (`bytes.toBlob()`, `iter.toVarArray()`) (#497).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#NNN).
 * Un-deprecate `List.get`, `Map.swap`, `Map.replace`, `Map.take`, `Set.deleteAll`, `Set.insertAll`, and the `Result.Result` type alias. These had no equivalent replacement (e.g. `List.get` returns `?T`, distinct from the trapping `List.at`) (#502).
 * Deprecate every `Module.fromX` conversion that has a `Module.toX` counterpart across `Nat`, `NatN`, `Int`, `IntN`, `Float`, `Float32`, `Text`, `Char`, `Blob`, `Array`, `VarArray`, and `Iter` (e.g. `Nat32.fromNat8` → `Nat8.toNat32`, `Int8.fromInt` → `Int.toInt8`, `Float.fromInt` → `Int.toFloat`, `Blob.fromArray` → `Array.toBlob`). The compiler now emits a regular `@deprecated` warning naming the replacement, instead of the caffeine-only `M0235` lint (#501).
 * Add `Array.toBlob` and `VarArray.toBlob` so `[Nat8]` and `[var Nat8]` arrays can be converted to `Blob` via dot notation, e.g. `bytes.toBlob()`. Deprecate `Blob.fromArray`, `Blob.fromVarArray`, and `VarArray.fromIter` in favour of the corresponding self-callable forms (`bytes.toBlob()`, `iter.toVarArray()`) (#497).

--- a/src/Base64.mo
+++ b/src/Base64.mo
@@ -19,6 +19,7 @@
 import Array "Array";
 import Blob "Blob";
 import List "List";
+import Nat "Nat";
 import Nat8 "Nat8";
 import Nat16 "Nat16";
 import Nat32 "Nat32";
@@ -186,7 +187,7 @@ module {
         nbits += 6;
         if (nbits >= 8) {
           nbits -= 8;
-          List.add(out, Nat8.fromNat(Nat32.toNat((acc >> nbits) & 0xFF)))
+          List.add(out, Nat.toNat8(Nat32.toNat((acc >> nbits) & 0xFF)))
         }
       }
     };

--- a/src/Base64.mo
+++ b/src/Base64.mo
@@ -1,6 +1,6 @@
-/// Module for Base64 encoding of byte sequences.
+/// Module for Base64 encoding and decoding of byte sequences.
 ///
-/// Base64 encoding converts binary data to an ASCII string using 64 printable
+/// Base64 converts binary data to and from an ASCII string using 64 printable
 /// characters, as specified in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648).
 /// It is widely used for HTTP Basic Authentication, encoding binary data in
 /// JSON payloads, and data URIs.
@@ -18,6 +18,7 @@
 
 import Array "Array";
 import Blob "Blob";
+import List "List";
 import Nat8 "Nat8";
 import Nat16 "Nat16";
 import Nat32 "Nat32";
@@ -134,6 +135,62 @@ module {
       i +%= 3
     };
     result
+  };
+
+  // Reverse lookup table for the standard Base64 alphabet (RFC 4648 §4).
+  // Index is the ASCII code point (0–127); value is the 6-bit decoded value (0–63),
+  // or 0xFF to signal an invalid character.
+  // prettier-ignore
+  private let decodeTable : [Nat8] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 0-15
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 16-31
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,   62, 0xFF, 0xFF, 0xFF,   63, // 32-47  '+' = 62, '/' = 63
+      52,   53,   54,   55,   56,   57,   58,   59,   60,   61, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 48-63  '0'-'9' = 52-61
+    0xFF,    0,    1,    2,    3,    4,    5,    6,    7,    8,    9,   10,   11,   12,   13,   14, // 64-79  'A'-'O' = 0-14
+      15,   16,   17,   18,   19,   20,   21,   22,   23,   24,   25, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 80-95  'P'-'Z' = 15-25
+    0xFF,   26,   27,   28,   29,   30,   31,   32,   33,   34,   35,   36,   37,   38,   39,   40, // 96-111 'a'-'o' = 26-40
+      41,   42,   43,   44,   45,   46,   47,   48,   49,   50,   51, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF  // 112-127 'p'-'z' = 41-51
+  ];
+
+  /// Decodes a Base64-encoded `Text` string to a `Blob` (RFC 4648 §4).
+  ///
+  /// Returns `?blob` on success, or `null` if the input contains any character
+  /// outside the standard Base64 alphabet (`A–Z`, `a–z`, `0–9`, `+`, `/`).
+  /// Padding characters (`=`) are accepted and ignored.
+  /// An empty `Text` decodes to `?("" : Blob)`.
+  ///
+  /// This function is the exact inverse of `encode`:
+  /// for every `Blob b`, `decode(encode(b)) == ?b`.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// assert Base64.decode("") == ?("" : Blob);
+  /// assert Base64.decode("Zg==") == ?("f" : Blob);
+  /// assert Base64.decode("Zm8=") == ?("fo" : Blob);
+  /// assert Base64.decode("Zm9v") == ?("foo" : Blob);
+  /// assert Base64.decode("Zm9vYmFy") == ?("foobar" : Blob);
+  /// assert Base64.decode("not!base64") == null;
+  /// ```
+  public func decode(text : Text) : ?Blob {
+    var acc : Nat32 = 0;
+    var nbits : Nat32 = 0;
+    let out = List.empty<Nat8>();
+    for (ch in text.chars()) {
+      if (ch != '=') {
+        let n = Prim.charToNat32(ch);
+        // Characters outside 0..127 are always invalid for Base64
+        if (n >= 128) return null;
+        let v = decodeTable[n.toNat()].toNat32();
+        if (v == 0xFF) return null;
+        acc := (acc << 6) | v;
+        nbits += 6;
+        if (nbits >= 8) {
+          nbits -= 8;
+          List.add(out, Nat8.fromNat(Nat32.toNat((acc >> nbits) & 0xFF)))
+        }
+      }
+    };
+    ?Array.toBlob(List.toArray(out))
   };
 
 }

--- a/test/Base64.test.mo
+++ b/test/Base64.test.mo
@@ -146,7 +146,7 @@ suite(
         expect.option<Blob>(Base64.decode("not!base64"), blobToText, Blob.equal).equal(null);
         expect.option<Blob>(Base64.decode("Zm9v Ym Fy"), blobToText, Blob.equal).equal(null); // spaces
         expect.option<Blob>(Base64.decode("Zm9v\nYmFy"), blobToText, Blob.equal).equal(null); // newline
-        expect.option<Blob>(Base64.decode("Zm9\FF"), blobToText, Blob.equal).equal(null); // non-ASCII
+        expect.option<Blob>(Base64.decode("Zm9vé"), blobToText, Blob.equal).equal(null); // non-ASCII Unicode (U+00E9)
         expect.option<Blob>(Base64.decode("===="), blobToText, Blob.equal).equal(?("" : Blob)) // only padding is valid (empty)
       }
     );

--- a/test/Base64.test.mo
+++ b/test/Base64.test.mo
@@ -5,6 +5,7 @@ import Nat8 "../src/Nat8";
 import Text "../src/Text";
 import { suite; test; expect } "mo:test";
 import Nat "../src/Nat";
+import Prim "mo:prim";
 
 suite(
   "Base64.encode",
@@ -95,6 +96,97 @@ suite(
         let txt = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs." : Blob;
         let expected = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4gUGFjayBteSBib3ggd2l0aCBmaXZlIGRvemVuIGxpcXVvciBqdWdzLg==";
         expect.text(Base64.encode(txt)).equal(expected)
+      }
+    )
+  }
+);
+
+// Helper: display a ?Blob value for test failure messages
+let blobToText : Blob -> Text = func b = debug_show (Prim.blobToArray(b));
+
+suite(
+  "Base64.decode",
+  func() {
+    // Examples from the module docs
+    test(
+      "decodes empty and short ASCII inputs",
+      func() {
+        expect.option<Blob>(Base64.decode(""), blobToText, Blob.equal).equal(?("" : Blob));
+        expect.option<Blob>(Base64.decode("Zg=="), blobToText, Blob.equal).equal(?("f" : Blob));
+        expect.option<Blob>(Base64.decode("Zm8="), blobToText, Blob.equal).equal(?("fo" : Blob));
+        expect.option<Blob>(Base64.decode("Zm9v"), blobToText, Blob.equal).equal(?("foo" : Blob));
+        expect.option<Blob>(Base64.decode("Zm9vYg=="), blobToText, Blob.equal).equal(?("foob" : Blob));
+        expect.option<Blob>(Base64.decode("Zm9vYmE="), blobToText, Blob.equal).equal(?("fooba" : Blob));
+        expect.option<Blob>(Base64.decode("Zm9vYmFy"), blobToText, Blob.equal).equal(?("foobar" : Blob))
+      }
+    );
+
+    // Padding lengths: 0, 1, and 2 '=' characters
+    test(
+      "decodes all padding lengths correctly",
+      func() {
+        // 3-byte group → no padding
+        let b3 : [Nat8] = [0, 255, 170];
+        expect.option<Blob>(Base64.decode("AP+q"), blobToText, Blob.equal).equal(?Array.toBlob(b3));
+
+        // 2-byte group → one '=' padding
+        let b2 : [Nat8] = [1, 2];
+        expect.option<Blob>(Base64.decode("AQI="), blobToText, Blob.equal).equal(?Array.toBlob(b2));
+
+        // 1-byte group → two '=' paddings
+        let b1 : [Nat8] = [255];
+        expect.option<Blob>(Base64.decode("/w=="), blobToText, Blob.equal).equal(?Array.toBlob(b1))
+      }
+    );
+
+    // Invalid input returns null
+    test(
+      "returns null for invalid characters",
+      func() {
+        expect.option<Blob>(Base64.decode("not!base64"), blobToText, Blob.equal).equal(null);
+        expect.option<Blob>(Base64.decode("Zm9v Ym Fy"), blobToText, Blob.equal).equal(null); // spaces
+        expect.option<Blob>(Base64.decode("Zm9v\nYmFy"), blobToText, Blob.equal).equal(null); // newline
+        expect.option<Blob>(Base64.decode("Zm9\FF"), blobToText, Blob.equal).equal(null); // non-ASCII
+        expect.option<Blob>(Base64.decode("===="), blobToText, Blob.equal).equal(?("" : Blob)) // only padding is valid (empty)
+      }
+    );
+
+    // Round-trip property: decode(encode(b)) == ?b
+    test(
+      "round-trips through encode",
+      func() {
+        let cases : [Blob] = [
+          "" : Blob,
+          "f" : Blob,
+          "fo" : Blob,
+          "foo" : Blob,
+          "foobar" : Blob,
+          "Hello, World!" : Blob,
+          Array.toBlob([0, 1, 2, 3, 127, 128, 254, 255])
+        ];
+        for (b in cases.vals()) {
+          expect.option<Blob>(Base64.decode(Base64.encode(b)), blobToText, Blob.equal).equal(?b)
+        }
+      }
+    );
+
+    // Round-trip over 256 sequential bytes
+    test(
+      "round-trips 256 sequential bytes",
+      func() {
+        let bytes : [Nat8] = Array.tabulate<Nat8>(256, func i = Nat.toNat8(i));
+        let b = Array.toBlob(bytes);
+        expect.option<Blob>(Base64.decode(Base64.encode(b)), blobToText, Blob.equal).equal(?b)
+      }
+    );
+
+    // Long known-value check
+    test(
+      "decodes multi-sentence ASCII text",
+      func() {
+        let encoded = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4gUGFjayBteSBib3ggd2l0aCBmaXZlIGRvemVuIGxpcXVvciBqdWdzLg==";
+        let expected = "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs." : Blob;
+        expect.option<Blob>(Base64.decode(encoded), blobToText, Blob.equal).equal(?expected)
       }
     )
   }

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -51,6 +51,7 @@
   {
     "name": "Base64",
     "exports": [
+      "public func decode(text : Text) : ?Blob",
       "public func encode(data : Blob) : Text"
     ]
   },


### PR DESCRIPTION
## Summary

- Add `Base64.decode : Text -> ?Blob`, the exact inverse of `Base64.encode`
- Uses a 128-entry reverse-lookup table mirroring the `encode` alphabet table style
- Returns `null` for any non-alphabet character; `=` padding characters are accepted
- Satisfies `decode(encode(b)) == ?b` for all blobs

## Changes

- `src/Base64.mo`: add `decodeTable` constant + `decode` function with doctest; update module-header doc to mention decoding; add `import List`
- `test/Base64.test.mo`: add `suite("Base64.decode", ...)` covering doc examples, padding variants (0/1/2 `=`), invalid inputs, round-trip over several blobs, and round-trip over all 256 byte values
- `validation/api/api.lock.json`: regenerated via `npm run validate:api`
- `CHANGELOG.md`: bullet added under `## Next`

## Test plan

- [x] `validate:changelog` passes after PR number is filled in (done post-PR-open)
- [x] `validate:api` passes (lock file regenerated locally)
- [x] `format:check` passes (prettier applied)
- [x] `test` passes (new decode suite + existing encode suite)
- [x] `validate:docs` passes (doctest assertions verified correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)