### PR TITLE
ci: drop dfx and take moc from the pinned toolchain

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: Whether to setup mops
     required: false
     default: "true"
-  setup-dfx:
-    description: Whether to setup dfx
-    required: false
-    default: "false"
 runs:
   using: composite
   steps:
@@ -34,12 +30,3 @@ runs:
     - name: Install dependencies
       shell: bash
       run: npm ci
-
-    - name: Setup dfx
-      if: ${{ inputs.setup-dfx == 'true' }}
-      uses: dfinity/setup-dfx@main
-
-    - name: Install dfx cache
-      if: ${{ inputs.setup-dfx == 'true' }}
-      shell: bash
-      run: dfx cache install

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-        with:
-          setup-dfx: true
 
       - name: Checkout baseline benchmark-results from upstream
         if: github.event_name == 'pull_request'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,9 +20,6 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
-        with:
-          setup-mops: false
-          setup-dfx: true
 
       - name: Build docs
         run: npm run docs

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -13,16 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
-      # Written rather than passed to `mops user import`, which takes the key as
-      # an argument: that puts it in the process table and echoes it back on a
-      # parse error. get-principal exits 0 when the file is missing, hence -s.
-      - env:
-          MOPS_IDENTITY_PEM: ${{ secrets.MOPS_IDENTITY_PEM }}
-        run: |
-          mkdir -p ~/.config/mops
-          printf '%s' "$MOPS_IDENTITY_PEM" > ~/.config/mops/identity.pem
-          chmod 600 ~/.config/mops/identity.pem
-          [ -s ~/.config/mops/identity.pem ]
-          npx mops user get-principal
-      - run: npx mops publish
+      - uses: caffeinelabs/setup-mops@5424732c5bb709eb6195b1ed1d351fa98f6c8aad # v1.1
+        with:
+          # Keep in step with the ic-mops devDependency in package.json.
+          mops-version: "3.1.0"
+          identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}
+      - run: mops install
+      - run: mops publish

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -14,7 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
+      # Written rather than passed to `mops user import`, which takes the key as
+      # an argument: that puts it in the process table and echoes it back on a
+      # parse error. get-principal exits 0 when the file is missing, hence -s.
       - env:
           MOPS_IDENTITY_PEM: ${{ secrets.MOPS_IDENTITY_PEM }}
-        run: npx mops user import --no-encrypt "$MOPS_IDENTITY_PEM"
+        run: |
+          mkdir -p ~/.config/mops
+          printf '%s' "$MOPS_IDENTITY_PEM" > ~/.config/mops/identity.pem
+          chmod 600 ~/.config/mops/identity.pem
+          [ -s ~/.config/mops/identity.pem ]
+          npx mops user get-principal
       - run: npx mops publish

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -13,10 +13,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dfinity/setup-dfx@main # Currently required for `mops publish`
-      - uses: ZenVoich/setup-mops@v1
-        with:
-          # Make sure you set the MOPS_IDENTITY_PEM secret in your repository settings https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
-          identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}
-      - run: mops install
-      - run: mops publish
+      - uses: ./.github/actions/setup
+      # Publishes with the ic-mops pinned in package.json, the same CLI every
+      # other job runs. Set the MOPS_IDENTITY_PEM repository secret:
+      # https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
+      - name: Configure mops identity
+        env:
+          MOPS_IDENTITY_PEM: ${{ secrets.MOPS_IDENTITY_PEM }}
+        run: |
+          mkdir -p ~/.config/mops
+          printf '%s' "$MOPS_IDENTITY_PEM" > ~/.config/mops/identity.pem
+          chmod 600 ~/.config/mops/identity.pem
+      - run: npx mops publish

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -14,11 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - name: Configure mops identity
-        env:
+      - env:
           MOPS_IDENTITY_PEM: ${{ secrets.MOPS_IDENTITY_PEM }}
