### PR TITLE
fix: restore pure/Queue invariant on popFront/popBack

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 ## Next
-* Fix `pure/Queue.peekFront`, `peekBack`, and `contains` returning wrong results (and trapping in debug builds) after a `popFront`/`popBack` empties one of the internal access lists. `popFront`/`popBack` now rebalance their result so the queue invariant is always restored.
+* Fix `Queue` and `pure/Queue` for certain sequences of push + peek (#513).
 
 ## 2.6.0
 * Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Next
+* Fix `pure/Queue.peekFront`, `peekBack`, and `contains` returning wrong results (and trapping in debug builds) after a `popFront`/`popBack` empties one of the internal access lists. `popFront`/`popBack` now rebalance their result so the queue invariant is always restored.
 
 ## 2.6.0
 * Add `Base64.decode : Text -> ?Blob`, the inverse of `Base64.encode` (RFC 4648 standard alphabet) (#507).

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -252,7 +252,7 @@ module {
   ///
   /// `n` denotes the number of elements stored in the queue.
   public func popFront<T>(self : Queue<T>) : ?(T, Queue<T>) = if (self.1 == 0) null else switch self {
-    case (?(i, f), n, b) ?(i, (f, n - 1, b));
+    case (?(i, f), n, b) ?(i, check(f, n - 1 : Nat, b));
     case (null, _, ?(i, null)) ?(i, (null, 0, null));
     case _ popFront(check self)
   };
@@ -290,7 +290,7 @@ module {
   ///
   /// `n` denotes the number of elements stored in the queue.
   public func popBack<T>(self : Queue<T>) : ?(Queue<T>, T) = if (self.1 == 0) null else switch self {
-    case (f, n, ?(i, b)) ?((f, n - 1, b), i);
+    case (f, n, ?(i, b)) ?((check(f, n - 1 : Nat, b), i));
     case (?(i, null), _, null) ?((null, 0, null), i);
     case _ popBack(check self)
   };

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -667,4 +667,45 @@ suite(
       }
     )
   }
+);
+
+suite(
+  "pop restores the queue invariant",
+  func() {
+    test(
+      "popFront that empties the front list keeps accessors correct",
+      func() {
+        // Build a back-loaded queue: the front list stays a singleton while
+        // the back list grows, so the following popFront empties the front.
+        var queue = Queue.empty<Nat>();
+        for (n in Nat.range(1, 5)) queue := Queue.pushBack(queue, n);
+        // logical queue: [1, 2, 3, 4]
+        let ?(x, rest) = Queue.popFront(queue) else Prim.trap("unexpected empty");
+        expect.nat(x).equal(1);
+        expect.nat(Queue.size(rest)).equal(3);
+        expect.option(Queue.peekFront(rest), Nat.toText, Nat.equal).equal(?2);
+        expect.option(Queue.peekBack(rest), Nat.toText, Nat.equal).equal(?4);
+        expect.bool(Queue.contains(rest, Nat.equal, 2)).isTrue();
+        expect.array(Queue.toArray(rest), Nat.toText, Nat.equal).equal([2, 3, 4])
+      }
+    );
+
+    test(
+      "popBack that empties the back list keeps accessors correct",
+      func() {
+        // Front-loaded queue: the back list stays a singleton while the front
+        // list grows, so the following popBack empties the back.
+        var queue = Queue.empty<Nat>();
+        for (n in Nat.rangeBy(4, 0, -1)) queue := Queue.pushFront(queue, n);
+        // logical queue: [1, 2, 3, 4]
+        let ?(rest, x) = Queue.popBack(queue) else Prim.trap("unexpected empty");
+        expect.nat(x).equal(4);
+        expect.nat(Queue.size(rest)).equal(3);
+        expect.option(Queue.peekBack(rest), Nat.toText, Nat.equal).equal(?3);
+        expect.option(Queue.peekFront(rest), Nat.toText, Nat.equal).equal(?1);
+        expect.bool(Queue.contains(rest, Nat.equal, 3)).isTrue();
+        expect.array(Queue.toArray(rest), Nat.toText, Nat.equal).equal([1, 2, 3])
+      }
+    )
+  }
 )


### PR DESCRIPTION
## Problem

`pure/Queue` is the two-list amortized deque `(front, size, backReversed)`. Its accessors `peekFront`, `peekBack`, and `contains` rely on the invariant that *if one access list is empty, the queue has ≤1 element*. `push`/`check` maintain it, but `popFront`/`popBack` returned the reduced queue **without** re-balancing:

```motoko
case (?(i, f), n, b) ?(i, (f, n - 1, b));   // popFront
case (f, n, ?(i, b)) ?((f, n - 1, b), i);   // popBack
```

When the queue is lopsided (a normal state after repeated `pushBack`/`pushFront`), popping the last element of one access list left the other list with >1 element. A *subsequent* pop self-heals via the `case _ → popFront(check self)` fallback, so pop-sequences worked — but the accessors observed the bad state directly:

- **Debug/test builds:** `debug assert` trips → **trap**.
- **Release builds:** silently returns the **wrong answer** (e.g. `peekFront` returns `null` on a 3-element queue).

`values`/`toArray` were unaffected (they read both lists), so only the O(1) accessors were hit.

## Fix

Route the reduced queue through `check` in both pop cases. `check` short-circuits (`case q q`) when both lists are non-empty — the common case — so this is O(1) there and amortized cost is unchanged; the split only runs when a pop actually empties one side.

## Tests

Added a `"pop restores the queue invariant"` suite covering both directions (back-loaded + `popFront`, front-loaded + `popBack`), asserting `peekFront`/`peekBack`/`size`/`contains`/`toArray` after the pop.

Verified with the `moc` interpreter against the working tree: the new suite **traps on the old code** and **passes on the fixed code**; all four queue suites (`pure/Queue`, `Queue`, `PriorityQueue`, `pure/RealTimeQueue`) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)