### PR TITLE
chore: bump toolchain moc → 1.11.0

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -24,7 +24,7 @@ bench-helper = "0.0.3"
 moc = "1.6.0"
 
 [toolchain]
-moc = "1.8.0"
+moc = "1.11.0"
 wasmtime = "44.0.0"
 
 [moc]


### PR DESCRIPTION
Bumps `[toolchain] moc` from 1.8.0 to **1.11.0** (just released) so CI exercises motoko-core against the new compiler. Pure verification/adoption of the new toolchain; `[requirements] moc` (1.6.0 minimum) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)