### PR TITLE
chore: release 2.6.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Next
+
+## 2.6.0
 * Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).
 * Un-deprecate `List.get`, `Map.swap`, `Map.replace`, `Map.take`, `Set.deleteAll`, `Set.insertAll`, and the `Result.Result` type alias. These had no equivalent replacement (e.g. `List.get` returns `?T`, distinct from the trapping `List.at`) (#502).
 * Deprecate every `Module.fromX` conversion that has a `Module.toX` counterpart across `Nat`, `NatN`, `Int`, `IntN`, `Float`, `Float32`, `Text`, `Char`, `Blob`, `Array`, `VarArray`, and `Iter` (e.g. `Nat32.fromNat8` → `Nat8.toNat32`, `Int8.fromInt` → `Int.toInt8`, `Float.fromInt` → `Int.toFloat`, `Blob.fromArray` → `Array.toBlob`). The compiler now emits a regular `@deprecated` warning naming the replacement, instead of the caffeine-only `M0235` lint (#501).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This adds the following dependency to your `mops.toml` config file:
 
 ```toml
 [dependencies]
-core = "2.5.0"
+core = "2.6.0"
 ```
 
 ## Contributing

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core"
-version = "2.5.0"
+version = "2.6.0"
 description = "The Motoko standard library"
 repository = "https://github.com/caffeinelabs/motoko-core"
 keywords = [


### PR DESCRIPTION
Release **2.6.0** of the `core` Mops package.

## Changes (per [Releasing.md](Releasing.md))
- `mops.toml`: `version` 2.5.0 → 2.6.0
- `README.md`: dependency snippet 2.5.0 → 2.6.0 (CI-checked)
- `Changelog.md`: `## Next` rolled into `## 2.6.0`, fresh empty `## Next` retained (CI-checked)

## Headline
- `Base64.decode : Text -> ?Blob` — inverse of `Base64.encode`, RFC 4648 standard alphabet (#507)

(plus the deprecation/un-deprecation work already in `## Next`: #502, #501, #497, #492)

## Publishing
After merge, push the tag to trigger the automated Mops publish:
```
git tag v2.6.0 && git push origin v2.6.0
```
`mops-publish.yml` runs `mops publish` on `v*.*.*` tags. Verify at https://mops.one/core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)