### PR TITLE
ci: gate merges on one aggregate check and run jobs on tooling changes

### DIFF
--- a/.github/workflows/check-motoko-changes.yml
+++ b/.github/workflows/check-motoko-changes.yml
@@ -24,6 +24,9 @@ on:
       has_validate_docs_script_changes:
         description: "Whether the validate:docs script was changed"
         value: ${{ jobs.check.outputs.has_validate_docs_script_changes }}
+      has_toolchain_changes:
+        description: "Whether the build/test tooling was changed"
+        value: ${{ jobs.check.outputs.has_toolchain_changes }}
 
 jobs:
   check:
@@ -36,6 +39,7 @@ jobs:
       has_mops_dependency_changes: ${{ steps.check_mo_changes.outputs.has_mops_dependency_changes }}
       has_mops_package_version_changes: ${{ steps.check_mo_changes.outputs.has_mops_package_version_changes }}
       has_validate_docs_script_changes: ${{ steps.check_mo_changes.outputs.has_validate_docs_script_changes }}
+      has_toolchain_changes: ${{ steps.check_mo_changes.outputs.has_toolchain_changes }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -89,6 +93,15 @@ jobs:
             echo "No mops package version changes detected"
           else
             echo "has_mops_package_version_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Tooling that decides how sources are compiled, tested and documented.
+          # A change here can break the build with no .mo file touched.
+          if [ -z "$(git diff --name-only $BASE_SHA $HEAD_SHA -- package.json package-lock.json mops.lock 'test/ts/**' '.github/**')" ]; then
+            echo "has_toolchain_changes=false" >> $GITHUB_OUTPUT
+            echo "No build or test tooling changes detected"
+          else
+            echo "has_toolchain_changes=true" >> $GITHUB_OUTPUT
           fi
 
           # Check for validate:docs script changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,13 +68,13 @@ jobs:
 
   validate-docs:
     needs: check-motoko-changes
-    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true'
+    if: needs.check-motoko-changes.outputs.has_src_mo_changes == 'true' || needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true' || needs.check-motoko-changes.outputs.has_toolchain_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Validate docs for changed src/*.mo files
-        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false' && needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'false'
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'false' && needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'false' && needs.check-motoko-changes.outputs.has_toolchain_changes == 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -90,7 +90,7 @@ jobs:
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
       - name: Validate all docs on version or script change
-        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true'
+        if: needs.check-motoko-changes.outputs.has_mops_package_version_changes == 'true' || needs.check-motoko-changes.outputs.has_validate_docs_script_changes == 'true' || needs.check-motoko-changes.outputs.has_toolchain_changes == 'true'
         run: npm run validate:docs
         env:
           FORCE_COLOR: 2 # https://github.com/chalk/supports-color/issues/106
@@ -106,7 +106,8 @@ jobs:
     needs: check-motoko-changes
     if: |
       needs.check-motoko-changes.outputs.has_mo_changes == 'true' ||
-      needs.check-motoko-changes.outputs.has_mops_dependency_changes == 'true'
+      needs.check-motoko-changes.outputs.has_mops_dependency_changes == 'true' ||
+      needs.check-motoko-changes.outputs.has_toolchain_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -120,10 +121,24 @@ jobs:
     needs: check-motoko-changes
     if: |
       needs.check-motoko-changes.outputs.has_mo_changes == 'true' ||
-      needs.check-motoko-changes.outputs.has_mops_dependency_changes == 'true'
+      needs.check-motoko-changes.outputs.has_mops_dependency_changes == 'true' ||
+      needs.check-motoko-changes.outputs.has_toolchain_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Run benchmarks (same replica path as mops publish)
         run: npm run bench
+
+  # Single required check. Gating on the individual jobs cannot work: most of
+  # them are conditional, and a skipped job satisfies a required check, so a PR
+  # touching no Motoko source would pass every gate without running anything.
+  ci:
+    name: "ci:required"
+    if: always()
+    needs: [check-motoko-changes, validate-changelog, validate-version, check-orphans, validate-api, validate-docs, format, test, bench]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,10 +133,11 @@ jobs:
   # Single required check. Gating on the individual jobs cannot work: most of
   # them are conditional, and a skipped job satisfies a required check, so a PR
   # touching no Motoko source would pass every gate without running anything.
+  # validate-changelog is advisory and deliberately absent.
   ci:
     name: "ci:required"
     if: always()
-    needs: [check-motoko-changes, validate-changelog, validate-version, check-orphans, validate-api, validate-docs, format, test, bench]
+    needs: [check-motoko-changes, validate-version, check-orphans, validate-api, validate-docs, format, test, bench]
     runs-on: ubuntu-24.04
     steps:
       - name: Fail if any job failed or was cancelled


### PR DESCRIPTION
Only `test` is a required check on `main` today, and it protects nothing: `test` is conditional on Motoko sources changing, and **a skipped job satisfies a required status check**. A PR touching only tooling passes every gate having run no tests at all.

That is not hypothetical — it is how two changes reached `main` in the last two days:

- [#521](https://github.com/caffeinelabs/motoko-core/pull/521) bumped the mops CLI and removed `mops toolchain init`. `test` skipped, and `npm test` was broken on `main` until [#522](https://github.com/caffeinelabs/motoko-core/pull/522) fixed it.
- [#522](https://github.com/caffeinelabs/motoko-core/pull/522) rewrote the `docs` script and the `moc` resolution in `importAll.ts`. `test`, `bench` and `validate-docs` all skipped — the jobs that exercise exactly those paths.

## One required check instead of a list

```yaml
  ci:
    name: "ci:required"
    if: always()
    needs: [check-motoko-changes, validate-changelog, validate-version, check-orphans,
            validate-api, validate-docs, format, test, bench]
    runs-on: ubuntu-24.04
    steps:
      - name: Fail if any job failed or was cancelled
        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
        run: exit 1
```

`if: always()` makes it report on every run, so it is requirable; `skipped` is not a failure, so genuinely-inapplicable jobs still work; and a new job never needs a ruleset change to be enforced.

`check-motoko-changes` is in `needs` deliberately. Without it, a failure in change detection skips everything downstream, the gate sees no failures, and the required check goes green having tested nothing.

`validate-changelog` is deliberately **not** a gate dependency. It runs `continue-on-error: true`, so it reports success to dependents whatever its steps do — listing it would have implied an enforcement it never had. It stays advisory.

Worth knowing separately: that job's "Verify Changelog updated when Motoko source files changed" step ends in `exit 1`, which `continue-on-error` swallows. So the repo reads as if it enforces a Changelog entry for Motoko changes and does not. Left as-is here, since making it enforce is a contributor-facing policy change rather than a CI-wiring fix.

## The gates were the actual hole

`check-motoko-changes` only looked at `*.mo` paths, so nothing that changes *how* sources are built was visible to it. A new `has_toolchain_changes` output covers `package.json`, `package-lock.json`, `mops.lock`, `test/ts/**` and `.github/**`, and now also triggers `test`, `bench` and `validate-docs`.

`validate-docs` needed its inner steps widened too: it picks between "validate changed `src/*.mo`" and "validate everything" based on those flags, and a toolchain-only change would otherwise have taken the changed-files path with an empty file list — running the job but validating nothing.

## Ordering

This must merge **before** the matching `caffeinelabs/infra` change that requires `ci:required`. The reverse order deadlocks: the ruleset would demand a check that does not exist yet, blocking every PR including the one that adds it.

The infra PR also replaces the current ruleset, which was created by hand in the UI rather than declared in Pulumi (`motoko-core.ts` sets only `protect: true`, with no `RepositoryRuleset`), so today's protection is undocumented and drifts silently.

## What this run should show

This PR touches `.github/**`, so `has_toolchain_changes` is true and `test`, `bench` and `validate-docs` should all **run** rather than skip — the first time they have on a non-Motoko diff. That is the change working, and it also finally exercises #522's `moc` resolution and docs script in CI.
