### PR TITLE
fix: correct List range/slice/get bounds handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+*  fix: correct List range/slice/get bounds handling (#512).
 
 ## 2.6.0
 * Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).

--- a/src/List.mo
+++ b/src/List.mo
@@ -1100,6 +1100,7 @@ module {
   ///
   /// Space: `O(1)`
   public func get<T>(self : List<T>, index : Nat) : ?T {
+    if (index >= 0x1_0000_0000) return null;
     // inlined version of locate
     let (a, b) = do {
       let i = Nat.toNat32(index);
@@ -2330,7 +2331,7 @@ module {
     } else {
       if (toExclusive > size) { size } else { toExclusive }
     };
-    (Prim.abs(startInt), Prim.abs(endInt))
+    (Prim.abs(startInt), Prim.abs(if (endInt < startInt) startInt else endInt))
   };
 
   /// Returns an iterator over a slice of `list` starting at `fromInclusive` up to (but not including) `toExclusive`.
@@ -2370,7 +2371,7 @@ module {
     };
     var db : [var ?T] = self.blocks[blockIndex];
     var dbSize = db.size();
-    var index = fromInclusive;
+    var index = start;
 
     public func next() : ?T {
       if (index >= end) return null;

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -2020,6 +2020,42 @@ Test.suite(
 );
 
 Test.suite(
+  "Out-of-bounds and inverted index handling",
+  func() {
+    let vec = List.fromArray<Nat>([0, 1, 2, 3, 4]);
+
+    Test.test(
+      "range clamps negative fromInclusive without over-reading",
+      func() {
+        Test.expect.array<Nat>(Iter.toArray(List.range(vec, -3, 3)), Nat.toText, Nat.equal).equal([2]);
+        Test.expect.array<Nat>(Iter.toArray(List.range(vec, -100, 2)), Nat.toText, Nat.equal).equal([0, 1]);
+        Test.expect.array<Nat>(Iter.toArray(List.range(vec, -1, 4)), Nat.toText, Nat.equal).equal([]);
+        Test.expect.array<Nat>(Iter.toArray(List.range(vec, -1, 2)), Nat.toText, Nat.equal).equal([])
+      }
+    );
+
+    Test.test(
+      "sliceToArray returns empty for inverted range",
+      func() {
+        Test.expect.array<Nat>(List.sliceToArray(vec, 3, 1), Nat.toText, Nat.equal).equal([]);
+        Test.expect.array<Nat>(List.sliceToArray(vec, -1, -3), Nat.toText, Nat.equal).equal([]);
+        Test.expect.bool(VarArray.equal<Nat>(List.sliceToVarArray(vec, 3, 1), [var], Nat.equal)).equal(true);
+        Test.expect.bool(VarArray.equal<Nat>(List.sliceToVarArray(vec, -1, -3), [var], Nat.equal)).equal(true)
+      }
+    );
+
+    Test.test(
+      "get returns null for index >= 2^32",
+      func() {
+        Test.expect.bool(List.get<Nat>(vec, 4294967296) == null).equal(true);
+        Test.expect.bool(List.get<Nat>(vec, 100) == null).equal(true);
+        Test.expect.bool(List.get<Nat>(vec, 1) == ?1).equal(true)
+      }
+    )
+  }
+);
+
+Test.suite(
   "Null on empty",
   func() {
     Test.test(


### PR DESCRIPTION
- range: clamp negative `fromInclusive` so the iterator stops at
  `toExclusive` instead of yielding elements past the requested window
- sliceToArray/sliceToVarArray: clamp `end` to `start` in actualInterval
  so an inverted range returns an empty slice instead of trapping on
  `end - start` underflow
- get: return null for `index >= 2^32` instead of trapping in Nat.toNat32

Add regression tests covering negative and inverted index arguments.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