-        run: |
-          mkdir -p ~/.config/mops
-          printf '%s' "$MOPS_IDENTITY_PEM" > ~/.config/mops/identity.pem
-          chmod 600 ~/.config/mops/identity.pem
+        run: npx mops user import --no-encrypt "$MOPS_IDENTITY_PEM"
       - run: npx mops publish

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      # Publishes with the ic-mops pinned in package.json, the same CLI every
-      # other job runs. Set the MOPS_IDENTITY_PEM repository secret:
-      # https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
       - name: Configure mops identity
         env:
           MOPS_IDENTITY_PEM: ${{ secrets.MOPS_IDENTITY_PEM }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "validate:version": "cd test/ts/validate && tsx version",
     "validate:api": "cd test/ts/validate && tsx api",
     "validate:docs": "cd test/ts/validate && tsx docs",
-    "docs": "$(dirname $(mops toolchain bin moc))/mo-doc",
+    "docs": "\"$(dirname \"$(mops toolchain bin moc)\")/mo-doc\"",
     "bench": "mops bench"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "validate:version": "cd test/ts/validate && tsx version",
     "validate:api": "cd test/ts/validate && tsx api",
     "validate:docs": "cd test/ts/validate && tsx docs",
-    "docs": "$(dfx cache show)/mo-doc",
+    "docs": "$(dirname $(mops toolchain bin moc))/mo-doc",
     "bench": "mops bench"
   },
   "repository": {

--- a/test/ts/importAll.ts
+++ b/test/ts/importAll.ts
@@ -27,7 +27,12 @@ const source = moFiles
 writeFileSync(outFile, source, "utf8");
 
 (async () => {
-  const mocPath = process.env.DFX_MOC_PATH || "moc";
+  // moc is not on PATH; it lives in the toolchain version mops.toml pins.
+  const { stdout: mocPath } = await execa(
+    "npx",
+    ["mops", "toolchain", "bin", "moc"],
+    { cwd: resolve(__dirname, "../..") },
+  );
   const wasmFile = join(outDir, `${baseFilename}.wasm`);
   const { stdout, stderr } = await execa(
     mocPath,


### PR DESCRIPTION
Follow-up to [#521](https://github.com/caffeinelabs/motoko-core/pull/521). mops v3 never invokes dfx — no bundled-`moc` fallback, no dfx replica, no `DFX_MOC_PATH` — so nothing in this repo needs dfx installed. Removing it also closes a break #521 left behind.

## The one real dfx dependency was docs

```diff
-"docs": "$(dfx cache show)/mo-doc"
+"docs": "$(dirname $(mops toolchain bin moc))/mo-doc"
```

`mo-doc` ships next to `moc` in the toolchain mops.toml pins, so this is the same binary from a pinned source instead of whatever dfx bundled. Verified: 56 HTML files in `./docs`, which is what `gh-pages.yml` publishes.

That makes `setup-dfx` unused, so the input and its two steps (`dfinity/setup-dfx@main`, `dfx cache install`) go. `gh-pages` drops `setup-mops: false` too, since docs now needs the toolchain the setup action caches. `benchmarks` never needed dfx once `[toolchain] pocket-ic = "12.0.0"` was pinned — v3 removed the dfx replica outright.

## A break #521 left behind

`test/ts/importAll.ts` shelled out to a bare `moc`:

```diff
-  const mocPath = process.env.DFX_MOC_PATH || "moc";
+  const { stdout: mocPath } = await execa("npx", ["mops", "toolchain", "bin", "moc"], …);
```

Nothing on v3 sets `DFX_MOC_PATH`, and `moc` is not on `PATH` in CI — `mops toolchain init`, which #521 removed, is what used to arrange that. **The `test` and `bench` jobs were `skipped` on #521's merge commit** (they are gated on `has_mo_changes`), so the workflow reported success without ever running this path. My verification of that PR did not account for the gating.

It now asks the toolchain, matching `test/ts/validate/docs.ts`. Locally this also fixed a real failure: the old code picked up an unrelated `moc` from `PATH` and failed to compile `ImportAll.test.mo`; against the pinned 1.8.0 it passes.

## Publishing keeps the shared action, minus dfx

`mops-publish.yml` carried `dfinity/setup-dfx@main # Currently required for mops publish` — untrue on v3, which never invokes dfx — and `ZenVoich/setup-mops@v1`. The dfx step goes, and the action moves to the first-party `caffeinelabs/setup-mops`, pinned by digest so the release path does not follow a mutable tag:

```yaml
      - uses: caffeinelabs/setup-mops@5424732c5bb709eb6195b1ed1d351fa98f6c8aad # v1.1
        with:
          mops-version: "3.1.0"
          identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}
```

The action already does the right thing for v3: it reads `MOPS_VERSION` from the environment when installing from the releases canister, and imports the identity as `mops user import --no-encrypt -- "<pem>"` — the `--` matters, because a PEM starts with dashes and commander otherwise rejects it as an unknown option and echoes the key back in the error.

`mops-version` duplicates the `ic-mops` pin in `package.json`, so the two need bumping together; the alternative is the action's `latest` default, which is worse on a release path.

## Risks

- **The publish path cannot be proven by this PR's CI.** `mops-publish.yml` is tag- and dispatch-triggered, so the identity handling and `npx mops publish` are only exercised on a real release. The secret name is unchanged; what changes is that mops reads it from `~/.config/mops/identity.pem` rather than the action placing it. Worth a `workflow_dispatch` against a `preview-*` tag before the next real release if you want it de-risked.
- `test` and `bench` are gated on Motoko-source changes, so they may skip on this PR too. Since this touches how `moc` is resolved, a manual `Benchmarks` dispatch (or a throwaway `.mo` edit) is the way to see `npm test` actually run.

